### PR TITLE
fix(nuget): add lidarr-taglib source for TagLibSharp-Lidarr resolution

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!-- Primary NuGet source -->
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- Lidarr Azure Artifacts feed for TagLibSharp-Lidarr (public, read-only) -->
+    <add key="lidarr-taglib" value="https://pkgs.dev.azure.com/Lidarr/Lidarr/_packaging/Taglib/nuget/v3/index.json" />
   </packageSources>
 
   <packageSourceMapping>
+    <!-- Default: all packages from nuget.org -->
     <packageSource key="nuget.org">
-      <package pattern="Microsoft.*" />
-      <package pattern="System.*" />
-      <package pattern="Newtonsoft.*" />
-      <package pattern="NLog*" />
-      <package pattern="FluentValidation*" />
-      <package pattern="xunit*" />
-      <package pattern="Moq*" />
-      <package pattern="Castle.*" />
-      <package pattern="dotnet-reportgenerator-globaltool" />
-      <package pattern="dotnet-stryker" />
       <package pattern="*" />
+    </packageSource>
+    <!-- TagLibSharp-Lidarr specifically from Lidarr feed (used when UseLidarrTaglib=true) -->
+    <packageSource key="lidarr-taglib">
+      <package pattern="TagLibSharp-Lidarr*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
## Summary
- Add Lidarr Azure Artifacts feed (`lidarr-taglib`) as a package source
- Add package source mapping for `TagLibSharp-Lidarr*` pattern
- Simplify nuget.org mapping to wildcard

## Problem
When consuming projects (Brainarr, Qobuzarr) build with `UseLidarrTaglib=true`, the `TagLibSharp-Lidarr` package cannot be resolved because this repo's NuGet.config didn't include the Lidarr Azure DevOps feed.

This forced consuming projects to patch this submodule's NuGet.config during CI builds with sed commands.

## Solution
Include the `lidarr-taglib` source directly in this repo's NuGet.config with proper package source mapping. This:
- Allows `TagLibSharp-Lidarr` to resolve automatically when `UseLidarrTaglib=true`
- Eliminates need for CI workflow patches in consuming projects
- Maintains backward compatibility (default `TagLibSharp` still resolves from nuget.org)

## Test plan
- [ ] Verify CI passes in this repo
- [ ] Test in Brainarr/Qobuzarr after merging and updating submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)