### PR TITLE
fix: upgrade Lidarr Docker image to 3.1.x for .NET 8.0 compatibility

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -8,10 +8,10 @@ on:
         required: true
         type: string
       lidarr_docker_version:
-        description: 'Lidarr Docker image version (e.g., pr-plugins-2.14.2.4786)'
+        description: 'Lidarr Docker image version (e.g., pr-plugins-3.1.1.4884)'
         required: false
         type: string
-        default: 'pr-plugins-2.14.2.4786'
+        default: 'pr-plugins-3.1.1.4884'
       test_plugins:
         description: 'Comma-separated list of plugins to test (default: all)'
         required: false


### PR DESCRIPTION
## Summary
- Upgrades the multi-plugin smoke test Docker image from `pr-plugins-2.14.2.4786` (.NET 6.0) to `pr-plugins-3.1.1.4884` (.NET 8.0)
- Fixes runtime assembly loading error: `Could not load file or assembly 'System.Runtime, Version=8.0.0.0'`

## Problem
The multi-plugin smoke test was failing because:
1. Plugins are built with `--framework net8.0`
2. Docker image runs Lidarr on .NET 6.0
3. When Lidarr loads the plugins, it can't find .NET 8.0 assemblies

## Solution
Update to Lidarr 3.1.x Docker image which runs on .NET 8.0, matching the plugin build target.

## Test plan
- [ ] CI smoke test passes
- [ ] Plugins load successfully in Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)