### PR TITLE
fix: exclude FluentValidation from ILRepack merge list

### DIFF
--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -66,8 +66,8 @@
       <_PluginDeps Include="$(OutputPath)Microsoft.Extensions.Options.dll" Condition="Exists('$(OutputPath)Microsoft.Extensions.Options.dll')" />
       <_PluginDeps Include="$(OutputPath)Microsoft.Extensions.Primitives.dll" Condition="Exists('$(OutputPath)Microsoft.Extensions.Primitives.dll')" />
       <_PluginDeps Include="$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll" Condition="Exists('$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll')" />
-      <!-- FluentValidation - merge to avoid version conflicts with Lidarr host (plugins may use 11.x, Lidarr has 9.x) -->
-      <_PluginDeps Include="$(OutputPath)FluentValidation.dll" Condition="Exists('$(OutputPath)FluentValidation.dll')" />
+      <!-- NOTE: FluentValidation must NOT be merged - it breaks DownloadClient.Test(List<ValidationFailure>) -->
+      <!-- <_PluginDeps Include="$(OutputPath)FluentValidation.dll" /> DO NOT ENABLE - breaks Test() signature -->
       <!-- System.Text.Json - merge to avoid version conflicts (plugins may use 9.x, Lidarr has 8.x or older) -->
       <_PluginDeps Include="$(OutputPath)System.Text.Json.dll" Condition="Exists('$(OutputPath)System.Text.Json.dll')" />
       <_PluginDeps Include="@(PluginPackagingAdditionalMerge)" />


### PR DESCRIPTION
## Summary
- FluentValidation must NOT be merged with `Internalize=true` because it's used in public API methods like `DownloadClientBase.Test(List<ValidationFailure>)`
- When ILRepack internalizes FluentValidation types, the `Test()` method signature no longer matches what Lidarr's base class expects

## Problem
Qobuzarr plugin fails to load on Lidarr plugins branch with:
```
TypeLoadException: Method 'Test' in type 'Lidarr.Plugin.Qobuzarr.Download.Clients.QobuzDownloadClient' does not have an implementation
```

## Root Cause
ILRepack with `Internalize=true` changes `FluentValidation.Results.ValidationFailure` to an internal type within the merged assembly. The `Test(List<ValidationFailure>)` method then has a different type signature than what `DownloadClientBase` expects from the Lidarr host's FluentValidation.

## Solution
Exclude FluentValidation from the ILRepack merge list. TrevTV's working plugins (Tidal, Qobuz, Deezer) do NOT merge FluentValidation - they only merge their own dependencies like QobuzApiSharp, Newtonsoft.Json, and TagLibSharp.

## Test plan
- [ ] Verify Qobuzarr plugin loads on Lidarr plugins branch v2.14.2.4786
- [ ] Verify plugin Test() method works (shows Qobuz login URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)