### PR TITLE
fix: use hashtable splatting for PluginZip array parameter

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -371,20 +371,19 @@ jobs:
           $containerName = "lidarr-multi-${{ matrix.name }}-${{ github.run_id }}-${{ github.run_attempt }}"
           "SMOKE_CONTAINER_NAME=$containerName" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
-          $args = @(
-            "-LidarrTag", "${{ matrix.lidarr_tag }}",
-            "-ContainerName", $containerName,
-            "-PluginZip", "qobuzarr=$env:QOBUZ_ZIP",
-            "-PluginZip", "tidalarr=$env:TIDAL_ZIP",
-            "-KeepRunning"
-          )
+          $params = @{
+            LidarrTag = "${{ matrix.lidarr_tag }}"
+            ContainerName = $containerName
+            PluginZip = @("qobuzarr=$env:QOBUZ_ZIP", "tidalarr=$env:TIDAL_ZIP")
+            KeepRunning = $true
+          }
 
-          if ("${{ inputs.run_medium_gate }}" -eq "true") { $args += "-RunMediumGate" }
-          if ("${{ inputs.run_downloadclient_gate }}" -eq "true") { $args += "-RunDownloadClientGate" }
-          if ("${{ inputs.run_search_gate }}" -eq "true") { $args += "-RunSearchGate" }
-          if ("${{ inputs.require_all_indexers_in_search }}" -eq "true") { $args += "-RequireAllConfiguredIndexersInSearch" }
+          if ("${{ inputs.run_medium_gate }}" -eq "true") { $params.RunMediumGate = $true }
+          if ("${{ inputs.run_downloadclient_gate }}" -eq "true") { $params.RunDownloadClientGate = $true }
+          if ("${{ inputs.run_search_gate }}" -eq "true") { $params.RunSearchGate = $true }
+          if ("${{ inputs.require_all_indexers_in_search }}" -eq "true") { $params.RequireAllConfiguredIndexersInSearch = $true }
 
-          & pwsh -File "scripts/multi-plugin-docker-smoke-test.ps1" @args
+          & ./scripts/multi-plugin-docker-smoke-test.ps1 @params
 
       - name: Collect container diagnostics
         if: always()


### PR DESCRIPTION
## Summary
- Fixes parameter binding error when passing multiple plugin zips to the smoke test harness

## Problem
The workflow was passing multiple `-PluginZip` arguments using array splatting:
```powershell
$args = @(
  "-PluginZip", "qobuzarr=...",
  "-PluginZip", "tidalarr=...",  # Duplicate!
)
& pwsh -File "script.ps1" @args
```

This caused PowerShell to reject it with:
> Cannot bind parameter because parameter 'PluginZip' is specified more than once.

## Solution
Use hashtable splatting with a proper array value:
```powershell
$params = @{
  PluginZip = @("qobuzarr=...", "tidalarr=...")
}
& ./script.ps1 @params
```

## Test plan
- [ ] Run smoke test and verify harness executes without parameter errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)