### PR TITLE
fix: sync tools from main checkout to plugin submodules

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -175,6 +175,39 @@ jobs:
           # Cleanup
           rm -rf _lidarr_extracted
 
+      - name: Sync tools from main checkout to submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Syncing tools and build assets from main checkout to plugin submodules..."
+
+          # Both plugins have submodules at ext/Lidarr.Plugin.Common
+          # The submodules may point to older commits, so we sync from this checkout
+          for plugin_dir in qobuzarr tidalarr; do
+            submod_common="$plugin_dir/ext/Lidarr.Plugin.Common"
+            if [ -d "$submod_common" ]; then
+              echo "Syncing to $submod_common..."
+
+              # Sync tools directory (includes ManifestCheck.ps1, PluginPack.psm1)
+              if [ -d "tools" ]; then
+                rm -rf "$submod_common/tools"
+                cp -r tools "$submod_common/tools"
+                echo "  - tools/ synced"
+              fi
+
+              # Sync build directory (includes PluginPackaging.targets)
+              if [ -d "build" ]; then
+                rm -rf "$submod_common/build"
+                cp -r build "$submod_common/build"
+                echo "  - build/ synced"
+              fi
+            else
+              echo "Warning: $submod_common not found, skipping sync"
+            fi
+          done
+
+          echo "Tool sync complete"
+
       - name: Build Qobuzarr package
         shell: pwsh
         working-directory: qobuzarr


### PR DESCRIPTION
## Summary
- Adds a step to sync `tools/` and `build/` directories from the main checkout to plugin submodule directories
- Ensures plugin builds use the latest ManifestCheck.ps1 and PluginPack.psm1 fixes

## Problem
When the smoke test checks out plugin repos (Qobuzarr, Tidalarr), their submodules point to older commits of Lidarr.Plugin.Common. This means fixes in the main checkout (like the ManifestCheck.ps1 version extraction fix in PR #150) aren't available during plugin builds.

The Tidalarr build was still failing with "Unable to resolve Version" because its submodule had an older ManifestCheck.ps1 that didn't have the semver extraction logic.

## Solution
After checking out both plugins, sync the tools and build directories from the main checkout to each plugin's `ext/Lidarr.Plugin.Common/` submodule directory.

## Test plan
- [ ] Run smoke test and verify both Qobuzarr and Tidalarr build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)