### PR TITLE
fix(ci): remove invalid job-level if referencing matrix

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -51,7 +51,6 @@ env:
 jobs:
   smoke-test:
     name: Smoke Test (${{ matrix.name }})
-    if: ${{ matrix.name != 'canary' || inputs.run_canary }}
     continue-on-error: ${{ matrix.allow_failure }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
GitHub Actions doesn't allow matrix context in job-level if conditions. Remove the condition - both gate and canary will run, with canary using continue-on-error: true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)