### PR TITLE
chore(release): bump to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ Template to copy when drafting a release:
 ### Reminder
 - Maintainers must keep host assemblies in sync with Lidarr 2.14.2.4786 before shipping plugin updates; see `docs/UNIFIED_PLUGIN_PIPELINE.md` for the complete process.
 
+## [1.1.6] - 2025-10-11
+**Upgrade note:** No public API changes. Improves diagnostics and hardens concurrency + caching behavior under load.
+
+**Highlights**
+- New `PluginOperationResultJson` helper for consistent, structured diagnostics across plugins.
+- 304 revalidation path: add a brief stale grace to avoid races and preserve cached bodies when validators hit right at TTL.
+- Windows file concurrency: `FileTokenStore` now writes via unique temp files and retries atomic replace/move to avoid transient sharing violations.
+- Retry semantics: when honoring `Retry-After` absolute dates, do not add jitter; still clamped by the retry budget.
+- CI: grant permissions for PR test result annotations; coverage summary appears reliably on PRs.
+
+**Breaking changes:** None
+**Deprecations:** None
+**Dependency changes:** None
+
+[Full diff](https://github.com/RicherTunes/Lidarr.Plugin.Common/compare/v1.1.5...v1.1.6)
+
 ## [1.1.5] - 2025-10-01
 **Upgrade note:** No public API changes. CLI `config` commands now persist settings consistently and surface the latest metadata across hosts.
 

--- a/src/Abstractions/Lidarr.Plugin.Abstractions.csproj
+++ b/src/Abstractions/Lidarr.Plugin.Abstractions.csproj
@@ -12,6 +12,7 @@
     <NoWarn>SA1200;SA1633;CS1591;RS0016;RS0017</NoWarn>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
+    <Version>1.1.6</Version>
   </PropertyGroup>
   <!-- Make PublicAPI baselines visible to analyzer tools (e.g., dotnet format) without relying on build targets -->
   <ItemGroup>

--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -11,8 +11,8 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.1.5</Version>
-    <PackageVersion>1.1.5</PackageVersion>
+    <Version>1.1.6</Version>
+    <PackageVersion>1.1.6</PackageVersion>
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
     <Authors>RicherTunes Community</Authors>
@@ -24,7 +24,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.1.5: CLI config persistence fixes, typed conversions, and new coverage.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.1.6: Diagnostics JSON helper; 304 revalidation deflake; Windows token store concurrency fix; CI test annotations.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->


### PR DESCRIPTION
This PR prepares the 1.1.6 release.

- Bump versions:
  - src/Lidarr.Plugin.Common.csproj: 1.1.6
  - src/Abstractions/Lidarr.Plugin.Abstractions.csproj: add <Version>1.1.6</Version> (keeps AssemblyVersion/FileVersion unchanged)
- CHANGELOG.md: add 1.1.6 entry (2025-10-11)
  - Diagnostics JSON helper
  - 304 revalidation stale-grace deflake
  - Windows token store concurrency fix
  - Retry-After absolute date: no jitter
  - CI: test result annotation permissions

Validation
- dotnet build -c Release -m:1 → OK
- dotnet test -c Release --no-build → 88 passed, 1 skipped
- dotnet format analyzers --verify-no-changes → clean

After merge
- Tag v1.1.6 on main to trigger the release workflow.