### PR TITLE
Ensure report_tests job can publish checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_and_test
     if: always()
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Download test artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- grant the report_tests job permission to write check runs so publishing succeeds on forks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8c30e140833187a40955d518d129