### PR TITLE
chore(ci): add verbose output to build commands

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -121,13 +121,13 @@ jobs:
         shell: pwsh
         working-directory: qobuzarr
         run: |
-          ./build.ps1 -Configuration Release -Restore -Package
+          ./build.ps1 -Configuration Release -Restore -Package -VerboseOutput
 
       - name: Build Tidalarr package
         shell: pwsh
         working-directory: tidalarr
         run: |
-          ./build.ps1 -Configuration Release -Restore -Package
+          ./build.ps1 -Configuration Release -Restore -Package -VerboseOutput
 
       - name: Locate plugin zips
         shell: pwsh


### PR DESCRIPTION
Add -VerboseOutput to build.ps1 calls to diagnose build failures in smoke test.