### PR TITLE
fix(ci): add global.json to pin SDK to 8.x

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Summary
- Adds global.json to pin .NET SDK to 8.x series
- Prevents rollforward to .NET 10 preview which causes file locking issues during multi-target builds in downstream plugin repos (Brainarr, etc.)

## Changes
- `rollForward`: `latestMinor` - stays within 8.x series

🤖 Generated with [Claude Code](https://claude.com/claude-code)