### PR TITLE
fix(hosting+packaging): cross-ALC HttpClient metrics + Azure DataProtection

### DIFF
--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -142,10 +142,18 @@
     <None Include="..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\CHANGELOG.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <!-- Azure Key Vault integration for Data Protection -->
+  <!-- Azure Key Vault integration for Data Protection.
+       PrivateAssets="all" + ExcludeAssets="runtime" so the Azure assemblies are
+       AVAILABLE FOR BUILD (DataProtectionTokenProtector compiles, AKV-using tests
+       can resolve Azure types) but DON'T flow into consuming plugins' deps.json
+       or get copied into their bin/. AKV usage in production code is reflection-
+       based (see DataProtectionTokenProtector.TryConfigureAzureKeyVaultViaReflection)
+       so plugins that don't opt into AKV don't need to ship the Azure SDK
+       (~10 MB of dead weight; also breaks packaging closure when the merged
+       plugin DLL has a hard ref but the host doesn't ship Azure assemblies). -->
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <Target Name="PreparePublicApiBaselines"

--- a/src/Security/TokenProtection/DataProtectionTokenProtector.cs
+++ b/src/Security/TokenProtection/DataProtectionTokenProtector.cs
@@ -1,10 +1,15 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-#if NET8_0_OR_GREATER
-using Azure.Identity;
-#endif
+// NOTE: Do NOT add `using Azure.Identity;` or any Azure.* reference here.
+// The compile-time AssemblyRef would force every consuming plugin's merged DLL
+// to ship Azure.Identity + Azure.Extensions.AspNetCore.DataProtection.Keys
+// (transitively Azure.Core, Microsoft.Identity.Client, etc.) — ~10 MB of dead
+// weight when AKV isn't used (the default for every Lidarr plugin shipped today).
+// AKV setup below uses reflection so the assembly load is on-demand; without an
+// AKV key id the Azure assemblies are never resolved.
 using Lidarr.Plugin.Common.Interfaces;
 using Microsoft.AspNetCore.DataProtection;
 
@@ -60,14 +65,8 @@ namespace Lidarr.Plugin.Common.Security.TokenProtection
                 {
                     try
                     {
-#if NET8_0_OR_GREATER
                         var keyId = new Uri(akvKeyIdentifier);
-                        var cred = new DefaultAzureCredential();
-                        options.ProtectKeysWithAzureKeyVault(keyId, cred);
-                        akvConfigured = true;
-#else
-                        // AKV wrapping requires .NET 8+ in this library build; ignore on older TFMs
-#endif
+                        akvConfigured = TryConfigureAzureKeyVaultViaReflection(options, keyId);
                     }
                     catch
                     {
@@ -127,6 +126,54 @@ namespace Lidarr.Plugin.Common.Security.TokenProtection
             }
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             return Path.Combine(home, ".config", "lidarr.plugin.common", "keys");
+        }
+
+        /// <summary>
+        /// Configures `options.ProtectKeysWithAzureKeyVault(keyId, new DefaultAzureCredential())`
+        /// via reflection so the Azure.Identity / Azure.Extensions.AspNetCore.DataProtection.Keys
+        /// assemblies are only resolved when AKV is actually opted into. Without this indirection,
+        /// every consuming plugin's merged DLL has a hard AssemblyRef to Azure.Identity and ships
+        /// (or fails to load if stripped) ~10 MB of Azure SDK assemblies.
+        ///
+        /// Returns true when AKV configuration succeeded; false (without throwing) when the Azure
+        /// assemblies aren't on disk — the caller treats that as "AKV not available" and falls back
+        /// to the local DataProtection key store.
+        /// </summary>
+        private static bool TryConfigureAzureKeyVaultViaReflection(IDataProtectionBuilder options, Uri keyId)
+        {
+            // Resolve `Azure.Identity.DefaultAzureCredential`. Assembly load is on-demand and
+            // returns null cleanly when the DLL isn't present (rather than throwing FileNotFound).
+            var credentialType = Type.GetType("Azure.Identity.DefaultAzureCredential, Azure.Identity", throwOnError: false);
+            if (credentialType is null) return false;
+
+            // The extension method lives in Microsoft.AspNetCore.DataProtection.AzureKeyVault.AzureDataProtectionBuilderExtensions
+            // (shipped by Azure.Extensions.AspNetCore.DataProtection.Keys). Three overloads exist;
+            // we want the (IDataProtectionBuilder, Uri, TokenCredential) one. Bind by name +
+            // signature shape (parameter count + first parameter type) to be tolerant of refactors.
+            var extType = Type.GetType(
+                "Microsoft.AspNetCore.DataProtection.AzureKeyVault.AzureDataProtectionBuilderExtensions, Azure.Extensions.AspNetCore.DataProtection.Keys",
+                throwOnError: false);
+            if (extType is null) return false;
+
+            MethodInfo? extMethod = null;
+            foreach (var m in extType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (!string.Equals(m.Name, "ProtectKeysWithAzureKeyVault", StringComparison.Ordinal)) continue;
+                var ps = m.GetParameters();
+                if (ps.Length != 3) continue;
+                if (ps[0].ParameterType != typeof(IDataProtectionBuilder)) continue;
+                if (ps[1].ParameterType != typeof(Uri)) continue;
+                // Third parameter is Azure.Core.TokenCredential — match by name to avoid taking
+                // a hard dep on Azure.Core.dll just to grab the type.
+                if (ps[2].ParameterType.FullName != "Azure.Core.TokenCredential") continue;
+                extMethod = m;
+                break;
+            }
+            if (extMethod is null) return false;
+
+            var credential = Activator.CreateInstance(credentialType);
+            extMethod.Invoke(null, new object?[] { options, keyId, credential });
+            return true;
         }
     }
 }

--- a/src/Services/Registration/StreamingPluginModule.cs
+++ b/src/Services/Registration/StreamingPluginModule.cs
@@ -55,7 +55,35 @@ namespace Lidarr.Plugin.Common.Services.Registration
             var services = new ServiceCollection();
             ConfigureServices(services);
             configureServices?.Invoke(services);
+            SuppressHttpClientMetricsFilter(services);
             return services;
+        }
+
+        /// <summary>
+        /// Removes <c>Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter</c> from the
+        /// service collection. The filter is auto-registered by <c>AddHttpClient</c> via
+        /// <c>TryAddEnumerable</c> and calls <c>socketsHandler.MeterFactory ??= ...</c> on the
+        /// primary handler. After ILRepack internalizes M.E.Http into the merged plugin DLL and
+        /// the plugin loads in an isolated AssemblyLoadContext, the JIT lookup for
+        /// <c>SocketsHttpHandler.get_MeterFactory</c> throws MissingMethodException — the ALC's
+        /// System.Net.Http resolution path produces a metadata view in which that property
+        /// reference can't be bound, despite .NET 8 having the property on the BCL type.
+        /// We don't surface HttpClient metrics from plugins (Lidarr's host owns that telemetry),
+        /// so removing the filter is safe and keeps IHttpClientFactory's other functionality
+        /// (typed-client wiring, connection pooling, delegating-handler chains) intact.
+        /// Targets only the named filter type, so future Logging / PolicyHttpMessageHandler
+        /// filters added to M.E.Http are unaffected.
+        /// </summary>
+        private static void SuppressHttpClientMetricsFilter(IServiceCollection services)
+        {
+            for (int i = services.Count - 1; i >= 0; i--)
+            {
+                var implType = services[i].ImplementationType;
+                if (implType is not null && implType.FullName == "Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter")
+                {
+                    services.RemoveAt(i);
+                }
+            }
         }
 
         /// <summary>

--- a/tests/StreamingPluginModuleHttpClientFilterTests.cs
+++ b/tests/StreamingPluginModuleHttpClientFilterTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Net.Http;
 using Lidarr.Plugin.Abstractions.Capabilities;
 using Lidarr.Plugin.Common.Services.Registration;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/StreamingPluginModuleHttpClientFilterTests.cs
+++ b/tests/StreamingPluginModuleHttpClientFilterTests.cs
@@ -1,0 +1,52 @@
+using Lidarr.Plugin.Abstractions.Capabilities;
+using Lidarr.Plugin.Common.Services.Registration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+public class StreamingPluginModuleHttpClientFilterTests
+{
+    [Fact]
+    public void CreateServiceCollection_RemovesMetricsFactoryHttpMessageHandlerFilter()
+    {
+        // Regression guard: derived modules that call AddHttpClient must not leave the
+        // M.E.Http MetricsFactoryHttpMessageHandlerFilter in the service collection. The
+        // filter throws MissingMethodException for SocketsHttpHandler.get_MeterFactory at
+        // runtime in isolated plugin AssemblyLoadContexts (see SuppressHttpClientMetricsFilter
+        // doc-comment in StreamingPluginModule for the full backstory). The filter is
+        // auto-registered by AddHttpClient; the suppression in CreateServiceCollection runs
+        // after ConfigureServices and removes it.
+        ServiceCollection services = new ModuleThatCallsAddHttpClient().CreateServiceCollection();
+
+        bool filterPresent = services.Any(s =>
+            s.ImplementationType?.FullName == "Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter");
+
+        Assert.False(filterPresent,
+            "MetricsFactoryHttpMessageHandlerFilter must be suppressed by StreamingPluginModule.CreateServiceCollection. " +
+            "If this fails, SuppressHttpClientMetricsFilter was removed or stopped matching the filter type name.");
+    }
+
+    [Fact]
+    public void CreateServiceCollection_PreservesIHttpClientFactoryRegistration()
+    {
+        // The suppression must NOT remove anything else. IHttpClientFactory and the
+        // typed-client wiring registered by AddHttpClient must still be present so callers
+        // can resolve their HTTP clients normally.
+        ServiceCollection services = new ModuleThatCallsAddHttpClient().CreateServiceCollection();
+
+        Assert.Contains(services, s => s.ServiceType == typeof(IHttpClientFactory));
+    }
+
+    private sealed class ModuleThatCallsAddHttpClient : StreamingPluginModule
+    {
+        public override string ServiceName => "Test";
+        public override string Description => "Test module";
+        public override string Author => "Tests";
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHttpClient("named");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two related plugin-side ALC hardening fixes (re-opened from #482 on a clean base after PR #481 merged).

### 1. Suppress `MetricsFactoryHttpMessageHandlerFilter`
When a plugin module calls `services.AddHttpClient(...)`, M.E.Http auto-registers `MetricsFactoryHttpMessageHandlerFilter` via `TryAddEnumerable`. The filter calls `socketsHandler.MeterFactory ??= …` on the primary handler. After ILRepack internalizes M.E.Http into the merged plugin DLL and the plugin loads in an isolated `AssemblyLoadContext`, the JIT lookup for `SocketsHttpHandler.get_MeterFactory` throws `MissingMethodException`. Tidalarr CI red since 2026-03-28; cleared by the same fix at the plugin level (tidalarr `ce19eee`). Hoisted into Common's `CreateServiceCollection` so every derived plugin gets the protection automatically. Includes regression test.

### 2. Reflection-load Azure.Identity / Azure DataProtection.Keys
`DataProtectionTokenProtector` previously had a compile-time `using Azure.Identity;` and called `new DefaultAzureCredential()` + `options.ProtectKeysWithAzureKeyVault(...)` directly. That forced every consuming plugin's merged DLL to ship Azure.Identity + Azure.Extensions.AspNetCore.DataProtection.Keys (~10 MB of dead weight). Tidalarr Packaging Gates CI red on `Could not load Azure.Extensions.AspNetCore.DataProtection.Keys`. Refactor to reflection-based AKV setup; mark Azure NuGet refs `PrivateAssets="all"` + `ExcludeAssets="runtime"` so the assemblies are available for build but don't flow into consumers.

## Test plan

- [ ] Regression test `StreamingPluginModuleHttpClientFilterTests` is green
- [ ] CI green (build + test + format)
- [ ] After plugins bump submodule: tidalarr Packaging Gates Azure-load failure clears
- [ ] After plugins bump submodule: tidalarr `Plugin_CreateDownloadClientAsync_*` MissingMethodException is gone (already verified at plugin level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)