### PR TITLE
fix(packaging): ship Lidarr.Plugin.Abstractions

### DIFF
--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -116,12 +116,12 @@
 
 
     <!-- Assemblies to keep (NOT merged but required at runtime).
-         IMPORTANT: In a multi-plugin Lidarr instance, shipping shared assemblies that the host already provides
-         (e.g., Lidarr.Plugin.Abstractions, Microsoft.Extensions.*.Abstractions) can cause load failures:
-         the first plugin may load the assembly, and subsequent plugins attempting to load a second copy
-         can trigger InvalidOperationException / TypeLoadException due to duplicate identities.
-         Prefer host-provided copies for cross-boundary type identity. -->
+         Notes:
+           - Lidarr.Plugin.Abstractions is required for plugin discovery/loading, and is not shipped by the Lidarr host image.
+           - Microsoft.Extensions.*.Abstractions are shipped by the host and should not be bundled with plugins to avoid duplicates. -->
     <ItemGroup>
+      <_PluginRuntimeDeps Include="$(_PluginOutputPath)Lidarr.Plugin.Abstractions.dll"
+                         Condition="Exists('$(_PluginOutputPath)Lidarr.Plugin.Abstractions.dll')" />
       <_PluginRuntimeDeps Include="@(PluginPackagingAdditionalKeep)" />
       <_ExtraAssemblies Include="$(_PluginOutputPath)*.dll" Exclude="$(_PluginOutputPath)$(PluginAssemblyFileName);@(_PluginRuntimeDeps)" />
       <_ExtraSymbols Include="$(_PluginOutputPath)*.pdb" Exclude="$(_PluginOutputPath)$(PluginSymbolFileName)" />

--- a/src/Utilities/PackageClosureValidator.cs
+++ b/src/Utilities/PackageClosureValidator.cs
@@ -39,7 +39,8 @@ namespace Lidarr.Plugin.Common.Utilities
         /// </summary>
         public static readonly IReadOnlyList<string> DefaultAllowedAssemblies = new[]
         {
-            "Lidarr.Plugin.Common.dll"
+            "Lidarr.Plugin.Common.dll",
+            "Lidarr.Plugin.Abstractions.dll"
         };
 
         /// <summary>

--- a/tools/PluginPack.psm1
+++ b/tools/PluginPack.psm1
@@ -191,11 +191,11 @@ function Invoke-PluginCleanup {
     
     Keeps:
     - Plugin assembly (merged)
-    
+    - Lidarr.Plugin.Abstractions.dll (required for plugin discovery/loading; host image does not ship it)
+
     NOTE: Do NOT ship host-provided / cross-boundary assemblies (type identity).
     In multi-plugin scenarios, shipping these can cause load failures when a second plugin
     attempts to load another copy into the same load context.
-      - Lidarr.Plugin.Abstractions.dll
       - Microsoft.Extensions.DependencyInjection.Abstractions.dll
       - Microsoft.Extensions.Logging.Abstractions.dll
       - FluentValidation.dll
@@ -211,9 +211,10 @@ function Invoke-PluginCleanup {
         [string]$AssemblyName
     )
 
-    # Assemblies to KEEP in the package.
+    # Assemblies to KEEP in the package (must match PluginPackaging.targets _PluginRuntimeDeps).
     $keepAssemblies = @(
-        "$AssemblyName.dll" # Plugin itself (merged)
+        "$AssemblyName.dll",                  # Plugin itself (merged)
+        'Lidarr.Plugin.Abstractions.dll'       # Required for plugin discovery/loading
     )
 
     # Remove everything except kept assemblies


### PR DESCRIPTION
Lidarr net8 plugin host images (e.g. ghcr.io/hotio/lidarr:pr-plugins-3.1.1.4884) do not ship Lidarr.Plugin.Abstractions.dll in /app/bin, so plugins must ship it for discovery/loading.

Changes:
- Keep Lidarr.Plugin.Abstractions.dll as a runtime dependency during ILRepack cleanup (uild/PluginPackaging.targets, 	ools/PluginPack.psm1).
- Require Abstractions in package validation (	ests/PackageValidation/PluginPackageValidator.cs, src/Utilities/PackageClosureValidator.cs).
- Multi-plugin smoke test now verifies all staged Abstractions copies are byte-identical (fails fast if they differ).