### PR TITLE
fix(smoke-test): add fallback dotnet build to capture actual errors

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -121,13 +121,46 @@ jobs:
         shell: pwsh
         working-directory: qobuzarr
         run: |
-          ./build.ps1 -Configuration Release -Restore -Package -VerboseOutput
+          $buildSuccess = $false
+          try {
+            ./build.ps1 -Configuration Release -Restore -Package -VerboseOutput
+            if ($LASTEXITCODE -eq 0) { $buildSuccess = $true }
+          } catch {
+            Write-Host "build.ps1 threw exception: $_" -ForegroundColor Red
+          }
+          if (-not $buildSuccess) {
+            Write-Host ""
+            Write-Host "::group::Detailed build error output"
+            dotnet restore --verbosity quiet 2>&1 | Out-Null
+            dotnet build Qobuzarr.csproj --configuration Release --no-restore --verbosity normal -p:RunAnalyzersDuringBuild=false -p:EnableNETAnalyzers=false -p:TreatWarningsAsErrors=false 2>&1
+            Write-Host "::endgroup::"
+            exit 1
+          }
 
       - name: Build Tidalarr package
         shell: pwsh
         working-directory: tidalarr
         run: |
-          ./build.ps1 -Configuration Release -Restore -Package -VerboseOutput
+          $buildSuccess = $false
+          try {
+            ./build.ps1 -Configuration Release -Restore -Package -VerboseOutput
+            if ($LASTEXITCODE -eq 0) { $buildSuccess = $true }
+          } catch {
+            Write-Host "build.ps1 threw exception: $_" -ForegroundColor Red
+          }
+          if (-not $buildSuccess) {
+            Write-Host ""
+            Write-Host "::group::Detailed build error output"
+            dotnet restore --verbosity quiet 2>&1 | Out-Null
+            $csproj = Get-ChildItem -Filter "*.csproj" | Where-Object { $_.Name -notmatch "Tests" } | Select-Object -First 1
+            if ($csproj) {
+              dotnet build $csproj.Name --configuration Release --no-restore --verbosity normal -p:RunAnalyzersDuringBuild=false -p:EnableNETAnalyzers=false -p:TreatWarningsAsErrors=false 2>&1
+            } else {
+              dotnet build --configuration Release --no-restore --verbosity normal -p:RunAnalyzersDuringBuild=false -p:EnableNETAnalyzers=false -p:TreatWarningsAsErrors=false 2>&1
+            }
+            Write-Host "::endgroup::"
+            exit 1
+          }
 
       - name: Locate plugin zips
         shell: pwsh


### PR DESCRIPTION
## Summary
- When build.ps1 fails, it now runs dotnet build directly with normal verbosity
- This captures the actual error messages that were being swallowed
- Helps diagnose build failures in Qobuzarr and Tidalarr plugins

## Problem
The build.ps1 scripts capture build output to a variable but don't display it when the build fails. This made it impossible to diagnose why builds were failing in CI.

## Solution
Added fallback logic that:
1. Tries build.ps1 first
2. If it fails, runs dotnet build directly with `--verbosity normal`
3. Outputs errors in a GitHub Actions group for easy viewing

## Test plan
- [ ] Run smoke test workflow to see actual build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)