### PR TITLE
fix: update scripts to use net8.0 instead of net6.0

### DIFF
--- a/scripts/lib/build-common.sh
+++ b/scripts/lib/build-common.sh
@@ -173,7 +173,7 @@ get_version_prefix() {
 
 # Check if Lidarr assemblies exist
 check_lidarr_assemblies() {
-    local path="${1:-ext/Lidarr/_output/net6.0}"
+    local path="${1:-ext/Lidarr/_output/net8.0}"
 
     if [[ -d "$path" ]] && [[ -f "$path/Lidarr.Core.dll" ]]; then
         log_success "Lidarr assemblies found at: $path"
@@ -186,7 +186,7 @@ check_lidarr_assemblies() {
 
 # Extract Lidarr assemblies from Docker
 extract_lidarr_from_docker() {
-    local output_dir="${1:-ext/Lidarr/_output/net6.0}"
+    local output_dir="${1:-ext/Lidarr/_output/net8.0}"
     local docker_version="${2:-pr-plugins-2.14.2.4786}"
 
     log_step "Extracting Lidarr assemblies from Docker..."

--- a/scripts/prepare-host-stub.ps1
+++ b/scripts/prepare-host-stub.ps1
@@ -8,7 +8,7 @@ $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path $scriptRoot -Parent
 
 if (-not $OutputPath -or [string]::IsNullOrWhiteSpace($OutputPath)) {
-    $OutputPath = [System.IO.Path]::Combine($repoRoot, '..', 'Lidarr', '_output', 'net6.0')
+    $OutputPath = [System.IO.Path]::Combine($repoRoot, '..', 'Lidarr', '_output', 'net8.0')
 }
 
 $resolvedOutput = [System.IO.Path]::GetFullPath($OutputPath)
@@ -24,7 +24,7 @@ $projectFile = Join-Path $workingDir 'HostStub.csproj'
 $projectContent = @"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <AssemblyVersion>$AssemblyVersion</AssemblyVersion>
@@ -52,7 +52,7 @@ if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-$builtAssembly = Join-Path $workingDir 'bin/Release/net6.0/HostStub.dll'
+$builtAssembly = Join-Path $workingDir 'bin/Release/net8.0/HostStub.dll'
 if (-not (Test-Path $builtAssembly)) {
     Write-Error "Expected stub assembly at $builtAssembly was not produced."
     exit 1

--- a/scripts/setup-lidarr.ps1
+++ b/scripts/setup-lidarr.ps1
@@ -69,8 +69,8 @@ try {
     }
 
     $lidarrOutputs = @(
-        Join-Path $destPath '_output/net6.0'
-        Join-Path $destPath 'src/Lidarr/bin/Release/net6.0'
+        Join-Path $destPath '_output/net8.0'
+        Join-Path $destPath 'src/Lidarr/bin/Release/net8.0'
     )
 
     $lidarrPath = $null
@@ -82,7 +82,7 @@ try {
     }
 
     if (-not $lidarrPath) {
-        $stubPath = [System.IO.Path]::Combine($destPath, '_output/net6.0')
+        $stubPath = [System.IO.Path]::Combine($destPath, '_output/net8.0')
         if (-not $SkipStub) {
             Write-Host "No Lidarr build output detected; generating host stub" -ForegroundColor Yellow
             & (Join-Path $repoRoot 'scripts/prepare-host-stub.ps1') -OutputPath $stubPath | Out-Null

--- a/scripts/setup-repository.sh
+++ b/scripts/setup-repository.sh
@@ -132,7 +132,7 @@ cat > tests/Lidarr.Plugin.Common.Tests/Lidarr.Plugin.Common.Tests.csproj << 'EOF
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/scripts/verify-assemblies.ps1
+++ b/scripts/verify-assemblies.ps1
@@ -3,7 +3,7 @@ param()
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path $scriptRoot -Parent
 
-$sourcePath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($repoRoot, '..', 'Lidarr', '_output', 'net6.0'))
+$sourcePath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($repoRoot, '..', 'Lidarr', '_output', 'net8.0'))
 if (-not (Test-Path $sourcePath)) {
     Write-Error "Host assemblies not found at $sourcePath. Run build/publish on Lidarr first."
     exit 1


### PR DESCRIPTION
## Summary

Since Common now targets net8.0 only, all scripts that reference net6.0 assembly paths need to be updated.

## Changes

- `verify-assemblies.ps1`: Update default path from net6.0 to net8.0
- `prepare-host-stub.ps1`: Update default output path and target framework
- `setup-lidarr.ps1`: Update Lidarr output path lookups
- `setup-repository.sh`: Update test project target framework
- `lib/build-common.sh`: Update default paths in helper functions

## Testing

This fixes CI failures in Tidalarr after updating the Common submodule.