### PR TITLE
chore(scripts): persistent local E2E runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ _nupkg_extract/
 # Local Docker smoke test staging
 .docker-multi-smoke-test/
 
+# Persistent local test state
+.persistent-*/
+
 # Test artifacts
 [Tt]est[Rr]esults*/
 *.trx

--- a/docs/PERSISTENT_E2E_TESTING.md
+++ b/docs/PERSISTENT_E2E_TESTING.md
@@ -1,0 +1,87 @@
+# Persistent Local E2E Testing (Lidarr + Plugins)
+
+This repo contains PowerShell scripts to run Lidarr in Docker while persisting config between runs.
+
+## Qobuzarr only (single-plugin)
+
+Script: `scripts/test-qobuzarr-persistent.ps1`
+
+```powershell
+# Start (uses cached build if present)
+pwsh scripts/test-qobuzarr-persistent.ps1
+
+# Force rebuild plugin zip before starting
+pwsh scripts/test-qobuzarr-persistent.ps1 -Rebuild
+
+# Wipe persisted config and start fresh
+pwsh scripts/test-qobuzarr-persistent.ps1 -Clean
+```
+
+UI: `http://localhost:8689`
+
+## Qobuzarr + Tidalarr together (multi-plugin, persistent)
+
+Script: `scripts/multi-plugin-docker-smoke-test.ps1`
+
+This script can run in a “persistent” mode so your Lidarr database/config survives container restarts.
+
+```powershell
+$q = (Resolve-Path ..\qobuzarr\artifacts\packages\qobuzarr-0.1.0-dev-net8.0.zip).Path
+$t = (Resolve-Path ..\tidalarr\src\Tidalarr\artifacts\packages\tidalarr-1.0.1-net8.0.zip).Path
+
+# Optional: mount a locally-built Lidarr DLL into the container to validate an upstream fix
+$hostOverride = (Resolve-Path ..\_upstream\Lidarr\_output\net8.0\Lidarr.Common.dll).Path
+
+pwsh scripts/multi-plugin-docker-smoke-test.ps1 `
+  -PluginZip @("qobuzarr=$q","tidalarr=$t") `
+  -ContainerName lidarr-multi-plugin-persist `
+  -Port 8691 `
+  -PreserveState `
+  -WorkRoot .persistent-multi `
+  -KeepRunning `
+  -HostOverrideAssembly @($hostOverride)
+```
+
+Config is stored under `.persistent-multi/<ContainerName>/config` (relative to `lidarr.plugin.common/`).
+
+### Convenience wrapper
+
+Script: `scripts/test-multi-plugin-persistent.ps1`
+
+```powershell
+# Start (keeps config between runs, refreshes plugin files)
+pwsh scripts/test-multi-plugin-persistent.ps1 -KeepRunning
+
+# Force rebuild both plugin zips first
+pwsh scripts/test-multi-plugin-persistent.ps1 -Rebuild -KeepRunning
+
+# Wipe persisted state and start fresh
+pwsh scripts/test-multi-plugin-persistent.ps1 -Clean -KeepRunning
+
+# Run a real Lidarr AlbumSearch using existing UI-configured indexers
+pwsh scripts/test-multi-plugin-persistent.ps1 -KeepRunning -RunSearchGate
+
+# Run search + grab (requires indexers + download clients already configured in UI)
+pwsh scripts/test-multi-plugin-persistent.ps1 -KeepRunning -RunGrabGate
+```
+
+## Running the Search gate against existing UI-configured indexers
+
+If you configured indexers via the Lidarr UI (persisted config), you can run the search gate without providing env vars by enabling:
+- `-UseExistingConfigForSearchGate`
+
+Example:
+
+```powershell
+pwsh scripts/multi-plugin-docker-smoke-test.ps1 `
+  -PluginZip @("qobuzarr=$q","tidalarr=$t") `
+  -ContainerName lidarr-multi-plugin-persist `
+  -Port 8691 `
+  -PreserveState -WorkRoot .persistent-multi -KeepRunning `
+  -RunSearchGate -UseExistingConfigForSearchGate
+```
+
+## Notes
+
+- If you see `Bind for 0.0.0.0:<port> failed: port is already allocated`, change `-Port` and/or `-ContainerName`.
+- Multi-plugin loading across independent plugin load contexts may still depend on upstream Lidarr fixes; `-HostOverrideAssembly` is intended for validating those before a new Docker tag exists.

--- a/scripts/test-multi-plugin-persistent.ps1
+++ b/scripts/test-multi-plugin-persistent.ps1
@@ -1,0 +1,172 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Persistent local Lidarr Docker runner for Qobuzarr + Tidalarr.
+
+.DESCRIPTION
+    Builds (optional), stages, and runs Lidarr with both Qobuzarr and Tidalarr plugins
+    while persisting /config and plugin installation between runs.
+
+    This is intended for iterative UI configuration (credentials, settings) and
+    repeatable validation without redoing setup each time.
+
+.PARAMETER Rebuild
+    Rebuild both plugins before starting.
+
+.PARAMETER RebuildQobuzarr
+    Rebuild Qobuzarr before starting.
+
+.PARAMETER RebuildTidalarr
+    Rebuild Tidalarr before starting.
+
+.PARAMETER Clean
+    Delete persistent state (config, plugins, downloads) and start fresh.
+
+.PARAMETER LidarrTag
+    Lidarr Docker tag. Default: pr-plugins-3.1.1.4884
+
+.PARAMETER Port
+    Host port to bind Lidarr to. Default: 8691
+
+.PARAMETER ContainerName
+    Docker container name. Default: lidarr-multi-plugin-persist
+
+.PARAMETER WorkRoot
+    Directory (relative to lidarr.plugin.common repo root) to persist state under.
+    Default: .persistent-multi
+
+.PARAMETER KeepRunning
+    Keep container running after the smoke test completes.
+#>
+param(
+    [switch]$Rebuild,
+    [switch]$RebuildQobuzarr,
+    [switch]$RebuildTidalarr,
+    [switch]$Clean,
+    [string]$LidarrTag = "pr-plugins-3.1.1.4884",
+    [int]$Port = 8691,
+    [string]$ContainerName = "lidarr-multi-plugin-persist",
+    [string]$WorkRoot = ".persistent-multi",
+    [switch]$KeepRunning,
+    [switch]$RunSearchGate,
+    [switch]$RunGrabGate,
+    [int]$SearchTimeoutSeconds = 180,
+    [string]$SearchArtistTerm = "Miles Davis",
+    [string]$SearchAlbumTitle = "Kind of Blue"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$commonRoot = Join-Path $repoRoot "lidarr.plugin.common"
+$qobuzarrRoot = Join-Path $repoRoot "qobuzarr"
+$tidalarrRoot = Join-Path $repoRoot "tidalarr"
+
+if (-not (Test-Path (Join-Path $qobuzarrRoot "Qobuzarr.csproj"))) {
+    throw "Qobuzarr repo not found at '$qobuzarrRoot'."
+}
+if (-not (Test-Path (Join-Path $tidalarrRoot "Tidalarr.sln"))) {
+    throw "Tidalarr repo not found at '$tidalarrRoot'."
+}
+
+function Find-LatestZip {
+    param([Parameter(Mandatory = $true)][string]$Directory)
+
+    if (-not (Test-Path $Directory)) { return $null }
+    return (Get-ChildItem -LiteralPath $Directory -Filter *.zip -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTimeUtc -Descending |
+            Select-Object -First 1)
+}
+
+if ($Rebuild) {
+    $RebuildQobuzarr = $true
+    $RebuildTidalarr = $true
+}
+
+if ($RebuildQobuzarr) {
+    Write-Host "Building Qobuzarr package..." -ForegroundColor Cyan
+    Push-Location $qobuzarrRoot
+    try {
+        Import-Module (Join-Path $commonRoot "tools/PluginPack.psm1") -Force
+        $null = New-PluginPackage -Csproj "Qobuzarr.csproj" -Manifest "plugin.json" -MergeAssemblies -Framework "net8.0" -Configuration Release
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if ($RebuildTidalarr) {
+    Write-Host "Building Tidalarr package..." -ForegroundColor Cyan
+    Push-Location $tidalarrRoot
+    try {
+        & pwsh -File ".\\build.ps1" -Package -Configuration Release | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "Tidalarr build.ps1 -Package failed." }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$qZip = Find-LatestZip -Directory (Join-Path $qobuzarrRoot "artifacts/packages")
+if (-not $qZip) { throw "No Qobuzarr package zip found under 'qobuzarr/artifacts/packages'." }
+
+$tZip = Find-LatestZip -Directory (Join-Path $tidalarrRoot "src/Tidalarr/artifacts/packages")
+if (-not $tZip) { throw "No Tidalarr package zip found under 'tidalarr/src/Tidalarr/artifacts/packages'." }
+
+$hostOverride = $null
+$upstreamHost = Join-Path $repoRoot "_upstream/Lidarr/_output/net8.0/Lidarr.Common.dll"
+if (Test-Path $upstreamHost) {
+    $hostOverride = (Resolve-Path $upstreamHost).Path
+}
+
+Write-Host "Qobuzarr zip: $($qZip.FullName)" -ForegroundColor Gray
+Write-Host "Tidalarr zip: $($tZip.FullName)" -ForegroundColor Gray
+if ($hostOverride) {
+    Write-Host "Host override: $hostOverride" -ForegroundColor Yellow
+}
+else {
+    Write-Host "Host override: (none) - multi-plugin load may depend on upstream host fixes." -ForegroundColor Yellow
+}
+
+$smokeScript = Join-Path $commonRoot "scripts/multi-plugin-docker-smoke-test.ps1"
+$params = @{
+    PluginZip = @("qobuzarr=$($qZip.FullName)", "tidalarr=$($tZip.FullName)")
+    LidarrTag = $LidarrTag
+    ContainerName = $ContainerName
+    Port = $Port
+    WorkRoot = $WorkRoot
+    PreserveState = $true
+}
+if ($Clean) { $params.CleanState = $true }
+if ($KeepRunning) { $params.KeepRunning = $true }
+if ($hostOverride) { $params.HostOverrideAssembly = @($hostOverride) }
+if ($RunSearchGate) {
+    $params.RunSearchGate = $true
+    $params.UseExistingConfigForSearchGate = $true
+    $params.SearchTimeoutSeconds = $SearchTimeoutSeconds
+    $params.SearchArtistTerm = $SearchArtistTerm
+    $params.SearchAlbumTitle = $SearchAlbumTitle
+}
+if ($RunGrabGate) {
+    $params.RunGrabGate = $true
+    $params.UseExistingConfigForSearchGate = $true
+    $params.UseExistingConfigForDownloadClientGate = $true
+    $params.UseExistingConfigForGrabGate = $true
+    $params.SearchTimeoutSeconds = $SearchTimeoutSeconds
+    $params.SearchArtistTerm = $SearchArtistTerm
+    $params.SearchAlbumTitle = $SearchAlbumTitle
+}
+
+Push-Location $commonRoot
+try {
+    & $smokeScript @params | Out-Host
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "" 
+Write-Host "Lidarr UI: http://localhost:$Port" -ForegroundColor Green
+Write-Host "Persisted state: $(Join-Path $commonRoot (Join-Path $WorkRoot $ContainerName))" -ForegroundColor Green

--- a/scripts/test-qobuzarr-persistent.ps1
+++ b/scripts/test-qobuzarr-persistent.ps1
@@ -1,0 +1,108 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Quick test script for Qobuzarr with persistent Lidarr config.
+
+.DESCRIPTION
+    Runs Lidarr with Qobuzarr plugin, preserving config between runs.
+    First run: Configure credentials in UI at http://localhost:8689
+    Subsequent runs: Config is preserved, just test.
+
+.PARAMETER Rebuild
+    Rebuild the plugin before starting.
+
+.PARAMETER Clean
+    Delete persistent config and start fresh.
+#>
+param(
+    [switch]$Rebuild,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$qobuzarrRoot = Join-Path $repoRoot "qobuzarr"
+$commonRoot = Join-Path $repoRoot "lidarr.plugin.common"
+
+# Persistent config directory
+$persistentConfig = Join-Path $commonRoot ".persistent-test-config"
+$configDir = Join-Path $persistentConfig "config"
+$pluginsDir = Join-Path $persistentConfig "plugins/RicherTunes/Qobuzarr"
+
+$containerName = "qobuzarr-test"
+$port = 8689
+
+if ($Clean) {
+    Write-Host "Cleaning persistent config..." -ForegroundColor Yellow
+    Remove-Item -Path $persistentConfig -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Create directories
+New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+New-Item -ItemType Directory -Path $pluginsDir -Force | Out-Null
+
+# Build plugin if requested or if it doesn't exist
+$zipPath = Join-Path $qobuzarrRoot "artifacts/packages/qobuzarr-0.1.0-dev-net8.0.zip"
+if ($Rebuild -or -not (Test-Path $zipPath)) {
+    Write-Host "Building Qobuzarr plugin..." -ForegroundColor Cyan
+    Push-Location $qobuzarrRoot
+    try {
+        Import-Module (Join-Path $commonRoot "tools/PluginPack.psm1") -Force
+        $zipPath = New-PluginPackage -Csproj "Qobuzarr.csproj" -Manifest "plugin.json" -MergeAssemblies -Framework "net8.0"
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+# Extract plugin
+Write-Host "Extracting plugin to persistent directory..." -ForegroundColor Cyan
+Remove-Item -Path (Join-Path $pluginsDir "*") -Recurse -Force -ErrorAction SilentlyContinue
+Expand-Archive -Path $zipPath -DestinationPath $pluginsDir -Force
+
+# Stop existing container
+docker stop $containerName 2>$null | Out-Null
+docker rm $containerName 2>$null | Out-Null
+
+# Start container with persistent config
+$configMount = $configDir.Replace('\', '/')
+$pluginsMount = (Split-Path $pluginsDir -Parent).Replace('\', '/')
+
+Write-Host "Starting Lidarr with persistent config..." -ForegroundColor Cyan
+docker run -d `
+    --name $containerName `
+    -p "${port}:8686" `
+    -v "${configMount}:/config" `
+    -v "${pluginsMount}:/config/plugins/RicherTunes" `
+    -e PUID=1000 `
+    -e PGID=1000 `
+    -e TZ=UTC `
+    "ghcr.io/hotio/lidarr:pr-plugins-3.1.1.4884"
+
+# Wait for startup
+Write-Host "Waiting for Lidarr to start..." -ForegroundColor Yellow
+$timeout = 60
+$start = Get-Date
+while (((Get-Date) - $start).TotalSeconds -lt $timeout) {
+    try {
+        $response = Invoke-WebRequest -Uri "http://localhost:$port/api/v1/system/status" -TimeoutSec 5 -ErrorAction SilentlyContinue
+        if ($response.StatusCode -eq 200) {
+            break
+        }
+    }
+    catch { }
+    Start-Sleep -Seconds 2
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Green
+Write-Host "Lidarr is running at: http://localhost:$port" -ForegroundColor Green
+Write-Host "Config persisted at: $configDir" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "First run: Configure Qobuz credentials in UI" -ForegroundColor Yellow
+Write-Host "Subsequent runs: Config is preserved!" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "To stop: docker stop $containerName" -ForegroundColor Cyan
+Write-Host "To view logs: docker logs -f $containerName" -ForegroundColor Cyan


### PR DESCRIPTION
Adds persistent local Docker runner scripts and docs for single- and multi-plugin testing (preserve /config between runs), plus harness options to reuse UI-configured indexers/download clients.\n\nKey files:\n- scripts/multi-plugin-docker-smoke-test.ps1\n- scripts/test-qobuzarr-persistent.ps1\n- scripts/test-multi-plugin-persistent.ps1\n- docs/PERSISTENT_E2E_TESTING.md\n\nMotivation: make Gates 1-3 repeatable locally while CI is blocked/billing and while upstream Lidarr multi-plugin load fixes are pending.