### PR TITLE
fix: harden download payload validation

### DIFF
--- a/src/Utilities/DownloadDiagnostics.cs
+++ b/src/Utilities/DownloadDiagnostics.cs
@@ -1,0 +1,136 @@
+using System;
+
+namespace Lidarr.Plugin.Common.Utilities
+{
+    /// <summary>
+    /// Helper utilities for download response diagnostics and error reporting.
+    /// Provides Content-Type sniffing, sensitive data redaction, and URL parsing.
+    /// </summary>
+    public static class DownloadDiagnostics
+    {
+        /// <summary>
+        /// Extracts the host from a URL for diagnostic messages.
+        /// Returns "unknown" if the URL is invalid.
+        /// </summary>
+        public static string TryGetHost(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return "unknown";
+            }
+
+            try
+            {
+                return new Uri(url).Host;
+            }
+            catch
+            {
+                return "unknown";
+            }
+        }
+
+        /// <summary>
+        /// Checks if a Content-Type header indicates text content (not audio).
+        /// </summary>
+        public static bool IsTextLikeContentType(string? contentType)
+        {
+            if (string.IsNullOrWhiteSpace(contentType))
+            {
+                return false;
+            }
+
+            return contentType.StartsWith("text/", StringComparison.OrdinalIgnoreCase) ||
+                   contentType.Contains("json", StringComparison.OrdinalIgnoreCase) ||
+                   contentType.Contains("xml", StringComparison.OrdinalIgnoreCase) ||
+                   contentType.Contains("html", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Checks if the payload looks like text content (HTML, JSON, XML).
+        /// Convenience overload for byte array + length (delegates to DownloadPayloadValidator).
+        /// </summary>
+        public static bool LooksLikeTextPayload(byte[] buffer, int length)
+        {
+            if (buffer == null || length <= 0)
+            {
+                return false;
+            }
+
+            return DownloadPayloadValidator.LooksLikeTextPayload(buffer.AsSpan(0, Math.Min(length, buffer.Length)));
+        }
+
+        /// <summary>
+        /// Checks if a Content-Type header indicates audio content.
+        /// </summary>
+        public static bool IsAudioContentType(string? contentType)
+        {
+            if (string.IsNullOrWhiteSpace(contentType))
+            {
+                return false;
+            }
+
+            return contentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) ||
+                   contentType.Contains("application/octet-stream", StringComparison.OrdinalIgnoreCase) ||
+                   contentType.Contains("application/x-flac", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines if a text snippet should be redacted from error messages
+        /// because it may contain sensitive information.
+        /// </summary>
+        public static bool ShouldRedactSnippet(string? snippet)
+        {
+            if (string.IsNullOrWhiteSpace(snippet))
+            {
+                return false;
+            }
+
+            // Check for common sensitive patterns
+            return snippet.Contains("http", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("token", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("password", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("secret", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("apikey", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("api_key", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("user_auth_token", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("app_secret", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("bearer", StringComparison.OrdinalIgnoreCase) ||
+                   snippet.Contains("authorization", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Creates a safe snippet preview from raw bytes for error messages.
+        /// Automatically redacts sensitive content.
+        /// </summary>
+        /// <param name="buffer">Buffer containing the first bytes of the download</param>
+        /// <param name="length">Number of bytes to consider</param>
+        /// <param name="maxLength">Maximum snippet length (default 512)</param>
+        /// <returns>Safe snippet for error messages, or "[redacted]" if sensitive</returns>
+        public static string CreateSafeSnippet(byte[] buffer, int length, int maxLength = 512)
+        {
+            if (buffer == null || length <= 0)
+            {
+                return "[empty]";
+            }
+
+            var actualLength = Math.Min(length, Math.Min(buffer.Length, maxLength));
+            var snippet = System.Text.Encoding.UTF8.GetString(buffer, 0, actualLength)
+                .Replace("\r", " ")
+                .Replace("\n", " ")
+                .Trim();
+
+            return ShouldRedactSnippet(snippet) ? "[redacted]" : snippet;
+        }
+
+        /// <summary>
+        /// Formats a download error message with diagnostic context.
+        /// </summary>
+        public static string FormatDownloadError(string message, string? url, string? contentType, long? contentLength)
+        {
+            var host = TryGetHost(url);
+            var ct = contentType ?? "unknown";
+            var cl = contentLength?.ToString() ?? "unknown";
+            return $"{message} (Host={host}, Content-Type={ct}, Content-Length={cl})";
+        }
+    }
+}

--- a/src/Utilities/DownloadPayloadValidator.cs
+++ b/src/Utilities/DownloadPayloadValidator.cs
@@ -1,0 +1,263 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Lidarr.Plugin.Common.Utilities
+{
+    /// <summary>
+    /// Validates download payloads to ensure they contain valid audio content.
+    /// Combines text/HTML detection with audio magic bytes validation.
+    /// </summary>
+    public static class DownloadPayloadValidator
+    {
+        // Audio format magic bytes
+        private static readonly byte[] FlacMagic = Encoding.ASCII.GetBytes("fLaC");
+        private static readonly byte[] OggMagic = Encoding.ASCII.GetBytes("OggS");
+        private static readonly byte[] RiffMagic = Encoding.ASCII.GetBytes("RIFF");
+        private static readonly byte[] Id3Magic = Encoding.ASCII.GetBytes("ID3");
+        private static readonly byte[] FtypMagic = Encoding.ASCII.GetBytes("ftyp");
+
+        /// <summary>
+        /// Validates a byte sample to ensure it looks like audio content.
+        /// Throws InvalidDataException if validation fails.
+        /// </summary>
+        /// <param name="sample">First bytes of the download payload</param>
+        /// <param name="fileExtension">Expected file extension (optional, e.g., "flac", ".mp3")</param>
+        /// <param name="mimeType">Content-Type from response headers (optional)</param>
+        public static void ValidateOrThrow(ReadOnlySpan<byte> sample, string? fileExtension = null, string? mimeType = null)
+        {
+            var ext = NormalizeExtension(fileExtension);
+            if (sample.IsEmpty)
+            {
+                if (ext is "m4a" or "mp4")
+                {
+                    const int minimumMp4HeaderLength = 8;
+                    throw new InvalidDataException(
+                        $"Insufficient header bytes for MP4/M4A signature (requires {minimumMp4HeaderLength} bytes, got {sample.Length}).");
+                }
+
+                throw new InvalidDataException("Downloaded stream contained no data.");
+            }
+
+            if (ext is "m4a" or "mp4")
+            {
+                // MP4/M4A signature validation requires the "ftyp" box at offset 4.
+                // If we don't have enough bytes, fail with a specific message to make diagnosis clear.
+                const int minimumMp4HeaderLength = 8;
+                if (sample.Length < minimumMp4HeaderLength)
+                {
+                    throw new InvalidDataException(
+                        $"Insufficient header bytes for MP4/M4A signature (requires {minimumMp4HeaderLength} bytes, got {sample.Length}).");
+                }
+            }
+
+            if (LooksLikeTextPayload(sample))
+            {
+                throw new InvalidDataException("Download returned non-audio content (HTML/JSON).");
+            }
+
+            if (!LooksLikeAudioPayload(sample, ext, mimeType))
+            {
+                throw new InvalidDataException("Download returned content that does not look like audio.");
+            }
+        }
+
+        /// <summary>
+        /// Validates a file on disk to ensure it contains valid audio content.
+        /// Throws InvalidOperationException if validation fails.
+        /// </summary>
+        /// <param name="filePath">Path to the file to validate</param>
+        public static void ValidateFileOrThrow(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("File path must not be empty.", nameof(filePath));
+            }
+
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException("File not found for validation.", filePath);
+            }
+
+            Span<byte> magicBytes = stackalloc byte[12];
+            int read;
+            using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                read = fs.Read(magicBytes);
+                if (read < 4)
+                {
+                    throw new InvalidOperationException($"File too small for magic validation: {Path.GetFileName(filePath)}");
+                }
+            }
+
+            var sample = magicBytes.Slice(0, read);
+            var ext = Path.GetExtension(filePath);
+
+            if (LooksLikeTextPayload(sample))
+            {
+                var hex = BitConverter.ToString(sample.ToArray());
+                var ascii = ToAsciiPreview(sample);
+                throw new InvalidOperationException($"File contains non-audio content '{hex}' ('{ascii}') for {Path.GetFileName(filePath)}");
+            }
+
+            if (!LooksLikeAudioPayload(sample, NormalizeExtension(ext), null))
+            {
+                var hex = BitConverter.ToString(sample.ToArray());
+                var ascii = ToAsciiPreview(sample);
+                throw new InvalidOperationException($"Invalid audio magic bytes '{hex}' ('{ascii}') for {Path.GetFileName(filePath)}");
+            }
+        }
+
+        /// <summary>
+        /// Checks if the payload looks like text content (HTML, JSON, XML).
+        /// </summary>
+        public static bool LooksLikeTextPayload(ReadOnlySpan<byte> sample)
+        {
+            if (sample.IsEmpty)
+            {
+                return false;
+            }
+
+            // Fast-path: skip UTF-8 BOM (EF BB BF) and leading whitespace
+            int index = 0;
+            if (sample.Length >= 3 && sample[0] == 0xEF && sample[1] == 0xBB && sample[2] == 0xBF)
+            {
+                index = 3;
+            }
+
+            while (index < sample.Length && sample[index] is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n')
+            {
+                index++;
+            }
+
+            if (index >= sample.Length)
+            {
+                return false;
+            }
+
+            var first = sample[index];
+            var max = Math.Min(sample.Length, 256);
+
+            // Heuristic: detect likely HTML/XML/JSON based on stronger evidence than the first byte alone.
+            if (first == (byte)'<')
+            {
+                var text = Encoding.UTF8.GetString(sample.Slice(index, max - index));
+                return text.StartsWith("<!doctype", StringComparison.OrdinalIgnoreCase)
+                       || text.StartsWith("<html", StringComparison.OrdinalIgnoreCase)
+                       || text.StartsWith("<script", StringComparison.OrdinalIgnoreCase)
+                       || text.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (first == (byte)'{')
+            {
+                // JSON object: { "key": ... } or {"key": ...}
+                int j = index + 1;
+                while (j < sample.Length && sample[j] is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n')
+                {
+                    j++;
+                }
+
+                return j < sample.Length && sample[j] == (byte)'"';
+            }
+
+            if (first == (byte)'[')
+            {
+                // JSON array: [ { ... } ] or [ "..." ] or []
+                int j = index + 1;
+                while (j < sample.Length && sample[j] is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n')
+                {
+                    j++;
+                }
+
+                if (j >= sample.Length)
+                {
+                    return false;
+                }
+
+                return sample[j] is (byte)'{' or (byte)'"' or (byte)']';
+            }
+
+            // Fallback: look for common HTML markers even if not first char
+            var fallbackText = Encoding.UTF8.GetString(sample.Slice(0, max));
+            return fallbackText.Contains("<!doctype", StringComparison.OrdinalIgnoreCase)
+                   || fallbackText.Contains("<html", StringComparison.OrdinalIgnoreCase)
+                   || fallbackText.Contains("<script", StringComparison.OrdinalIgnoreCase)
+                   || fallbackText.Contains("<?xml", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Checks if the payload looks like valid audio content.
+        /// </summary>
+        public static bool LooksLikeAudioPayload(ReadOnlySpan<byte> sample, string? normalizedExtension = null, string? mimeType = null)
+        {
+            if (sample.Length < 2)
+            {
+                return false;
+            }
+
+            // Check for known audio signatures
+            var hasFlac = HasMagic(sample, FlacMagic, 0);
+            var hasOgg = HasMagic(sample, OggMagic, 0);
+            var hasRiff = HasMagic(sample, RiffMagic, 0);
+            var hasId3 = HasMagic(sample, Id3Magic, 0);
+            var hasMpegSync = sample[0] == 0xFF && (sample[1] & 0xE0) == 0xE0;
+            var hasFtyp = HasMagic(sample, FtypMagic, 4); // ftyp appears at offset 4 in MP4/M4A
+
+            var hasAnyAudioSignature = hasFlac || hasOgg || hasRiff || hasId3 || hasMpegSync || hasFtyp;
+
+            if (string.IsNullOrEmpty(normalizedExtension))
+            {
+                return hasAnyAudioSignature;
+            }
+
+            // Extension-specific strictness
+            return normalizedExtension switch
+            {
+                "flac" => hasFlac,
+                "m4a" or "mp4" => hasFtyp,
+                "mp3" => hasId3 || hasMpegSync,
+                "ogg" or "oga" => hasOgg,
+                "wav" => hasRiff,
+                _ => hasAnyAudioSignature // Accept any recognized audio signature for unknown extensions
+            };
+        }
+
+        /// <summary>
+        /// Checks if the byte array contains valid audio magic bytes (for backward compatibility).
+        /// </summary>
+        public static bool IsValidAudioMagicBytes(ReadOnlySpan<byte> magicBytes)
+        {
+            return LooksLikeAudioPayload(magicBytes);
+        }
+
+        private static string NormalizeExtension(string? fileExtension)
+        {
+            if (string.IsNullOrWhiteSpace(fileExtension))
+            {
+                return string.Empty;
+            }
+
+            return fileExtension.Trim().TrimStart('.').ToLowerInvariant();
+        }
+
+        private static bool HasMagic(ReadOnlySpan<byte> sample, byte[] magic, int offset)
+        {
+            if (offset < 0 || sample.Length < offset + magic.Length)
+            {
+                return false;
+            }
+
+            return sample.Slice(offset, magic.Length).SequenceEqual(magic);
+        }
+
+        private static string ToAsciiPreview(ReadOnlySpan<byte> bytes)
+        {
+            var sb = new StringBuilder(bytes.Length);
+            foreach (var b in bytes)
+            {
+                sb.Append(b is >= 32 and <= 126 ? (char)b : '.');
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/DownloadPayloadValidatorTests.cs
+++ b/tests/DownloadPayloadValidatorTests.cs
@@ -1,0 +1,454 @@
+using System;
+using System.IO;
+using System.Text;
+using Lidarr.Plugin.Common.Utilities;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+public class DownloadPayloadValidatorTests
+{
+    // Magic byte constants for test clarity
+    private static readonly byte[] FlacMagic = Encoding.ASCII.GetBytes("fLaC");
+    private static readonly byte[] OggMagic = Encoding.ASCII.GetBytes("OggS");
+    private static readonly byte[] Id3Magic = Encoding.ASCII.GetBytes("ID3");
+    private static readonly byte[] RiffMagic = Encoding.ASCII.GetBytes("RIFF");
+
+    // ftyp appears at offset 4 in MP4/M4A: [4-byte size][ftyp][brand...]
+    private static byte[] CreateFtypHeader(int totalLength = 12)
+    {
+        if (totalLength <= 0) return Array.Empty<byte>();
+        var buffer = new byte[totalLength];
+        // Size field (first 4 bytes)
+        if (totalLength > 0) buffer[0] = 0x00;
+        if (totalLength > 1) buffer[1] = 0x00;
+        if (totalLength > 2) buffer[2] = 0x00;
+        if (totalLength > 3) buffer[3] = 0x14; // size = 20
+        // "ftyp" magic (bytes 4-7)
+        if (totalLength > 4) buffer[4] = (byte)'f';
+        if (totalLength > 5) buffer[5] = (byte)'t';
+        if (totalLength > 6) buffer[6] = (byte)'y';
+        if (totalLength > 7) buffer[7] = (byte)'p';
+        // Brand "M4A " (bytes 8-11)
+        if (totalLength > 8) buffer[8] = (byte)'M';
+        if (totalLength > 9) buffer[9] = (byte)'4';
+        if (totalLength > 10) buffer[10] = (byte)'A';
+        if (totalLength > 11) buffer[11] = (byte)' ';
+        return buffer;
+    }
+
+    #region Test 1: Short-buffer boundary cases (ftyp offset=4)
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    public void ValidateOrThrow_M4A_ShortBuffer_ThrowsWithSpecificMessage(int bufferLength)
+    {
+        // Arrange: Create a buffer that is too short to contain ftyp at offset 4
+        var buffer = bufferLength > 0 ? CreateFtypHeader(bufferLength) : Array.Empty<byte>();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidDataException>(() =>
+            DownloadPayloadValidator.ValidateOrThrow(buffer, ".m4a", "audio/mp4"));
+
+        // Should mention insufficient bytes or similar - not just generic message
+        Assert.True(
+            ex.Message.Contains("insufficient", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("too small", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("header", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("MP4", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("M4A", StringComparison.OrdinalIgnoreCase),
+            $"Expected specific error about insufficient header bytes for M4A, got: {ex.Message}");
+    }
+
+    [Fact]
+    public void ValidateOrThrow_M4A_ExactlyEightBytes_ValidFtyp_Passes()
+    {
+        // Arrange: Minimum valid ftyp header (8 bytes: 4-byte size + "ftyp")
+        var buffer = CreateFtypHeader(8);
+
+        // Act & Assert: Should not throw
+        DownloadPayloadValidator.ValidateOrThrow(buffer, ".m4a", "audio/mp4");
+    }
+
+    [Fact]
+    public void ValidateOrThrow_M4A_FullHeader_Passes()
+    {
+        // Arrange: Full valid ftyp header
+        var buffer = CreateFtypHeader(12);
+
+        // Act & Assert: Should not throw
+        DownloadPayloadValidator.ValidateOrThrow(buffer, ".m4a", "audio/mp4");
+    }
+
+    #endregion
+
+    #region Test 3: Extension vs magic mismatch contract
+
+    [Fact]
+    public void ValidateOrThrow_FtypHeader_FlacExtension_Throws()
+    {
+        // Arrange: ftyp header but .flac extension
+        var buffer = CreateFtypHeader(12);
+
+        // Act & Assert: Should throw - mismatch
+        Assert.Throws<InvalidDataException>(() =>
+            DownloadPayloadValidator.ValidateOrThrow(buffer, ".flac", "audio/flac"));
+    }
+
+    [Fact]
+    public void ValidateOrThrow_FlacHeader_M4aExtension_Throws()
+    {
+        // Arrange: FLAC header but .m4a extension
+        var buffer = new byte[64];
+        FlacMagic.CopyTo(buffer, 0);
+
+        // Act & Assert: Should throw - mismatch
+        Assert.Throws<InvalidDataException>(() =>
+            DownloadPayloadValidator.ValidateOrThrow(buffer, ".m4a", "audio/mp4"));
+    }
+
+    [Fact]
+    public void ValidateOrThrow_FlacHeader_UnknownExtension_Passes()
+    {
+        // Arrange: Valid FLAC header with unknown extension
+        var buffer = new byte[64];
+        FlacMagic.CopyTo(buffer, 0);
+
+        // Act & Assert: Should pass - unknown ext accepts any valid audio signature
+        DownloadPayloadValidator.ValidateOrThrow(buffer, ".xyz", null);
+    }
+
+    [Fact]
+    public void ValidateOrThrow_FlacHeader_NoExtension_Passes()
+    {
+        // Arrange: Valid FLAC header with no extension
+        var buffer = new byte[64];
+        FlacMagic.CopyTo(buffer, 0);
+
+        // Act & Assert: Should pass
+        DownloadPayloadValidator.ValidateOrThrow(buffer, null, null);
+    }
+
+    [Theory]
+    [InlineData(".flac")]
+    [InlineData("flac")]
+    [InlineData(".FLAC")]
+    [InlineData("FLAC")]
+    public void ValidateOrThrow_FlacHeader_VariousFlacExtensions_Passes(string extension)
+    {
+        // Arrange: Valid FLAC header with various extension formats
+        var buffer = new byte[64];
+        FlacMagic.CopyTo(buffer, 0);
+
+        // Act & Assert: Should pass - extension normalization handles dot and case
+        DownloadPayloadValidator.ValidateOrThrow(buffer, extension, "audio/flac");
+    }
+
+    [Theory]
+    [InlineData(".m4a")]
+    [InlineData("m4a")]
+    [InlineData(".mp4")]
+    [InlineData("mp4")]
+    [InlineData(".M4A")]
+    public void ValidateOrThrow_FtypHeader_VariousM4aExtensions_Passes(string extension)
+    {
+        // Arrange: Valid ftyp header with various extension formats
+        var buffer = CreateFtypHeader(12);
+
+        // Act & Assert: Should pass
+        DownloadPayloadValidator.ValidateOrThrow(buffer, extension, "audio/mp4");
+    }
+
+    #endregion
+
+    #region Test 4: ValidateFileOrThrow on partial/empty files
+
+    [Fact]
+    public void ValidateFileOrThrow_EmptyFile_Throws()
+    {
+        // Arrange
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, Array.Empty<byte>());
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                DownloadPayloadValidator.ValidateFileOrThrow(tempFile));
+            Assert.Contains("too small", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void ValidateFileOrThrow_TinyJunkFile_Throws(int size)
+    {
+        // Arrange
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var junk = new byte[size];
+            new Random(42).NextBytes(junk);
+            File.WriteAllBytes(tempFile, junk);
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                DownloadPayloadValidator.ValidateFileOrThrow(tempFile));
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ValidateFileOrThrow_ValidFlacHeaderOnly_Passes()
+    {
+        // Arrange: Just the FLAC magic bytes (structural sanity check, not completeness)
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, FlacMagic);
+
+            // Act & Assert: Should pass - header matches known container
+            DownloadPayloadValidator.ValidateFileOrThrow(tempFile);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ValidateFileOrThrow_ValidId3HeaderOnly_Passes()
+    {
+        // Arrange: Just the ID3 magic bytes
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var header = new byte[4];
+            Id3Magic.CopyTo(header, 0);
+            File.WriteAllBytes(tempFile, header);
+
+            // Act & Assert: Should pass
+            DownloadPayloadValidator.ValidateFileOrThrow(tempFile);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ValidateFileOrThrow_NonexistentFile_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<FileNotFoundException>(() =>
+            DownloadPayloadValidator.ValidateFileOrThrow("/nonexistent/path/file.flac"));
+    }
+
+    #endregion
+
+    #region Valid audio signature detection
+
+    [Fact]
+    public void LooksLikeAudioPayload_ValidFlac_ReturnsTrue()
+    {
+        var buffer = new byte[64];
+        FlacMagic.CopyTo(buffer, 0);
+        Assert.True(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeAudioPayload_ValidOgg_ReturnsTrue()
+    {
+        var buffer = new byte[64];
+        OggMagic.CopyTo(buffer, 0);
+        Assert.True(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeAudioPayload_ValidId3_ReturnsTrue()
+    {
+        var buffer = new byte[64];
+        Id3Magic.CopyTo(buffer, 0);
+        Assert.True(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeAudioPayload_ValidMpegSync_ReturnsTrue()
+    {
+        var buffer = new byte[] { 0xFF, 0xFB, 0x90, 0x00 }; // MP3 frame sync
+        Assert.True(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeAudioPayload_ValidRiff_ReturnsTrue()
+    {
+        var buffer = new byte[64];
+        RiffMagic.CopyTo(buffer, 0);
+        Assert.True(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeAudioPayload_ValidFtyp_ReturnsTrue()
+    {
+        var buffer = CreateFtypHeader(12);
+        Assert.True(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeAudioPayload_RandomJunk_ReturnsFalse()
+    {
+        var buffer = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+        Assert.False(DownloadPayloadValidator.LooksLikeAudioPayload(buffer));
+    }
+
+    #endregion
+
+    #region Test 2: False-positive text detection
+
+    [Fact]
+    public void LooksLikeTextPayload_ValidHtml_ReturnsTrue()
+    {
+        var html = Encoding.UTF8.GetBytes("<!DOCTYPE html><html><body>Error</body></html>");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(html));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_ValidJson_ReturnsTrue()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"error\": \"unauthorized\", \"code\": 401}");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(json));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_ValidJsonArray_ReturnsTrue()
+    {
+        var json = Encoding.UTF8.GetBytes("[{\"id\": 1}, {\"id\": 2}]");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(json));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_BinaryStartingWithOpenBrace_ShouldNotFalsePositive()
+    {
+        // Binary data that happens to start with '{' but is not JSON
+        // This is a key test - the eager check should NOT trigger here
+        var binary = new byte[] { (byte)'{', 0x00, 0x01, 0xFF, 0xFE, 0x89, 0x50, 0x4E };
+
+        // Current implementation is too eager - this test documents expected behavior
+        // After fix: should return false (binary, not real JSON)
+        // For now, this test will likely fail, showing the bug
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(binary));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_BinaryStartingWithLessThan_ShouldNotFalsePositive()
+    {
+        // Binary data that happens to start with '<' but is not HTML
+        var binary = new byte[] { (byte)'<', 0x00, 0xFF, 0xFE, 0x89, 0x50, 0x4E, 0x47 };
+
+        // After fix: should return false (binary, not real HTML)
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(binary));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_BinaryStartingWithBracket_ShouldNotFalsePositive()
+    {
+        // Binary data that happens to start with '[' but is not JSON array
+        var binary = new byte[] { (byte)'[', 0x00, 0xFF, 0xFE, 0x89, 0x50, 0x4E, 0x47 };
+
+        // After fix: should return false
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(binary));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_ValidFlacMagic_ReturnsFalse()
+    {
+        // FLAC magic bytes should not be detected as text
+        var buffer = new byte[64];
+        FlacMagic.CopyTo(buffer, 0);
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_ValidFtypMagic_ReturnsFalse()
+    {
+        // ftyp magic bytes should not be detected as text
+        var buffer = CreateFtypHeader(12);
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_EmptyBuffer_ReturnsFalse()
+    {
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_WhitespaceOnly_ReturnsFalse()
+    {
+        var whitespace = Encoding.UTF8.GetBytes("   \t\r\n   ");
+        Assert.False(DownloadPayloadValidator.LooksLikeTextPayload(whitespace));
+    }
+
+    #endregion
+
+    #region Test 5: BOM/whitespace prefix for text detection
+
+    [Fact]
+    public void LooksLikeTextPayload_HtmlWithUtf8Bom_ReturnsTrue()
+    {
+        // UTF-8 BOM: EF BB BF
+        var bom = new byte[] { 0xEF, 0xBB, 0xBF };
+        var html = Encoding.UTF8.GetBytes("<!DOCTYPE html>");
+        var buffer = new byte[bom.Length + html.Length];
+        bom.CopyTo(buffer, 0);
+        html.CopyTo(buffer, bom.Length);
+
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(buffer));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_JsonWithLeadingWhitespace_ReturnsTrue()
+    {
+        var json = Encoding.UTF8.GetBytes("  \n\t  {\"error\": \"test\"}");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(json));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_HtmlWithLeadingNewlines_ReturnsTrue()
+    {
+        var html = Encoding.UTF8.GetBytes("\r\n\r\n<!DOCTYPE html><html>");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(html));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_HtmlLowercase_ReturnsTrue()
+    {
+        var html = Encoding.UTF8.GetBytes("<html><head></head><body>Error page</body></html>");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(html));
+    }
+
+    [Fact]
+    public void LooksLikeTextPayload_ScriptTag_ReturnsTrue()
+    {
+        var html = Encoding.UTF8.GetBytes("<script>alert('error')</script>");
+        Assert.True(DownloadPayloadValidator.LooksLikeTextPayload(html));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Why
Qobuzarr/Tidalarr need a shared, strict-but-safe way to detect "HTML/JSON instead of audio" and validate container signatures (FLAC/MP3/OGG/WAV/MP4). New tests exposed two concrete issues:
- MP4/M4A short buffers (<8 bytes) should fail with a specific diagnostic message (ftyp offset=4 requirement).
- Text detection should not false-positive on arbitrary binary that starts with `<`, `{`, or `[`. 

## What
- Add `DownloadPayloadValidator` with stricter MP4/M4A short-buffer diagnostics and tightened `LooksLikeTextPayload` heuristics.
- Add `DownloadDiagnostics` helpers for Content-Type sniffing + safe snippet generation.
- Add `DownloadPayloadValidatorTests` covering short-buffer MP4/M4A, false-positive text detection, extension-vs-magic behavior, and file-based validation.

## Test
- `dotnet test -c Release -p:GeneratePackageOnBuild=false -p:UseSharedCompilation=false -p:BuildInParallel=false --nologo`
