### PR TITLE
Fix deduplicated request cancellation handling

### DIFF
--- a/src/Services/Deduplication/RequestDeduplicator.cs
+++ b/src/Services/Deduplication/RequestDeduplicator.cs
@@ -389,7 +389,7 @@ namespace Lidarr.Plugin.Common.Services.Deduplication
 
         public async Task<T> GetResultAsync<T>(CancellationToken cancellationToken)
         {
-            var result = await TaskCompletionSource.Task.ConfigureAwait(false);
+            var result = await TaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
             return (T)result;
         }
     }

--- a/tests/RequestDeduplicatorTests.cs
+++ b/tests/RequestDeduplicatorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Lidarr.Plugin.Common.Services.Deduplication;
@@ -30,6 +31,47 @@ namespace Lidarr.Plugin.Common.Tests
             blockedTcs.SetResult(null);
 
             await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+        }
+
+        [Fact]
+        public async Task CoalescedRequestHonorsCancellationAndFallsBack()
+        {
+            var dedupe = new RequestDeduplicator(new NullLogger<RequestDeduplicator>(),
+                requestTimeout: TimeSpan.FromSeconds(5), cleanupInterval: TimeSpan.FromSeconds(5));
+
+            var firstStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstRelease = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var primaryTask = dedupe.GetOrCreateAsync("shared-key", async () =>
+            {
+                firstStarted.TrySetResult(null);
+                await firstRelease.Task;
+                return "primary";
+            });
+
+            await firstStarted.Task; // ensure the primary request is in flight
+
+            var fallbackInvocations = 0;
+            using var shortTimeoutCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+            var stopwatch = Stopwatch.StartNew();
+
+            var fallbackResult = await dedupe.GetOrCreateAsync("shared-key", () =>
+            {
+                Interlocked.Increment(ref fallbackInvocations);
+                return Task.FromResult("fallback");
+            }, shortTimeoutCts.Token);
+
+            stopwatch.Stop();
+
+            Assert.Equal("fallback", fallbackResult);
+            Assert.Equal(1, fallbackInvocations);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1), "Fallback should occur before the timeout window elapses.");
+
+            firstRelease.SetResult(null);
+            Assert.Equal("primary", await primaryTask);
+
+            dedupe.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure deduplicated wait operations observe cancellation tokens by awaiting WaitAsync
- add a regression test covering coalesced requests that cancel and fall back quickly

## Testing
- dotnet test *(fails for net6 due to missing runtime; net8 tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c564c9608331a7f6b393bca86633