### PR TITLE
fix: Keep FluentValidation.dll in plugin output (not deleted after merge)

### DIFF
--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -105,11 +105,17 @@
     <Delete Files="$(IntermediateOutputPath)$(AssemblyName).merged.pdb"
             Condition="Exists('$(IntermediateOutputPath)$(AssemblyName).merged.pdb')" />
 
+
+    <!-- Assemblies to keep (NOT merged but required at runtime).
+         FluentValidation can't be merged (breaks Test() signature) but is still needed. -->
     <ItemGroup>
-      <_ExtraAssemblies Include="$(OutputPath)*.dll" Exclude="$(OutputPath)$(PluginAssemblyFileName)" />
+      <_PluginRuntimeDeps Include="$(OutputPath)FluentValidation.dll" Condition="Exists('$(OutputPath)FluentValidation.dll')" />
+      <_PluginRuntimeDeps Include="@(PluginPackagingAdditionalKeep)" />
+      <_ExtraAssemblies Include="$(OutputPath)*.dll" Exclude="$(OutputPath)$(PluginAssemblyFileName);@(_PluginRuntimeDeps)" />
       <_ExtraSymbols Include="$(OutputPath)*.pdb" Exclude="$(OutputPath)$(PluginSymbolFileName)" />
     </ItemGroup>
 
+    <Message Text="[ILRepack] Keeping runtime dependencies: @(_PluginRuntimeDeps->'%(Filename)')" Importance="high" Condition="'@(_PluginRuntimeDeps)' != ''" />
     <Delete Files="@(_ExtraAssemblies)" />
     <Delete Files="@(_ExtraSymbols)" />
     <Delete Files="$(OutputPath)$(AssemblyName).deps.json" Condition="Exists('$(OutputPath)$(AssemblyName).deps.json')" />


### PR DESCRIPTION
## Summary

- Fixes Qobuzarr plugin loading failure caused by missing FluentValidation.dll
- PR #118 correctly excluded FluentValidation from ILRepack merging, but the cleanup step was still deleting it
- Adds `_PluginRuntimeDeps` ItemGroup to preserve assemblies needed at runtime but not merged

## Problem

After PR #118 (exclude FluentValidation from ILRepack merge), Qobuzarr fails to load with:
```
Could not load file or assembly 'FluentValidation, Version=11.0.0.0...'
```

## Root Cause

The `RepackPlugin` target's cleanup step deletes ALL DLLs except the merged assembly:
```xml
<_ExtraAssemblies Include="$(OutputPath)*.dll" Exclude="$(OutputPath)$(PluginAssemblyFileName)" />
<Delete Files="@(_ExtraAssemblies)" />
```

This deleted FluentValidation.dll even though it was excluded from merging (and still needed at runtime).

## Solution

Add a new ItemGroup `_PluginRuntimeDeps` that tracks assemblies to KEEP:
- FluentValidation.dll is automatically kept if present
- Plugins can add additional assemblies via `PluginPackagingAdditionalKeep`
- Added diagnostic message showing which runtime deps are being preserved

## Test plan

- [ ] Build Qobuzarr with updated submodule
- [ ] Verify FluentValidation.dll exists in output alongside merged plugin DLL
- [ ] Verify plugin loads successfully on Lidarr plugins branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)