### PR TITLE
docs: manual enforcement runbook + NuGet procedure

### DIFF
--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -1,6 +1,7 @@
 # Architecture Status — Bridge Runtime Migration
 
-**Status:** COMPLETE (frozen 2026-03-28)
+**Status:** Migration is complete and frozen at a documented baseline. Remaining work is operational enforcement.
+**Frozen at:** commit b73ccfe on main (2026-03-28)
 **Baseline:** Common v1.7.1, all plugins on SHA `aae92da`
 **Promotion matrix:** 107/107 green
 
@@ -54,6 +55,7 @@
 2. **No bridge surface expansion** until all existing contracts have full consumer coverage
 3. **Promotion matrix must pass** (107/107) before any Common release is promoted
 4. **Quarterly parity audit** required (next: 2026-06-28)
+5. **No release of Common or plugin bumps** without promotion matrix evidence attached
 
 ## Next Phase: Enforcement, Not Migration
 

--- a/docs/HOST_VERSION_UPGRADE_PLAYBOOK.md
+++ b/docs/HOST_VERSION_UPGRADE_PLAYBOOK.md
@@ -1,0 +1,30 @@
+# Host Version Upgrade Playbook
+
+## When to use
+When upgrading the Lidarr host target (e.g., pr-plugins-3.1.2.4913 → next version).
+
+## Steps
+
+1. **Update Common**
+   - Change DefaultHostVersion in PluginSandbox.cs
+   - Update ARCHITECTURE_STATUS.md baseline
+   - Update ECOSYSTEM_PROMOTION_CHECKLIST.md
+   - Tag patch release if needed
+
+2. **Update each plugin**
+   - CLAUDE.md Docker image references
+   - CI workflow Docker image tags
+   - verify-local.ps1 / build scripts
+   - DockerSmokeTests.cs image constant
+
+3. **Extract new host assemblies**
+   - `crane export ghcr.io/hotio/lidarr:<new-tag> /tmp/lidarr-image.tar`
+   - Extract DLLs, verify FV version, verify net8.0 target
+
+4. **Run promotion matrix**
+   - All 107 tests must pass against new host
+   - Docker smoke must pass (if host-bridge build available)
+
+5. **Freeze**
+   - Update ARCHITECTURE_STATUS.md with new baseline
+   - Bump all plugins to same Common tag

--- a/docs/MANUAL_ENFORCEMENT_RUNBOOK.md
+++ b/docs/MANUAL_ENFORCEMENT_RUNBOOK.md
@@ -1,0 +1,74 @@
+# Manual Enforcement Runbook
+
+**Use until:** CI billing is restored for Tidalarr, Qobuzarr, AppleMusicarr (issue #459)
+
+## Before merging ANY PR in billing-blocked repos
+
+### Required checks (run locally, paste output in PR)
+
+1. **Build**
+   ```bash
+   dotnet build -m:1
+   ```
+   Expected: 0 errors
+
+2. **Full test suite**
+   ```bash
+   dotnet test --blame-hang-timeout 30s -m:1
+   ```
+   Expected: 0 new failures, count matches baseline
+
+3. **Runtime sandbox**
+   ```bash
+   dotnet test --filter "Category=Runtime" --blame-hang-timeout 30s -m:1
+   ```
+   Expected: all pass (Tidalarr 10, Qobuzarr 11, AppleMusicarr 10)
+
+4. **No net6.0 regressions**
+   ```bash
+   grep -r "net6\.0" --include="*.csproj" --include="*.props" --include="*.ps1" --include="*.sh" --include="*.yml" . | grep -v ext/ | grep -v obj/ | grep -v .git/
+   ```
+   Expected: 0 matches (Common is allowed 2 in tooling)
+
+5. **Single IPlugin** (plugin repos only)
+   ```bash
+   grep -rn "class.*:.*IPlugin" src/ --include="*.cs" | grep -v "internal\|abstract\|//"
+   ```
+   Expected: exactly 1 match
+
+### If Common submodule changed
+
+6. **Common SHA is a tagged release**
+   ```bash
+   cd ext/Lidarr.Plugin.Common && git describe --tags --exact-match HEAD
+   ```
+   Expected: v1.7.x tag
+
+7. **Promotion matrix**
+   Run full matrix per `ext/Lidarr.Plugin.Common/docs/ECOSYSTEM_PROMOTION_CHECKLIST.md`
+
+### Evidence format
+Paste in PR comment:
+```
+Build: 0 errors
+Tests: XXX passed, X failed (pre-existing), X skipped
+Runtime: XX/XX pass
+net6.0: 0 matches
+IPlugin: 1 match
+```
+
+## Before promoting a Common release
+
+Run the full promotion matrix:
+```bash
+# Common compliance
+dotnet test tests/Lidarr.Plugin.Common.Tests.csproj --filter "FullyQualifiedName~Bridge|FullyQualifiedName~Compliance" --blame-hang-timeout 30s
+
+# Each plugin runtime
+for repo in tidalarr qobuzarr applemusicarr brainarr; do
+  echo "=== $repo ==="
+  cd /d/Alex/github/$repo
+  dotnet test --filter "Category=Runtime" --blame-hang-timeout 30s -m:1
+done
+```
+Expected: 107/107 (68 + 10 + 11 + 10 + 8)

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -70,6 +70,38 @@ Plugin repos should NOT bump Common for:
 - Documentation changes
 - Changes that don't affect the public API or testkit
 
+## NuGet Publishing Procedure
+
+### First-time setup
+1. Create NuGet.org account (or use existing)
+2. Generate API key:
+   - Name: `Lidarr.Plugin.Common GitHub Actions`
+   - Expiration: 365 days
+   - Glob: `Lidarr.Plugin.*`
+   - Scope: Push new packages and package versions
+3. Set org-level secret:
+   ```bash
+   gh secret set NUGET_API_KEY --repo RicherTunes/Lidarr.Plugin.Common
+   ```
+4. Verify: `gh secret list --repo RicherTunes/Lidarr.Plugin.Common`
+
+### Manual publish (for existing releases)
+```bash
+mkdir -p /tmp/nuget-publish && cd /tmp/nuget-publish
+gh release download v1.7.1 -p "*.nupkg" -R RicherTunes/Lidarr.Plugin.Common
+dotnet nuget push "Lidarr.Plugin.Abstractions.1.7.1.nupkg" --source https://api.nuget.org/v3/index.json --api-key YOUR_KEY --skip-duplicate
+dotnet nuget push "Lidarr.Plugin.Common.1.7.1.nupkg" --source https://api.nuget.org/v3/index.json --api-key YOUR_KEY --skip-duplicate
+rm -rf /tmp/nuget-publish
+```
+
+### Key rotation
+- Keys expire after 365 days
+- Rotation: generate new key on NuGet.org, update GitHub secret
+- If key holder unavailable: org admin generates new key via NuGet.org API Keys page
+
+### Automated publish (future releases)
+Once `NUGET_API_KEY` secret is set, the release workflow automatically publishes on tag push.
+
 ## Current Baseline
 
 - Common: v1.7.1 (2026-03-27)


### PR DESCRIPTION
## Summary
- Add `docs/MANUAL_ENFORCEMENT_RUNBOOK.md` with local verification checklist for billing-blocked repos (Tidalarr, Qobuzarr, AppleMusicarr) — covers build, test suite, runtime sandbox, net6.0 regression, IPlugin uniqueness, Common submodule checks, and evidence format for PR comments
- Add "NuGet Publishing Procedure" section to `docs/RELEASE_POLICY.md` covering first-time setup, manual publish for existing releases, key rotation, and automated publish path

## Test plan
- [ ] Verify MANUAL_ENFORCEMENT_RUNBOOK.md renders correctly on GitHub
- [ ] Verify RELEASE_POLICY.md NuGet section has correct commands
- [ ] Docs-only change — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)