### PR TITLE
feat(ci): add nightly tests and failure notification workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,165 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    # Run every day at 5 AM UTC (before downstream plugins at 6 AM)
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      dotnet_version:
+        description: '.NET version to test'
+        required: false
+        default: '8.0.x'
+        type: choice
+        options:
+          - '8.0.x'
+          - '9.0.x'
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  nightly-tests:
+    name: Nightly Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        dotnet-version: ['8.0.x']
+        include:
+          # Also test on .NET 9 preview (Ubuntu only)
+          - os: ubuntu-latest
+            dotnet-version: '9.0.x'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet_version || matrix.dotnet-version }}
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/Directory.Packages.props
+            **/NuGet.config
+            global.json
+
+      - name: Restore dependencies
+        run: dotnet restore lidarr.plugin.common.sln
+
+      - name: Build
+        run: dotnet build lidarr.plugin.common.sln --configuration Release --no-restore
+
+      - name: Run tests
+        run: |
+          dotnet test lidarr.plugin.common.sln \
+            --configuration Release \
+            --no-build \
+            --verbosity normal \
+            --collect:"XPlat Code Coverage" \
+            --results-directory TestResults/ \
+            --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}-${{ matrix.dotnet-version }}
+          path: TestResults/
+          retention-days: 7
+
+      - name: Generate coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.dotnet-version == '8.0.x'
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool || true
+          reportgenerator \
+            -reports:TestResults/**/coverage.cobertura.xml \
+            -targetdir:TestResults/CoverageReport \
+            -reporttypes:MarkdownSummaryGithub
+
+      - name: Add coverage to summary
+        if: matrix.os == 'ubuntu-latest' && matrix.dotnet-version == '8.0.x'
+        run: |
+          if [ -f TestResults/CoverageReport/SummaryGithub.md ]; then
+            echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
+            cat TestResults/CoverageReport/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # Check for outdated packages
+  dependency-check:
+    name: Dependency Health Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install dotnet-outdated
+        run: dotnet tool install --global dotnet-outdated-tool
+
+      - name: Check for outdated packages
+        id: outdated
+        run: |
+          echo "## Dependency Health Check" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Run outdated check and capture output
+          dotnet outdated --output outdated.md --output-format markdown || true
+
+          if [ -f outdated.md ] && [ -s outdated.md ]; then
+            cat outdated.md >> $GITHUB_STEP_SUMMARY
+            echo "has_outdated=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ All packages are up to date!" >> $GITHUB_STEP_SUMMARY
+            echo "has_outdated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload outdated report
+        if: steps.outdated.outputs.has_outdated == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: outdated-packages-report
+          path: outdated.md
+          retention-days: 7
+
+  # Summary job
+  nightly-summary:
+    name: Nightly Summary
+    runs-on: ubuntu-latest
+    needs: [nightly-tests, dependency-check]
+    if: always()
+
+    steps:
+      - name: Check results
+        run: |
+          echo "## Nightly Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Tests | ${{ needs.nightly-tests.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dependency Check | ${{ needs.dependency-check.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Run:** [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail if any job failed
+        if: needs.nightly-tests.result == 'failure'
+        run: exit 1

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,131 @@
+name: Notify on Failure
+
+# Reusable workflow for failure notifications
+# Can be called from other workflows or triggered on schedule failures
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        description: 'Name of the failed workflow'
+        required: true
+        type: string
+      run_url:
+        description: 'URL to the failed run'
+        required: false
+        type: string
+    secrets:
+      DISCORD_WEBHOOK:
+        required: false
+      SLACK_WEBHOOK:
+        required: false
+
+  workflow_run:
+    workflows:
+      - "CI"
+      - "Nightly Tests"
+      - "PR Validation"
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  notify:
+    name: Send Failure Notification
+    runs-on: ubuntu-latest
+    # Only run if the triggering workflow failed, or if called directly
+    if: >
+      github.event_name == 'workflow_call' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
+
+    steps:
+      - name: Prepare notification data
+        id: data
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_call" ]; then
+            echo "workflow_name=${{ inputs.workflow_name }}" >> $GITHUB_OUTPUT
+            echo "run_url=${{ inputs.run_url || github.server_url }}/${{ github.repository }}/actions" >> $GITHUB_OUTPUT
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+          else
+            echo "workflow_name=${{ github.event.workflow_run.name }}" >> $GITHUB_OUTPUT
+            echo "run_url=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
+            echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord notification
+        if: ${{ secrets.DISCORD_WEBHOOK != '' }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "❌ CI Failure: ${{ steps.data.outputs.workflow_name }}",
+                "description": "Workflow failed on **${{ steps.data.outputs.branch }}**",
+                "color": 15158332,
+                "fields": [
+                  {"name": "Repository", "value": "`${{ steps.data.outputs.repo }}`", "inline": true},
+                  {"name": "Branch", "value": "`${{ steps.data.outputs.branch }}`", "inline": true}
+                ],
+                "url": "${{ steps.data.outputs.run_url }}",
+                "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+              }]
+            }' \
+            "$DISCORD_WEBHOOK"
+
+      - name: Send Slack notification
+        if: ${{ secrets.SLACK_WEBHOOK != '' }}
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {"type": "plain_text", "text": "❌ CI Failure", "emoji": true}
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {"type": "mrkdwn", "text": "*Workflow:*\n${{ steps.data.outputs.workflow_name }}"},
+                    {"type": "mrkdwn", "text": "*Repository:*\n${{ steps.data.outputs.repo }}"},
+                    {"type": "mrkdwn", "text": "*Branch:*\n${{ steps.data.outputs.branch }}"}
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {"type": "plain_text", "text": "View Run"},
+                      "url": "${{ steps.data.outputs.run_url }}"
+                    }
+                  ]
+                }
+              ]
+            }' \
+            "$SLACK_WEBHOOK"
+
+      - name: Log notification (fallback if no webhook configured)
+        if: ${{ secrets.DISCORD_WEBHOOK == '' && secrets.SLACK_WEBHOOK == '' }}
+        run: |
+          echo "::warning::No notification webhook configured (DISCORD_WEBHOOK or SLACK_WEBHOOK)"
+          echo ""
+          echo "## ❌ Workflow Failure Detected" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow | ${{ steps.data.outputs.workflow_name }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Repository | ${{ steps.data.outputs.repo }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Branch | ${{ steps.data.outputs.branch }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Run URL | ${{ steps.data.outputs.run_url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ **Configure webhooks for real-time notifications:**" >> $GITHUB_STEP_SUMMARY
+          echo "- Add \`DISCORD_WEBHOOK\` secret for Discord notifications" >> $GITHUB_STEP_SUMMARY
+          echo "- Add \`SLACK_WEBHOOK\` secret for Slack notifications" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds two critical CI/CD improvements:

### 1. Nightly Tests (`nightly.yml`)
- **Schedule:** Daily at 5 AM UTC (1 hour before downstream plugins)
- **Matrix:** Ubuntu + Windows, .NET 8.x + 9.x preview
- **Features:**
  - Full test suite with code coverage
  - Coverage reporting via ReportGenerator
  - Dependency health check with `dotnet-outdated`
  - Test result artifacts retained for 7 days

### 2. Failure Notifications (`notify-failure.yml`)
- **Reusable workflow** that can be called from other workflows
- **Auto-triggers** on CI, Nightly Tests, and PR Validation failures
- **Supports:**
  - Discord webhooks (`DISCORD_WEBHOOK` secret)
  - Slack webhooks (`SLACK_WEBHOOK` secret)
  - Falls back to GitHub Step Summary if no webhook configured

## Why This Matters

Common is upstream of all plugins (Brainarr, Tidalarr, Qobuzarr). Without nightly tests:
- Breaking changes can propagate undetected
- Environment-specific issues aren't caught early
- No visibility into dependency drift

## Configuration Required

To enable notifications, add one or both secrets:
- `DISCORD_WEBHOOK` - Discord webhook URL
- `SLACK_WEBHOOK` - Slack incoming webhook URL

Without webhooks, failures are logged to GitHub Step Summary.