### PR TITLE
fix(smoke): use net8 host tag + TFM preflight

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       lidarr_tag:
-        description: Lidarr Docker tag (plugins branch)
+        description: Lidarr Docker tag (plugins branch; must support net8 plugins)
         required: true
-        default: pr-plugins-2.14.2.4786
+        default: pr-plugins-3.1.1.4884
       qobuzarr_ref:
         description: Qobuzarr branch/tag/SHA
         required: true

--- a/docs/INVESTIGATION-PLUGIN-LOADING-ISSUE.md
+++ b/docs/INVESTIGATION-PLUGIN-LOADING-ISSUE.md
@@ -145,7 +145,7 @@ public abstract DownloadProtocol Protocol { get; }  // ENUM type
 
 **Evidence supporting this**:
 - Workflow builds with `-p:TargetFramework=net6.0`
-- Container is `ghcr.io/hotio/lidarr:pr-plugins-2.14.2.4786`
+- Container is `ghcr.io/hotio/lidarr:pr-plugins-2.14.2.4786` (net6 host; cannot load net8 plugins)
 - CLAUDE.md in Qobuzarr has extensive documentation about this exact issue
 - Working plugins (TrevTV's, TypNull's) use specific patterns for plugins branch
 
@@ -175,7 +175,7 @@ Plugin DLL might be:
 ```yaml
 env:
   DOTNET_VERSION: '8.0.x'
-  LIDARR_DOCKER_VERSION: 'pr-plugins-2.14.2.4786'
+  LIDARR_DOCKER_VERSION: 'pr-plugins-2.14.2.4786'  # net6 host (use pr-plugins-3.x for net8 plugins)
 
 # Build step
 dotnet restore src/Tidalarr/Tidalarr.csproj -p:TargetFramework=net6.0

--- a/docs/MULTI_PLUGIN_SMOKE_TEST.md
+++ b/docs/MULTI_PLUGIN_SMOKE_TEST.md
@@ -42,7 +42,7 @@ Secrets can use either `QOBUZARR_*` or `QOBUZ_*` prefix (and similarly `TIDALARR
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `lidarr_tag` | string | `pr-plugins-2.14.2.4786` | Lidarr Docker image tag (plugins branch) |
+| `lidarr_tag` | string | `pr-plugins-3.1.1.4884` | Lidarr Docker image tag (plugins branch; must support net8 plugins) |
 | `qobuzarr_ref` | string | `main` | Qobuzarr branch/tag/SHA to test |
 | `tidalarr_ref` | string | `main` | Tidalarr branch/tag/SHA to test |
 | `run_medium_gate` | boolean | `false` | Configure and test indexers (requires credentials) |

--- a/scripts/lib/build-common.sh
+++ b/scripts/lib/build-common.sh
@@ -187,7 +187,7 @@ check_lidarr_assemblies() {
 # Extract Lidarr assemblies from Docker
 extract_lidarr_from_docker() {
     local output_dir="${1:-ext/Lidarr/_output/net8.0}"
-    local docker_version="${2:-pr-plugins-2.14.2.4786}"
+    local docker_version="${2:-pr-plugins-3.1.1.4884}"
 
     log_step "Extracting Lidarr assemblies from Docker..."
 


### PR DESCRIPTION
Fixes the multi-plugin smoke test failing with System.Runtime, Version=8.0.0.0 when the workflow default Lidarr image is a net6 host.\n\nChanges:\n- Default Lidarr image tag to pr-plugins-3.1.1.4884 (net8).\n- Add TFM preflight in scripts/multi-plugin-docker-smoke-test.ps1 that reads the host Lidarr.runtimeconfig.json and fails fast if host net major < plugin net major (based on plugin.json.targetFramework).\n- Improve trap handling to rethrow the original error record (keeps message).\n- Update docs defaults.