### PR TITLE
fix(ci): Pin scorecard-action to v2.4.0

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

Fixes the failing OpenSSF Scorecard workflow by pinning `ossf/scorecard-action` to `v2.4.0`.

## Problem

The `v2` tag for `ossf/scorecard-action` is no longer resolvable, causing the CI to fail with:
```
Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

## Solution

Pin to the specific `v2.4.0` release (latest stable version as of Sept 2024) for stability.

## Test plan

- [ ] Scorecard workflow passes on this PR
- [ ] No other CI jobs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)