### PR TITLE
feat(template+ci+docs): scaffold template; CI polish; NuGet badges

### DIFF
--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -17,6 +17,7 @@
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
     <Authors>RicherTunes Community</Authors>
+    <!-- ci-touch: trigger Build & Test for PRs that only change docs/badges -->
     <Company>RicherTunes</Company>
     <Description>Shared library for building Lidarr streaming service plugins. Reduces development time by 60%+ through battle-tested utilities, models, and patterns.</Description>
     <Copyright>Copyright © 2025 RicherTunes Community</Copyright>
@@ -207,6 +208,5 @@
     <PackageReference Include="TagLibSharp-Lidarr" Version="2.2.0.27" />
   </ItemGroup>
 </Project>
-
 
 


### PR DESCRIPTION
This implements parts of the architect’s week-1 plan.\n\nTemplates\n- Add dotnet new template (shortName: lidarr-plugin) under templates/. Includes minimal project + Plugin class.\n- Add Template package project (PackageType=Template). Not yet packed in release CI.\n\nCI\n- Set DOTNET_ROLL_FORWARD=LatestMajor to reduce SDK mismatch noise.\n- Upload-artifact retention set to 14 days.\n- PR validation runs dotnet format style --verify-no-changes.\n\nDocs\n- Add NuGet badges for Common and Abstractions (will light up after first publish to nuget.org).