### PR TITLE
fix(e2e): support token auth + robust Grab queue matching

### DIFF
--- a/scripts/e2e-runner.ps1
+++ b/scripts/e2e-runner.ps1
@@ -157,8 +157,15 @@ $pluginConfigs = @{
         # Search gate settings
         SearchQuery = "Kind of Blue Miles Davis"
         ExpectedMinResults = 1
-        CredentialAllOfFieldNames = @("password")
-        CredentialAnyOfFieldNames = @("email", "username")
+        # Qobuzarr supports two auth modes:
+        # 1. Email/Password: (email OR username) + password
+        # 2. Token: userId + authToken
+        CredentialAllOfFieldNames = @()
+        CredentialAnyOfFieldNames = @(
+            @("password", "email"),
+            @("password", "username"),
+            @("authToken", "userId")
+        )
         SkipIndexerTest = $false
     }
     'Tidalarr' = @{


### PR DESCRIPTION
- Qobuzarr credentials: support token mode (userId+authToken) as well as email/username+password; supports grouped any-of requirements.
- Grab gate: queue item lookup falls back to albumId+indexer+recency when downloadId is absent.
- Grab validation: ignores .partial files when counting/validating output.

Local: validated module import (Import-Module scripts/lib/e2e-gates.psm1)