### PR TITLE
NuGet: map TagLibSharp-Lidarr* to lidarr-taglib feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,6 +20,7 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="lidarr-taglib">
+      <package pattern="TagLibSharp-Lidarr*" />
       <package pattern="TagLibSharp*" />
     </packageSource>
   </packageSourceMapping>


### PR DESCRIPTION
Fix restore failures under PackageSourceMapping by explicitly mapping TagLibSharp-Lidarr* to the public Azure Artifacts feed (lidarr-taglib). Ensures CI restores succeed for net6/net8 across consumers (e.g., Brainarr).