### PR TITLE
feat(ilrepack): add System.Text.Json to assembly merge list

### DIFF
--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -68,6 +68,8 @@
       <_PluginDeps Include="$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll" Condition="Exists('$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll')" />
       <!-- FluentValidation - merge to avoid version conflicts with Lidarr host (plugins may use 11.x, Lidarr has 9.x) -->
       <_PluginDeps Include="$(OutputPath)FluentValidation.dll" Condition="Exists('$(OutputPath)FluentValidation.dll')" />
+      <!-- System.Text.Json - merge to avoid version conflicts (plugins may use 9.x, Lidarr has 8.x or older) -->
+      <_PluginDeps Include="$(OutputPath)System.Text.Json.dll" Condition="Exists('$(OutputPath)System.Text.Json.dll')" />
       <_PluginDeps Include="@(PluginPackagingAdditionalMerge)" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Adds System.Text.Json to the ILRepack merge list in PluginPackaging.targets
- Fixes version conflicts when plugins use newer System.Text.Json (9.x) than what Lidarr provides (8.x or older)
- Required for Tidalarr plugin which uses System.Text.Json v9.0.0.0

## Test plan
- [ ] Build Tidalarr plugin with this change
- [ ] Verify System.Text.Json is included in merged assembly
- [ ] Test plugin loads in Lidarr without version conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)