### PR TITLE
fix(ilrepack): add UsingTask for ExcludeAssets=build compatibility

### DIFF
--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -1,15 +1,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Plugin Packaging with ILRepack Internalization
-    
+
     Merges plugin dependencies into a single DLL with internal visibility,
     preventing version conflicts when multiple RicherTunes plugins are installed.
 
     USAGE:
-    1. Add ILRepack.Lib.MSBuild.Task package
+    1. Add ILRepack.Lib.MSBuild.Task package with ExcludeAssets="build" and GeneratePathProperty="true"
     2. Import this targets file
     3. Optionally set LidarrAssembliesPath
   -->
+
+  <!-- Import ILRepack task from NuGet package - supports both netfx and netcore -->
+  <UsingTask TaskName="ILRepack"
+             AssemblyFile="$(PkgILRepack_Lib_MSBuild_Task)/build/ILRepack.Lib.MSBuild.Task.dll"
+             Condition="'$(PkgILRepack_Lib_MSBuild_Task)' != '' and Exists('$(PkgILRepack_Lib_MSBuild_Task)/build/ILRepack.Lib.MSBuild.Task.dll')" />
 
   <PropertyGroup>
     <PluginAssemblyFileName Condition="'$(PluginAssemblyFileName)' == ''">$(AssemblyName).dll</PluginAssemblyFileName>


### PR DESCRIPTION
## Summary
- Adds UsingTask definition to PluginPackaging.targets for ILRepack task loading
- Enables plugins to use `ExcludeAssets="build"` to prevent double ILRepack execution
- Updates USAGE documentation

## Problem
When plugins use the ILRepack.Lib.MSBuild.Task NuGet package without `ExcludeAssets="build"`, the package's built-in ILRepack target runs IN ADDITION to our custom RepackPlugin target. This causes:
1. Double ILRepack execution
2. The second run fails because it lacks LibraryPath to Lidarr assemblies

## Solution
Allow plugins to use `ExcludeAssets="build" GeneratePathProperty="true"` on the PackageReference:
- `ExcludeAssets="build"` prevents the package's built-in target from running
- `GeneratePathProperty="true"` creates `$(PkgILRepack_Lib_MSBuild_Task)` variable
- Our PluginPackaging.targets now has its own UsingTask that uses this path variable

## Test plan
- [ ] Qobuzarr screenshot workflow passes
- [ ] Tidalarr screenshot workflow passes
- [ ] Brainarr screenshot workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)