### PR TITLE
fix(ci): only run canary when run_canary=true

### DIFF
--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -66,6 +66,7 @@ env:
 jobs:
   smoke-test:
     name: Smoke Test (${{ matrix.name }})
+    if: ${{ matrix.name != 'canary' || inputs.run_canary }}
     continue-on-error: ${{ matrix.allow_failure }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Stops the canary matrix job from running unless un_canary is enabled.

This avoids failing the workflow on Validate credentials when canary is off (default) but credential-gated gates are enabled.