### PR TITLE
feat(testkit): add test data builders, validation helpers, and HTTP handlers

### DIFF
--- a/testkit/Builders/StreamingModelBuilders.cs
+++ b/testkit/Builders/StreamingModelBuilders.cs
@@ -1,0 +1,759 @@
+using System;
+using System.Collections.Generic;
+using Lidarr.Plugin.Abstractions.Models;
+
+namespace Lidarr.Plugin.Common.TestKit.Builders;
+
+/// <summary>
+/// Fluent builder for creating <see cref="StreamingArtist"/> instances in tests.
+/// </summary>
+public sealed class StreamingArtistBuilder
+{
+    private string _id = Guid.NewGuid().ToString();
+    private string _name = "Test Artist";
+    private string _biography = string.Empty;
+    private readonly List<string> _genres = new();
+    private string _country = string.Empty;
+    private readonly Dictionary<string, string> _imageUrls = new();
+    private readonly Dictionary<string, string> _externalUrls = new();
+    private readonly Dictionary<string, object> _metadata = new();
+
+    public StreamingArtistBuilder WithId(string id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public StreamingArtistBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public StreamingArtistBuilder WithBiography(string biography)
+    {
+        _biography = biography;
+        return this;
+    }
+
+    public StreamingArtistBuilder WithGenre(string genre)
+    {
+        _genres.Add(genre);
+        return this;
+    }
+
+    public StreamingArtistBuilder WithGenres(params string[] genres)
+    {
+        _genres.AddRange(genres);
+        return this;
+    }
+
+    public StreamingArtistBuilder WithCountry(string country)
+    {
+        _country = country;
+        return this;
+    }
+
+    public StreamingArtistBuilder WithImageUrl(string size, string url)
+    {
+        _imageUrls[size] = url;
+        return this;
+    }
+
+    public StreamingArtistBuilder WithExternalUrl(string service, string url)
+    {
+        _externalUrls[service] = url;
+        return this;
+    }
+
+    public StreamingArtistBuilder WithMetadata(string key, object value)
+    {
+        _metadata[key] = value;
+        return this;
+    }
+
+    public StreamingArtist Build() => new()
+    {
+        Id = _id,
+        Name = _name,
+        Biography = _biography,
+        Genres = new List<string>(_genres),
+        Country = _country,
+        ImageUrls = new Dictionary<string, string>(_imageUrls),
+        ExternalUrls = new Dictionary<string, string>(_externalUrls),
+        Metadata = new Dictionary<string, object>(_metadata)
+    };
+
+    /// <summary>
+    /// Creates a minimal artist for quick tests.
+    /// </summary>
+    public static StreamingArtist CreateMinimal(string name = "Test Artist", string? id = null) =>
+        new StreamingArtistBuilder()
+            .WithId(id ?? Guid.NewGuid().ToString())
+            .WithName(name)
+            .Build();
+
+    /// <summary>
+    /// Creates a fully populated artist for comprehensive tests.
+    /// </summary>
+    public static StreamingArtist CreateComplete(string name = "Complete Artist") =>
+        new StreamingArtistBuilder()
+            .WithName(name)
+            .WithBiography("A comprehensive test artist biography.")
+            .WithGenres("Rock", "Alternative", "Indie")
+            .WithCountry("US")
+            .WithImageUrl("small", "https://example.com/artist-small.jpg")
+            .WithImageUrl("medium", "https://example.com/artist-medium.jpg")
+            .WithImageUrl("large", "https://example.com/artist-large.jpg")
+            .WithExternalUrl("spotify", "https://open.spotify.com/artist/123")
+            .WithExternalUrl("musicbrainz", "https://musicbrainz.org/artist/456")
+            .WithMetadata("popularity", 85)
+            .WithMetadata("followers", 1000000)
+            .Build();
+}
+
+/// <summary>
+/// Fluent builder for creating <see cref="StreamingAlbum"/> instances in tests.
+/// </summary>
+public sealed class StreamingAlbumBuilder
+{
+    private string _id = Guid.NewGuid().ToString();
+    private string _title = "Test Album";
+    private StreamingArtist _artist = StreamingArtistBuilder.CreateMinimal();
+    private readonly List<StreamingArtist> _additionalArtists = new();
+    private DateTime? _releaseDate = DateTime.Today;
+    private StreamingAlbumType _type = StreamingAlbumType.Album;
+    private int _trackCount = 10;
+    private TimeSpan? _duration = TimeSpan.FromMinutes(45);
+    private readonly List<string> _genres = new();
+    private string _label = string.Empty;
+    private string _upc = string.Empty;
+    private string _musicBrainzId = string.Empty;
+    private readonly List<StreamingQuality> _availableQualities = new();
+    private readonly Dictionary<string, string> _coverArtUrls = new();
+    private readonly Dictionary<string, string> _externalUrls = new();
+    private readonly Dictionary<string, string> _externalIds = new();
+    private readonly Dictionary<string, object> _metadata = new();
+
+    public StreamingAlbumBuilder WithId(string id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithArtist(StreamingArtist artist)
+    {
+        _artist = artist;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithArtist(string name)
+    {
+        _artist = StreamingArtistBuilder.CreateMinimal(name);
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithAdditionalArtist(StreamingArtist artist)
+    {
+        _additionalArtists.Add(artist);
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithReleaseDate(DateTime? date)
+    {
+        _releaseDate = date;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithType(StreamingAlbumType type)
+    {
+        _type = type;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithTrackCount(int count)
+    {
+        _trackCount = count;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithDuration(TimeSpan? duration)
+    {
+        _duration = duration;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithGenre(string genre)
+    {
+        _genres.Add(genre);
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithGenres(params string[] genres)
+    {
+        _genres.AddRange(genres);
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithLabel(string label)
+    {
+        _label = label;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithUpc(string upc)
+    {
+        _upc = upc;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithMusicBrainzId(string mbid)
+    {
+        _musicBrainzId = mbid;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithQuality(StreamingQuality quality)
+    {
+        _availableQualities.Add(quality);
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithCoverArtUrl(string size, string url)
+    {
+        _coverArtUrls[size] = url;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithExternalUrl(string service, string url)
+    {
+        _externalUrls[service] = url;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithExternalId(string service, string id)
+    {
+        _externalIds[service] = id;
+        return this;
+    }
+
+    public StreamingAlbumBuilder WithMetadata(string key, object value)
+    {
+        _metadata[key] = value;
+        return this;
+    }
+
+    public StreamingAlbum Build()
+    {
+        var album = new StreamingAlbum
+        {
+            Id = _id,
+            Title = _title,
+            Artist = _artist,
+            AdditionalArtists = new List<StreamingArtist>(_additionalArtists),
+            ReleaseDate = _releaseDate,
+            Type = _type,
+            TrackCount = _trackCount,
+            Duration = _duration,
+            Genres = new List<string>(_genres),
+            Label = _label,
+            Upc = _upc,
+            MusicBrainzId = _musicBrainzId,
+            AvailableQualities = new List<StreamingQuality>(_availableQualities),
+            CoverArtUrls = new Dictionary<string, string>(_coverArtUrls),
+            ExternalUrls = new Dictionary<string, string>(_externalUrls),
+            Metadata = new Dictionary<string, object>(_metadata)
+        };
+
+        foreach (var kvp in _externalIds)
+        {
+            album.ExternalIds[kvp.Key] = kvp.Value;
+        }
+
+        return album;
+    }
+
+    /// <summary>
+    /// Creates a minimal album for quick tests.
+    /// </summary>
+    public static StreamingAlbum CreateMinimal(string title = "Test Album", string artistName = "Test Artist") =>
+        new StreamingAlbumBuilder()
+            .WithTitle(title)
+            .WithArtist(artistName)
+            .Build();
+
+    /// <summary>
+    /// Creates a lossless album with high-quality settings.
+    /// </summary>
+    public static StreamingAlbum CreateLossless(string title = "Lossless Album") =>
+        new StreamingAlbumBuilder()
+            .WithTitle(title)
+            .WithQuality(StreamingQualityBuilder.CreateFlacCd())
+            .WithQuality(StreamingQualityBuilder.CreateFlacHiRes())
+            .Build();
+
+    /// <summary>
+    /// Creates a fully populated album for comprehensive tests.
+    /// </summary>
+    public static StreamingAlbum CreateComplete(string title = "Complete Album") =>
+        new StreamingAlbumBuilder()
+            .WithTitle(title)
+            .WithArtist(StreamingArtistBuilder.CreateComplete())
+            .WithReleaseDate(new DateTime(2024, 1, 15))
+            .WithType(StreamingAlbumType.Album)
+            .WithTrackCount(12)
+            .WithDuration(TimeSpan.FromMinutes(52))
+            .WithGenres("Rock", "Alternative")
+            .WithLabel("Test Records")
+            .WithUpc("012345678901")
+            .WithMusicBrainzId("12345678-1234-1234-1234-123456789012")
+            .WithQuality(StreamingQualityBuilder.CreateMp3320())
+            .WithQuality(StreamingQualityBuilder.CreateFlacCd())
+            .WithCoverArtUrl("small", "https://example.com/cover-small.jpg")
+            .WithCoverArtUrl("large", "https://example.com/cover-large.jpg")
+            .WithExternalId("tidal", "tidal-123")
+            .WithExternalId("qobuz", "qobuz-456")
+            .Build();
+}
+
+/// <summary>
+/// Fluent builder for creating <see cref="StreamingTrack"/> instances in tests.
+/// </summary>
+public sealed class StreamingTrackBuilder
+{
+    private string _id = Guid.NewGuid().ToString();
+    private string _title = "Test Track";
+    private StreamingArtist _artist = StreamingArtistBuilder.CreateMinimal();
+    private StreamingAlbum _album = StreamingAlbumBuilder.CreateMinimal();
+    private int? _trackNumber = 1;
+    private int? _discNumber = 1;
+    private TimeSpan? _duration = TimeSpan.FromMinutes(3.5);
+    private bool _isExplicit;
+    private string _isrc = string.Empty;
+    private string _musicBrainzId = string.Empty;
+    private readonly List<StreamingArtist> _featuredArtists = new();
+    private readonly List<StreamingQuality> _availableQualities = new();
+    private string _previewUrl = string.Empty;
+    private long? _popularity;
+    private readonly Dictionary<string, string> _externalIds = new();
+    private readonly Dictionary<string, object> _metadata = new();
+
+    public StreamingTrackBuilder WithId(string id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithArtist(StreamingArtist artist)
+    {
+        _artist = artist;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithArtist(string name)
+    {
+        _artist = StreamingArtistBuilder.CreateMinimal(name);
+        return this;
+    }
+
+    public StreamingTrackBuilder WithAlbum(StreamingAlbum album)
+    {
+        _album = album;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithTrackNumber(int? number)
+    {
+        _trackNumber = number;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithDiscNumber(int? number)
+    {
+        _discNumber = number;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithDuration(TimeSpan? duration)
+    {
+        _duration = duration;
+        return this;
+    }
+
+    public StreamingTrackBuilder AsExplicit(bool isExplicit = true)
+    {
+        _isExplicit = isExplicit;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithIsrc(string isrc)
+    {
+        _isrc = isrc;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithMusicBrainzId(string mbid)
+    {
+        _musicBrainzId = mbid;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithFeaturedArtist(StreamingArtist artist)
+    {
+        _featuredArtists.Add(artist);
+        return this;
+    }
+
+    public StreamingTrackBuilder WithFeaturedArtist(string name)
+    {
+        _featuredArtists.Add(StreamingArtistBuilder.CreateMinimal(name));
+        return this;
+    }
+
+    public StreamingTrackBuilder WithQuality(StreamingQuality quality)
+    {
+        _availableQualities.Add(quality);
+        return this;
+    }
+
+    public StreamingTrackBuilder WithPreviewUrl(string url)
+    {
+        _previewUrl = url;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithPopularity(long? popularity)
+    {
+        _popularity = popularity;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithExternalId(string service, string id)
+    {
+        _externalIds[service] = id;
+        return this;
+    }
+
+    public StreamingTrackBuilder WithMetadata(string key, object value)
+    {
+        _metadata[key] = value;
+        return this;
+    }
+
+    public StreamingTrack Build()
+    {
+        var track = new StreamingTrack
+        {
+            Id = _id,
+            Title = _title,
+            Artist = _artist,
+            Album = _album,
+            TrackNumber = _trackNumber,
+            DiscNumber = _discNumber,
+            Duration = _duration,
+            IsExplicit = _isExplicit,
+            Isrc = _isrc,
+            MusicBrainzId = _musicBrainzId,
+            FeaturedArtists = new List<StreamingArtist>(_featuredArtists),
+            AvailableQualities = new List<StreamingQuality>(_availableQualities),
+            PreviewUrl = _previewUrl,
+            Popularity = _popularity,
+            Metadata = new Dictionary<string, object>(_metadata)
+        };
+
+        foreach (var kvp in _externalIds)
+        {
+            track.ExternalIds[kvp.Key] = kvp.Value;
+        }
+
+        return track;
+    }
+
+    /// <summary>
+    /// Creates a minimal track for quick tests.
+    /// </summary>
+    public static StreamingTrack CreateMinimal(string title = "Test Track") =>
+        new StreamingTrackBuilder()
+            .WithTitle(title)
+            .Build();
+
+    /// <summary>
+    /// Creates a track with featured artists.
+    /// </summary>
+    public static StreamingTrack CreateWithFeatures(string title, params string[] featureNames)
+    {
+        var builder = new StreamingTrackBuilder().WithTitle(title);
+        foreach (var name in featureNames)
+        {
+            builder.WithFeaturedArtist(name);
+        }
+        return builder.Build();
+    }
+}
+
+/// <summary>
+/// Fluent builder for creating <see cref="StreamingQuality"/> instances in tests.
+/// </summary>
+public sealed class StreamingQualityBuilder
+{
+    private string _id = "quality-id";
+    private string _name = "Test Quality";
+    private string _format = "FLAC";
+    private int? _bitrate;
+    private int? _sampleRate = 44100;
+    private int? _bitDepth = 16;
+
+    public StreamingQualityBuilder WithId(string id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public StreamingQualityBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public StreamingQualityBuilder WithFormat(string format)
+    {
+        _format = format;
+        return this;
+    }
+
+    public StreamingQualityBuilder WithBitrate(int? bitrate)
+    {
+        _bitrate = bitrate;
+        return this;
+    }
+
+    public StreamingQualityBuilder WithSampleRate(int? sampleRate)
+    {
+        _sampleRate = sampleRate;
+        return this;
+    }
+
+    public StreamingQualityBuilder WithBitDepth(int? bitDepth)
+    {
+        _bitDepth = bitDepth;
+        return this;
+    }
+
+    public StreamingQuality Build() => new()
+    {
+        Id = _id,
+        Name = _name,
+        Format = _format,
+        Bitrate = _bitrate,
+        SampleRate = _sampleRate,
+        BitDepth = _bitDepth
+    };
+
+    /// <summary>Creates MP3 320kbps quality.</summary>
+    public static StreamingQuality CreateMp3320() =>
+        new StreamingQualityBuilder()
+            .WithId("mp3-320")
+            .WithName("MP3 320")
+            .WithFormat("MP3")
+            .WithBitrate(320)
+            .WithSampleRate(null)
+            .WithBitDepth(null)
+            .Build();
+
+    /// <summary>Creates AAC 256kbps quality.</summary>
+    public static StreamingQuality CreateAac256() =>
+        new StreamingQualityBuilder()
+            .WithId("aac-256")
+            .WithName("AAC 256")
+            .WithFormat("AAC")
+            .WithBitrate(256)
+            .WithSampleRate(null)
+            .WithBitDepth(null)
+            .Build();
+
+    /// <summary>Creates FLAC CD quality (44.1kHz/16bit).</summary>
+    public static StreamingQuality CreateFlacCd() =>
+        new StreamingQualityBuilder()
+            .WithId("flac-cd")
+            .WithName("FLAC CD")
+            .WithFormat("FLAC")
+            .WithSampleRate(44100)
+            .WithBitDepth(16)
+            .Build();
+
+    /// <summary>Creates FLAC Hi-Res quality (96kHz/24bit).</summary>
+    public static StreamingQuality CreateFlacHiRes() =>
+        new StreamingQualityBuilder()
+            .WithId("flac-hires")
+            .WithName("FLAC Hi-Res")
+            .WithFormat("FLAC")
+            .WithSampleRate(96000)
+            .WithBitDepth(24)
+            .Build();
+
+    /// <summary>Creates FLAC Ultra Hi-Res quality (192kHz/24bit).</summary>
+    public static StreamingQuality CreateFlacUltraHiRes() =>
+        new StreamingQualityBuilder()
+            .WithId("flac-ultrahires")
+            .WithName("FLAC Ultra Hi-Res")
+            .WithFormat("FLAC")
+            .WithSampleRate(192000)
+            .WithBitDepth(24)
+            .Build();
+
+    /// <summary>Creates a Tidal-style MQA quality.</summary>
+    public static StreamingQuality CreateMqa() =>
+        new StreamingQualityBuilder()
+            .WithId("mqa")
+            .WithName("MQA")
+            .WithFormat("MQA")
+            .WithSampleRate(96000)
+            .WithBitDepth(24)
+            .Build();
+}
+
+/// <summary>
+/// Fluent builder for creating <see cref="StreamingSearchResult"/> instances in tests.
+/// </summary>
+public sealed class StreamingSearchResultBuilder
+{
+    private string _id = Guid.NewGuid().ToString();
+    private string _title = "Search Result";
+    private string _artist = "Test Artist";
+    private string _album = string.Empty;
+    private StreamingSearchType _type = StreamingSearchType.Album;
+    private DateTime? _releaseDate;
+    private string _genre = string.Empty;
+    private string _label = string.Empty;
+    private string _coverArtUrl = string.Empty;
+    private int? _trackCount;
+    private TimeSpan? _duration;
+    private readonly Dictionary<string, object> _metadata = new();
+
+    public StreamingSearchResultBuilder WithId(string id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithArtist(string artist)
+    {
+        _artist = artist;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithAlbum(string album)
+    {
+        _album = album;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithType(StreamingSearchType type)
+    {
+        _type = type;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithReleaseDate(DateTime? date)
+    {
+        _releaseDate = date;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithGenre(string genre)
+    {
+        _genre = genre;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithLabel(string label)
+    {
+        _label = label;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithCoverArtUrl(string url)
+    {
+        _coverArtUrl = url;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithTrackCount(int? count)
+    {
+        _trackCount = count;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithDuration(TimeSpan? duration)
+    {
+        _duration = duration;
+        return this;
+    }
+
+    public StreamingSearchResultBuilder WithMetadata(string key, object value)
+    {
+        _metadata[key] = value;
+        return this;
+    }
+
+    public StreamingSearchResult Build() => new()
+    {
+        Id = _id,
+        Title = _title,
+        Artist = _artist,
+        Album = _album,
+        Type = _type,
+        ReleaseDate = _releaseDate,
+        Genre = _genre,
+        Label = _label,
+        CoverArtUrl = _coverArtUrl,
+        TrackCount = _trackCount,
+        Duration = _duration,
+        Metadata = new Dictionary<string, object>(_metadata)
+    };
+
+    /// <summary>Creates an album search result.</summary>
+    public static StreamingSearchResult CreateAlbumResult(string title, string artist) =>
+        new StreamingSearchResultBuilder()
+            .WithTitle(title)
+            .WithArtist(artist)
+            .WithType(StreamingSearchType.Album)
+            .WithTrackCount(10)
+            .Build();
+
+    /// <summary>Creates an artist search result.</summary>
+    public static StreamingSearchResult CreateArtistResult(string name) =>
+        new StreamingSearchResultBuilder()
+            .WithTitle(name)
+            .WithArtist(name)
+            .WithType(StreamingSearchType.Artist)
+            .Build();
+
+    /// <summary>Creates a track search result.</summary>
+    public static StreamingSearchResult CreateTrackResult(string title, string artist, string album) =>
+        new StreamingSearchResultBuilder()
+            .WithTitle(title)
+            .WithArtist(artist)
+            .WithAlbum(album)
+            .WithType(StreamingSearchType.Track)
+            .WithDuration(TimeSpan.FromMinutes(3.5))
+            .Build();
+}

--- a/testkit/Http/AuthenticationTestHandler.cs
+++ b/testkit/Http/AuthenticationTestHandler.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lidarr.Plugin.Common.TestKit.Http;
+
+/// <summary>
+/// Test handler that simulates OAuth/token authentication flows.
+/// Useful for testing authentication service implementations.
+/// </summary>
+public class AuthenticationTestHandler : DelegatingHandler
+{
+    private readonly AuthenticationTestOptions _options;
+    private string? _currentAccessToken;
+    private string? _currentRefreshToken;
+    private DateTime _tokenExpiration = DateTime.MinValue;
+    private int _refreshCount;
+
+    public AuthenticationTestHandler(AuthenticationTestOptions? options = null)
+    {
+        _options = options ?? new AuthenticationTestOptions();
+        InnerHandler = new HttpClientHandler();
+    }
+
+    /// <summary>Number of times the token was refreshed.</summary>
+    public int RefreshCount => _refreshCount;
+
+    /// <summary>Current access token (for test assertions).</summary>
+    public string? CurrentAccessToken => _currentAccessToken;
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        await Task.Yield(); // Simulate async work
+
+        // Handle token endpoint
+        if (request.RequestUri?.AbsolutePath.Contains(_options.TokenEndpoint, StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return await HandleTokenRequestAsync(request, cancellationToken);
+        }
+
+        // Handle authenticated requests
+        if (request.Headers.Authorization != null)
+        {
+            var token = request.Headers.Authorization.Parameter;
+
+            // Check if token matches current valid token
+            if (token == _currentAccessToken && DateTime.UtcNow < _tokenExpiration)
+            {
+                return CreateSuccessResponse();
+            }
+
+            // Token expired or invalid
+            if (DateTime.UtcNow >= _tokenExpiration)
+            {
+                return CreateErrorResponse(HttpStatusCode.Unauthorized, "token_expired", "Access token has expired");
+            }
+
+            return CreateErrorResponse(HttpStatusCode.Unauthorized, "invalid_token", "Access token is invalid");
+        }
+
+        // No authentication provided
+        return CreateErrorResponse(HttpStatusCode.Unauthorized, "missing_auth", "Authentication required");
+    }
+
+    private Task<HttpResponseMessage> HandleTokenRequestAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var content = request.Content?.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult() ?? "";
+
+        // Simulate grant_type handling
+        if (content.Contains("grant_type=password") || content.Contains("grant_type=client_credentials"))
+        {
+            // Initial authentication
+            if (_options.SimulateAuthFailure)
+            {
+                return Task.FromResult(CreateErrorResponse(HttpStatusCode.Unauthorized, "invalid_grant", "Invalid credentials"));
+            }
+
+            return Task.FromResult(CreateTokenResponse());
+        }
+
+        if (content.Contains("grant_type=refresh_token"))
+        {
+            _refreshCount++;
+
+            if (_options.SimulateRefreshFailure)
+            {
+                return Task.FromResult(CreateErrorResponse(HttpStatusCode.Unauthorized, "invalid_grant", "Refresh token expired"));
+            }
+
+            return Task.FromResult(CreateTokenResponse());
+        }
+
+        return Task.FromResult(CreateErrorResponse(HttpStatusCode.BadRequest, "unsupported_grant_type", "Grant type not supported"));
+    }
+
+    private HttpResponseMessage CreateTokenResponse()
+    {
+        _currentAccessToken = Guid.NewGuid().ToString("N");
+        _currentRefreshToken = Guid.NewGuid().ToString("N");
+        _tokenExpiration = DateTime.UtcNow.Add(_options.TokenLifetime);
+
+        var response = new
+        {
+            access_token = _currentAccessToken,
+            refresh_token = _currentRefreshToken,
+            token_type = "Bearer",
+            expires_in = (int)_options.TokenLifetime.TotalSeconds,
+            scope = _options.Scope
+        };
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(response),
+                Encoding.UTF8,
+                "application/json")
+        };
+    }
+
+    private static HttpResponseMessage CreateSuccessResponse()
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"status\":\"ok\"}", Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static HttpResponseMessage CreateErrorResponse(HttpStatusCode status, string error, string description)
+    {
+        var errorResponse = new
+        {
+            error = error,
+            error_description = description
+        };
+
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(errorResponse),
+                Encoding.UTF8,
+                "application/json")
+        };
+    }
+
+    /// <summary>
+    /// Forces the current token to expire for testing refresh flows.
+    /// </summary>
+    public void ExpireToken()
+    {
+        _tokenExpiration = DateTime.UtcNow.AddSeconds(-1);
+    }
+
+    /// <summary>
+    /// Invalidates the current token (simulates server-side revocation).
+    /// </summary>
+    public void InvalidateToken()
+    {
+        _currentAccessToken = null;
+        _tokenExpiration = DateTime.MinValue;
+    }
+}
+
+/// <summary>
+/// Options for configuring <see cref="AuthenticationTestHandler"/>.
+/// </summary>
+public class AuthenticationTestOptions
+{
+    /// <summary>Token endpoint path (default: "/oauth/token").</summary>
+    public string TokenEndpoint { get; init; } = "/oauth/token";
+
+    /// <summary>Token lifetime (default: 1 hour).</summary>
+    public TimeSpan TokenLifetime { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>OAuth scope to include in response.</summary>
+    public string Scope { get; init; } = "read write";
+
+    /// <summary>If true, initial authentication will fail.</summary>
+    public bool SimulateAuthFailure { get; init; }
+
+    /// <summary>If true, token refresh will fail.</summary>
+    public bool SimulateRefreshFailure { get; init; }
+}
+
+/// <summary>
+/// Test handler that simulates rate limiting responses.
+/// </summary>
+public class RateLimitTestHandler : DelegatingHandler
+{
+    private readonly RateLimitTestOptions _options;
+    private int _requestCount;
+    private DateTime _windowStart = DateTime.UtcNow;
+
+    public RateLimitTestHandler(RateLimitTestOptions? options = null)
+    {
+        _options = options ?? new RateLimitTestOptions();
+        InnerHandler = new HttpClientHandler();
+    }
+
+    /// <summary>Total number of requests made.</summary>
+    public int RequestCount => _requestCount;
+
+    /// <summary>Number of requests that were rate limited.</summary>
+    public int RateLimitedCount { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Reset window if expired
+        if (DateTime.UtcNow - _windowStart > _options.WindowDuration)
+        {
+            _requestCount = 0;
+            _windowStart = DateTime.UtcNow;
+        }
+
+        _requestCount++;
+
+        // Check rate limit
+        if (_requestCount > _options.RequestsPerWindow)
+        {
+            RateLimitedCount++;
+            var retryAfter = (int)(_options.WindowDuration - (DateTime.UtcNow - _windowStart)).TotalSeconds;
+            return Task.FromResult(CreateRateLimitResponse(retryAfter));
+        }
+
+        var remaining = _options.RequestsPerWindow - _requestCount;
+        return Task.FromResult(CreateSuccessResponse(remaining));
+    }
+
+    private HttpResponseMessage CreateSuccessResponse(int remaining)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"status\":\"ok\"}", Encoding.UTF8, "application/json")
+        };
+
+        response.Headers.Add("X-RateLimit-Limit", _options.RequestsPerWindow.ToString());
+        response.Headers.Add("X-RateLimit-Remaining", remaining.ToString());
+        response.Headers.Add("X-RateLimit-Reset", ((DateTimeOffset)_windowStart.Add(_options.WindowDuration)).ToUnixTimeSeconds().ToString());
+
+        return response;
+    }
+
+    private HttpResponseMessage CreateRateLimitResponse(int retryAfter)
+    {
+        var response = new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(new { error = "rate_limit_exceeded", retry_after = retryAfter }),
+                Encoding.UTF8,
+                "application/json")
+        };
+
+        response.Headers.Add("Retry-After", retryAfter.ToString());
+        response.Headers.Add("X-RateLimit-Limit", _options.RequestsPerWindow.ToString());
+        response.Headers.Add("X-RateLimit-Remaining", "0");
+
+        return response;
+    }
+
+    /// <summary>
+    /// Resets the rate limit window for testing.
+    /// </summary>
+    public void ResetWindow()
+    {
+        _requestCount = 0;
+        _windowStart = DateTime.UtcNow;
+    }
+}
+
+/// <summary>
+/// Options for configuring <see cref="RateLimitTestHandler"/>.
+/// </summary>
+public class RateLimitTestOptions
+{
+    /// <summary>Maximum requests per window (default: 100).</summary>
+    public int RequestsPerWindow { get; init; } = 100;
+
+    /// <summary>Duration of the rate limit window (default: 1 minute).</summary>
+    public TimeSpan WindowDuration { get; init; } = TimeSpan.FromMinutes(1);
+}
+
+/// <summary>
+/// Test handler that simulates server errors with configurable patterns.
+/// </summary>
+public class ErrorSimulationHandler : DelegatingHandler
+{
+    private readonly ErrorSimulationOptions _options;
+    private int _requestCount;
+    private readonly Random _random = new();
+
+    public ErrorSimulationHandler(ErrorSimulationOptions? options = null)
+    {
+        _options = options ?? new ErrorSimulationOptions();
+        InnerHandler = new HttpClientHandler();
+    }
+
+    /// <summary>Total number of requests made.</summary>
+    public int RequestCount => _requestCount;
+
+    /// <summary>Number of errors simulated.</summary>
+    public int ErrorCount { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        _requestCount++;
+
+        // Check for specific error patterns
+        if (_options.FailOnRequestNumber > 0 && _requestCount == _options.FailOnRequestNumber)
+        {
+            ErrorCount++;
+            return Task.FromResult(CreateErrorResponse(_options.ErrorStatusCode, _options.ErrorMessage));
+        }
+
+        // Random failure chance
+        if (_options.FailureChance > 0 && _random.NextDouble() < _options.FailureChance)
+        {
+            ErrorCount++;
+            return Task.FromResult(CreateErrorResponse(_options.ErrorStatusCode, _options.ErrorMessage));
+        }
+
+        // Simulate timeout
+        if (_options.SimulateTimeout)
+        {
+            throw new TaskCanceledException("Request timeout simulated");
+        }
+
+        // Simulate network error
+        if (_options.SimulateNetworkError)
+        {
+            throw new HttpRequestException("Network error simulated");
+        }
+
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"status\":\"ok\"}", Encoding.UTF8, "application/json")
+        });
+    }
+
+    private static HttpResponseMessage CreateErrorResponse(HttpStatusCode status, string message)
+    {
+        return new HttpResponseMessage(status)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(new { error = message }),
+                Encoding.UTF8,
+                "application/json")
+        };
+    }
+}
+
+/// <summary>
+/// Options for configuring <see cref="ErrorSimulationHandler"/>.
+/// </summary>
+public class ErrorSimulationOptions
+{
+    /// <summary>Fail on a specific request number (0 = disabled).</summary>
+    public int FailOnRequestNumber { get; init; }
+
+    /// <summary>Random failure chance (0.0 to 1.0).</summary>
+    public double FailureChance { get; init; }
+
+    /// <summary>HTTP status code for errors (default: 500).</summary>
+    public HttpStatusCode ErrorStatusCode { get; init; } = HttpStatusCode.InternalServerError;
+
+    /// <summary>Error message to return.</summary>
+    public string ErrorMessage { get; init; } = "Internal server error";
+
+    /// <summary>If true, simulate request timeout.</summary>
+    public bool SimulateTimeout { get; init; }
+
+    /// <summary>If true, simulate network error.</summary>
+    public bool SimulateNetworkError { get; init; }
+}

--- a/testkit/Lidarr.Plugin.Common.TestKit.csproj
+++ b/testkit/Lidarr.Plugin.Common.TestKit.csproj
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Lidarr.Plugin.Common.TestKit</PackageId>
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
     <Authors>RicherTunes Community</Authors>
     <Company>RicherTunes</Company>
     <Description>Shared testing utilities for Lidarr streaming plugins, including AssemblyLoadContext fixtures, HTTP test handlers, and manifest/data helpers.</Description>
@@ -32,6 +32,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testkit/README.md
+++ b/testkit/README.md
@@ -4,9 +4,37 @@ Shared testing helpers for Lidarr streaming plugins.
 
 ## Features
 
+### Plugin Sandbox & Hosting
 - `PluginSandbox` fixture that loads a compiled plugin inside a collectible AssemblyLoadContext and disposes it cleanly, making it easy to test side-by-side versions.
 - Lightweight `PluginTestContext` with a captured log sink so plugin tests can assert on host logs without real host infrastructure.
+
+### HTTP Test Handlers
 - Battle-tested `HttpMessageHandler` shims for the most common upstream behaviours (mislabelled gzip, flaky retries, partial content resumptions, slow streams, preview/sample markers, and problem+json errors).
+- `AuthenticationTestHandler` - Simulates OAuth/token authentication flows for testing auth service implementations.
+- `RateLimitTestHandler` - Simulates rate limiting responses with configurable windows and limits.
+- `ErrorSimulationHandler` - Simulates server errors with configurable failure patterns.
+
+### Test Data Builders
+Fluent builders for creating test instances of streaming models:
+- `StreamingArtistBuilder` - Create test artists with genres, images, metadata.
+- `StreamingAlbumBuilder` - Create test albums with qualities, cover art, external IDs.
+- `StreamingTrackBuilder` - Create test tracks with featured artists, ISRCs, qualities.
+- `StreamingQualityBuilder` - Create test quality levels (MP3, FLAC CD, Hi-Res, etc.).
+- `StreamingSearchResultBuilder` - Create test search results.
+
+### Model Validation
+- `ModelValidationHelpers` - Validators for StreamingModels (artist, album, track, quality).
+- ISRC format validation.
+- UPC/EAN barcode validation with check digit verification.
+- Tracklist validation (sequential numbering, no duplicates).
+- Quality ordering validation for proper fallback behaviour.
+
+### Compliance Testing
+- `PluginComplianceTestBase` - Base class for plugin compliance checks.
+- `StreamingServiceComplianceTestBase` - Extended compliance for streaming plugins.
+- `SecurityComplianceTestBase` - Security-focused compliance checks.
+
+### Test Data
 - Embedded JSON payloads covering tricky streaming metadata (multidisc Qobuz albums, Tidal preview tracks, unicode/emoji artists) for repeatable parsing tests.
 - Assertion helpers for download outcomes, quality fallback checks, and preview rejection.
 
@@ -14,7 +42,7 @@ Shared testing helpers for Lidarr streaming plugins.
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Lidarr.Plugin.Common.TestKit" Version="1.1.4" />
+  <PackageReference Include="Lidarr.Plugin.Common.TestKit" Version="1.1.8" />
 </ItemGroup>
 ```
 
@@ -23,6 +51,70 @@ Then in your test project:
 ```csharp
 await using var sandbox = await PluginSandbox.CreateAsync(pluginPath);
 var indexer = await sandbox.CreateIndexerAsync();
+```
+
+### Using Test Data Builders
+
+```csharp
+using Lidarr.Plugin.Common.TestKit.Builders;
+
+// Create minimal test data
+var artist = StreamingArtistBuilder.CreateMinimal("Pink Floyd");
+var album = StreamingAlbumBuilder.CreateLossless("The Dark Side of the Moon");
+
+// Or use the fluent builder for detailed test scenarios
+var track = new StreamingTrackBuilder()
+    .WithTitle("Money")
+    .WithArtist("Pink Floyd")
+    .WithTrackNumber(6)
+    .WithDuration(TimeSpan.FromMinutes(6.5))
+    .WithIsrc("USCA20200001")
+    .WithFeaturedArtist("Guest Artist")
+    .WithQuality(StreamingQualityBuilder.CreateFlacHiRes())
+    .Build();
+```
+
+### Using Model Validation
+
+```csharp
+using Lidarr.Plugin.Common.TestKit.Validation;
+
+var result = ModelValidationHelpers.ValidateAlbum(album, requireComplete: true);
+if (!result.IsValid)
+{
+    Console.WriteLine(result.GetErrorSummary());
+}
+
+// Validate ISRC/UPC codes
+ModelValidationHelpers.ValidateIsrc("USCA20200001").ThrowIfInvalid();
+ModelValidationHelpers.ValidateUpc("012345678905").ThrowIfInvalid();
+```
+
+### Using HTTP Test Handlers
+
+```csharp
+using Lidarr.Plugin.Common.TestKit.Http;
+
+// Simulate authentication flows
+var authHandler = new AuthenticationTestHandler(new AuthenticationTestOptions
+{
+    TokenLifetime = TimeSpan.FromMinutes(5),
+    SimulateRefreshFailure = false
+});
+
+// Simulate rate limiting
+var rateLimitHandler = new RateLimitTestHandler(new RateLimitTestOptions
+{
+    RequestsPerWindow = 10,
+    WindowDuration = TimeSpan.FromSeconds(30)
+});
+
+// Simulate server errors
+var errorHandler = new ErrorSimulationHandler(new ErrorSimulationOptions
+{
+    FailOnRequestNumber = 3, // Fail on the 3rd request
+    ErrorStatusCode = HttpStatusCode.ServiceUnavailable
+});
 ```
 
 See the library documentation under `docs/how-to/TEST_WITH_TESTKIT.md` for full guidance.

--- a/testkit/Validation/ModelValidationHelpers.cs
+++ b/testkit/Validation/ModelValidationHelpers.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Lidarr.Plugin.Abstractions.Models;
+
+namespace Lidarr.Plugin.Common.TestKit.Validation;
+
+/// <summary>
+/// Validation helpers for StreamingModel objects in tests.
+/// </summary>
+public static class ModelValidationHelpers
+{
+    /// <summary>
+    /// Validates that a StreamingArtist has all required fields populated.
+    /// </summary>
+    public static ValidationResult ValidateArtist(StreamingArtist? artist, bool requireComplete = false)
+    {
+        var errors = new List<string>();
+
+        if (artist == null)
+        {
+            return ValidationResult.Failure("Artist is null");
+        }
+
+        if (string.IsNullOrWhiteSpace(artist.Id))
+            errors.Add("Artist.Id is required");
+
+        if (string.IsNullOrWhiteSpace(artist.Name))
+            errors.Add("Artist.Name is required");
+
+        if (requireComplete)
+        {
+            if (!artist.Genres.Any())
+                errors.Add("Artist.Genres should not be empty for complete validation");
+
+            if (!artist.ImageUrls.Any())
+                errors.Add("Artist.ImageUrls should have at least one image");
+        }
+
+        return errors.Any()
+            ? ValidationResult.Failure(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates that a StreamingAlbum has all required fields populated.
+    /// </summary>
+    public static ValidationResult ValidateAlbum(StreamingAlbum? album, bool requireComplete = false)
+    {
+        var errors = new List<string>();
+
+        if (album == null)
+        {
+            return ValidationResult.Failure("Album is null");
+        }
+
+        if (string.IsNullOrWhiteSpace(album.Id))
+            errors.Add("Album.Id is required");
+
+        if (string.IsNullOrWhiteSpace(album.Title))
+            errors.Add("Album.Title is required");
+
+        var artistResult = ValidateArtist(album.Artist);
+        if (!artistResult.IsValid)
+            errors.AddRange(artistResult.Errors.Select(e => $"Album.Artist: {e}"));
+
+        if (album.TrackCount < 0)
+            errors.Add("Album.TrackCount cannot be negative");
+
+        if (requireComplete)
+        {
+            if (!album.ReleaseDate.HasValue)
+                errors.Add("Album.ReleaseDate is required for complete validation");
+
+            if (string.IsNullOrWhiteSpace(album.Label))
+                errors.Add("Album.Label should be set for complete validation");
+
+            if (!album.CoverArtUrls.Any())
+                errors.Add("Album.CoverArtUrls should have at least one cover");
+
+            if (!album.AvailableQualities.Any())
+                errors.Add("Album.AvailableQualities should have at least one quality");
+        }
+
+        return errors.Any()
+            ? ValidationResult.Failure(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates that a StreamingTrack has all required fields populated.
+    /// </summary>
+    public static ValidationResult ValidateTrack(StreamingTrack? track, bool requireComplete = false)
+    {
+        var errors = new List<string>();
+
+        if (track == null)
+        {
+            return ValidationResult.Failure("Track is null");
+        }
+
+        if (string.IsNullOrWhiteSpace(track.Id))
+            errors.Add("Track.Id is required");
+
+        if (string.IsNullOrWhiteSpace(track.Title))
+            errors.Add("Track.Title is required");
+
+        var artistResult = ValidateArtist(track.Artist);
+        if (!artistResult.IsValid)
+            errors.AddRange(artistResult.Errors.Select(e => $"Track.Artist: {e}"));
+
+        if (requireComplete)
+        {
+            if (!track.TrackNumber.HasValue || track.TrackNumber < 1)
+                errors.Add("Track.TrackNumber should be a positive integer");
+
+            if (!track.Duration.HasValue || track.Duration.Value.TotalSeconds <= 0)
+                errors.Add("Track.Duration should be positive");
+
+            if (string.IsNullOrWhiteSpace(track.Isrc))
+                errors.Add("Track.Isrc should be set for complete validation");
+        }
+
+        return errors.Any()
+            ? ValidationResult.Failure(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates that a StreamingQuality has valid specifications.
+    /// </summary>
+    public static ValidationResult ValidateQuality(StreamingQuality? quality)
+    {
+        var errors = new List<string>();
+
+        if (quality == null)
+        {
+            return ValidationResult.Failure("Quality is null");
+        }
+
+        if (string.IsNullOrWhiteSpace(quality.Id))
+            errors.Add("Quality.Id is required");
+
+        if (string.IsNullOrWhiteSpace(quality.Format))
+            errors.Add("Quality.Format is required");
+
+        // Validate bitrate for lossy formats
+        if (!quality.IsLossless && (!quality.Bitrate.HasValue || quality.Bitrate <= 0))
+            errors.Add("Quality.Bitrate is required for lossy formats");
+
+        // Validate sample rate and bit depth for lossless formats
+        if (quality.IsLossless)
+        {
+            if (!quality.SampleRate.HasValue || quality.SampleRate <= 0)
+                errors.Add("Quality.SampleRate is required for lossless formats");
+
+            if (!quality.BitDepth.HasValue || quality.BitDepth <= 0)
+                errors.Add("Quality.BitDepth is required for lossless formats");
+        }
+
+        // Check for reasonable values
+        if (quality.SampleRate.HasValue && (quality.SampleRate < 8000 || quality.SampleRate > 384000))
+            errors.Add("Quality.SampleRate should be between 8000 and 384000 Hz");
+
+        if (quality.BitDepth.HasValue && (quality.BitDepth < 8 || quality.BitDepth > 32))
+            errors.Add("Quality.BitDepth should be between 8 and 32");
+
+        if (quality.Bitrate.HasValue && (quality.Bitrate < 32 || quality.Bitrate > 9216))
+            errors.Add("Quality.Bitrate should be between 32 and 9216 kbps");
+
+        return errors.Any()
+            ? ValidationResult.Failure(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates that a collection of tracks forms a valid album tracklist.
+    /// </summary>
+    public static ValidationResult ValidateTracklist(IEnumerable<StreamingTrack>? tracks)
+    {
+        var errors = new List<string>();
+
+        if (tracks == null)
+        {
+            return ValidationResult.Failure("Tracklist is null");
+        }
+
+        var trackList = tracks.ToList();
+
+        if (!trackList.Any())
+        {
+            return ValidationResult.Failure("Tracklist is empty");
+        }
+
+        // Validate each track
+        for (int i = 0; i < trackList.Count; i++)
+        {
+            var trackResult = ValidateTrack(trackList[i]);
+            if (!trackResult.IsValid)
+            {
+                errors.AddRange(trackResult.Errors.Select(e => $"Track[{i}]: {e}"));
+            }
+        }
+
+        // Check for duplicate track numbers within each disc
+        var tracksByDisc = trackList.GroupBy(t => t.DiscNumber ?? 1);
+        foreach (var discGroup in tracksByDisc)
+        {
+            var duplicateTrackNumbers = discGroup
+                .Where(t => t.TrackNumber.HasValue)
+                .GroupBy(t => t.TrackNumber)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
+
+            foreach (var dup in duplicateTrackNumbers)
+            {
+                errors.Add($"Disc {discGroup.Key} has duplicate track number: {dup}");
+            }
+        }
+
+        // Check for sequential track numbering
+        foreach (var discGroup in tracksByDisc)
+        {
+            var trackNumbers = discGroup
+                .Where(t => t.TrackNumber.HasValue)
+                .Select(t => t.TrackNumber!.Value)
+                .OrderBy(n => n)
+                .ToList();
+
+            if (trackNumbers.Any() && trackNumbers.First() != 1)
+            {
+                errors.Add($"Disc {discGroup.Key} tracklist should start at track 1, but starts at {trackNumbers.First()}");
+            }
+
+            for (int i = 1; i < trackNumbers.Count; i++)
+            {
+                if (trackNumbers[i] != trackNumbers[i - 1] + 1)
+                {
+                    errors.Add($"Disc {discGroup.Key} has gap in track numbering between {trackNumbers[i - 1]} and {trackNumbers[i]}");
+                }
+            }
+        }
+
+        return errors.Any()
+            ? ValidationResult.Failure(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates quality tier ordering (ensures qualities are properly ranked).
+    /// </summary>
+    public static ValidationResult ValidateQualityOrdering(IEnumerable<StreamingQuality>? qualities)
+    {
+        var errors = new List<string>();
+
+        if (qualities == null)
+        {
+            return ValidationResult.Failure("Qualities collection is null");
+        }
+
+        var qualityList = qualities.ToList();
+
+        if (!qualityList.Any())
+        {
+            return ValidationResult.Failure("Qualities collection is empty");
+        }
+
+        // Validate each quality
+        foreach (var quality in qualityList)
+        {
+            var result = ValidateQuality(quality);
+            if (!result.IsValid)
+            {
+                errors.AddRange(result.Errors.Select(e => $"{quality.Name ?? quality.Id}: {e}"));
+            }
+        }
+
+        // Check tier ordering for fallback logic
+        var tiers = qualityList.Select(q => q.GetTier()).ToList();
+        var expectedOrder = tiers.OrderByDescending(t => t).ToList();
+
+        if (!tiers.SequenceEqual(expectedOrder))
+        {
+            errors.Add("Quality list should be ordered from highest to lowest tier for proper fallback behavior");
+        }
+
+        return errors.Any()
+            ? ValidationResult.Failure(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates ISRC format (International Standard Recording Code).
+    /// </summary>
+    public static ValidationResult ValidateIsrc(string? isrc)
+    {
+        if (string.IsNullOrWhiteSpace(isrc))
+            return ValidationResult.Failure("ISRC is empty");
+
+        // ISRC format: CC-XXX-YY-NNNNN (12 characters without hyphens)
+        var cleanIsrc = isrc.Replace("-", "").Replace(" ", "").ToUpperInvariant();
+
+        if (cleanIsrc.Length != 12)
+            return ValidationResult.Failure($"ISRC must be 12 characters (got {cleanIsrc.Length})");
+
+        // First 2 characters: country code (letters)
+        if (!cleanIsrc.Substring(0, 2).All(char.IsLetter))
+            return ValidationResult.Failure("ISRC country code must be letters");
+
+        // Characters 3-5: registrant code (alphanumeric)
+        if (!cleanIsrc.Substring(2, 3).All(char.IsLetterOrDigit))
+            return ValidationResult.Failure("ISRC registrant code must be alphanumeric");
+
+        // Characters 6-7: year of reference (digits)
+        if (!cleanIsrc.Substring(5, 2).All(char.IsDigit))
+            return ValidationResult.Failure("ISRC year must be digits");
+
+        // Characters 8-12: designation code (digits)
+        if (!cleanIsrc.Substring(7, 5).All(char.IsDigit))
+            return ValidationResult.Failure("ISRC designation code must be digits");
+
+        return ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates UPC/EAN barcode format.
+    /// </summary>
+    public static ValidationResult ValidateUpc(string? upc)
+    {
+        if (string.IsNullOrWhiteSpace(upc))
+            return ValidationResult.Failure("UPC is empty");
+
+        var cleanUpc = upc.Replace("-", "").Replace(" ", "");
+
+        if (!cleanUpc.All(char.IsDigit))
+            return ValidationResult.Failure("UPC must contain only digits");
+
+        // UPC-A is 12 digits, EAN-13 is 13 digits
+        if (cleanUpc.Length != 12 && cleanUpc.Length != 13)
+            return ValidationResult.Failure($"UPC must be 12 or 13 digits (got {cleanUpc.Length})");
+
+        // Validate check digit
+        if (!ValidateUpcCheckDigit(cleanUpc))
+            return ValidationResult.Failure("UPC check digit is invalid");
+
+        return ValidationResult.Success();
+    }
+
+    private static bool ValidateUpcCheckDigit(string upc)
+    {
+        int sum = 0;
+        bool isEan = upc.Length == 13;
+
+        for (int i = 0; i < upc.Length - 1; i++)
+        {
+            int digit = upc[i] - '0';
+            // EAN-13: odd positions × 1, even positions × 3
+            // UPC-A: odd positions × 3, even positions × 1
+            if (isEan)
+                sum += (i % 2 == 0) ? digit : digit * 3;
+            else
+                sum += (i % 2 == 0) ? digit * 3 : digit;
+        }
+
+        int checkDigit = (10 - (sum % 10)) % 10;
+        int actualCheckDigit = upc[^1] - '0';
+
+        return checkDigit == actualCheckDigit;
+    }
+}
+
+/// <summary>
+/// Result of a validation operation.
+/// </summary>
+public sealed class ValidationResult
+{
+    public bool IsValid { get; }
+    public IReadOnlyList<string> Errors { get; }
+
+    private ValidationResult(bool isValid, IReadOnlyList<string> errors)
+    {
+        IsValid = isValid;
+        Errors = errors;
+    }
+
+    public static ValidationResult Success() =>
+        new(true, Array.Empty<string>());
+
+    public static ValidationResult Failure(params string[] errors) =>
+        new(false, errors);
+
+    public string GetErrorSummary(string separator = "; ") =>
+        string.Join(separator, Errors);
+
+    /// <summary>
+    /// Throws if validation failed.
+    /// </summary>
+    public void ThrowIfInvalid()
+    {
+        if (!IsValid)
+            throw new ValidationException(GetErrorSummary());
+    }
+}
+
+/// <summary>
+/// Exception thrown when validation fails.
+/// </summary>
+public class ValidationException : Exception
+{
+    public ValidationException(string message) : base(message) { }
+}


### PR DESCRIPTION
## Summary
- Add fluent builders for StreamingArtist, StreamingAlbum, StreamingTrack, StreamingQuality, and StreamingSearchResult
- Add ModelValidationHelpers with ISRC/UPC validation and tracklist validation
- Add AuthenticationTestHandler, RateLimitTestHandler, and ErrorSimulationHandler for HTTP testing
- Update README with comprehensive usage examples
- Bump version to 1.1.8

## Test plan
- [ ] TestKit builds successfully
- [ ] New builders can create test data without Lidarr dependencies
- [ ] Validation helpers correctly validate ISRC/UPC formats
- [ ] HTTP handlers work for simulating authentication, rate limits, and errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)