### PR TITLE
ci(smoke-test): add analyzer suppression to Tidalarr build

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -210,12 +210,18 @@ jobs:
             --no-restore \
             --framework net6.0 \
             -p:PluginPackagingDisable=true \
+            -p:RunAnalyzersDuringBuild=false \
+            -p:EnableNETAnalyzers=false \
+            -p:TreatWarningsAsErrors=false \
             -m:1
           dotnet build src/Tidalarr.HostBridge/Tidalarr.HostBridge.csproj \
             --configuration Release \
             --no-restore \
             --framework net6.0 \
             -p:PluginPackagingDisable=true \
+            -p:RunAnalyzersDuringBuild=false \
+            -p:EnableNETAnalyzers=false \
+            -p:TreatWarningsAsErrors=false \
             -m:1
 
           echo "Tidalarr build complete"


### PR DESCRIPTION
## Summary
Tidalarr has `TreatWarningsAsErrors=true` enabled, causing analyzer warnings (CA1805, CA1848, CA1822, etc.) to fail the multi-plugin smoke test build.

## Changes
Add `-p:RunAnalyzersDuringBuild=false -p:EnableNETAnalyzers=false -p:TreatWarningsAsErrors=false` to Tidalarr and HostBridge build commands, matching the pattern used for Qobuzarr.

## Test plan
- [ ] CI builds pass
- [ ] Multi-plugin smoke test completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)