### PR TITLE
feat(test): runnable multi-plugin co-existence proof

### DIFF
--- a/.github/workflows/multi-plugin-coexistence-proof.yml
+++ b/.github/workflows/multi-plugin-coexistence-proof.yml
@@ -30,6 +30,13 @@ on:
       - 'src/**'
       - 'testkit/**'
       - '.github/workflows/multi-plugin-coexistence-proof.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/multi-plugin-coexistence-proof.ps1'
+      - 'src/**'
+      - 'testkit/**'
+      - '.github/workflows/multi-plugin-coexistence-proof.yml'
   schedule:
     - cron: '0 7 * * 1'  # Mondays 07:00 UTC
 

--- a/.github/workflows/multi-plugin-coexistence-proof.yml
+++ b/.github/workflows/multi-plugin-coexistence-proof.yml
@@ -56,37 +56,21 @@ jobs:
           path: lidarr.plugin.common
           submodules: false
 
-      - name: Checkout tidalarr
-        uses: actions/checkout@v4
-        with:
-          repository: RicherTunes/tidalarr
-          path: tidalarr
-          submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout qobuzarr
-        uses: actions/checkout@v4
-        with:
-          repository: RicherTunes/qobuzarr
-          path: qobuzarr
-          submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout brainarr
-        uses: actions/checkout@v4
-        with:
-          repository: RicherTunes/brainarr
-          path: brainarr
-          submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout applemusicarr
-        uses: actions/checkout@v4
-        with:
-          repository: RicherTunes/applemusicarr
-          path: applemusicarr
-          submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # Public-repo clones via direct git — the workflow's default GITHUB_TOKEN is
+      # scoped to the running repo only and gets 404 on cross-repo metadata lookups
+      # (the Lidarr.Plugin.Common-issued token is correctly NOT trusted by the
+      # tidalarr/qobuzarr/brainarr/applemusicarr repos). Bypass actions/checkout's
+      # token-based default-branch probe by cloning unauthenticated — these are
+      # public repos.
+      - name: Clone sibling plugin repos (unauth, public)
+        shell: bash
+        run: |
+          set -e
+          for repo in tidalarr qobuzarr brainarr applemusicarr; do
+            echo "[clone] $repo"
+            git clone --depth 1 --recurse-submodules --shallow-submodules \
+              "https://github.com/RicherTunes/$repo.git" "$repo"
+          done
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/multi-plugin-coexistence-proof.yml
+++ b/.github/workflows/multi-plugin-coexistence-proof.yml
@@ -1,0 +1,112 @@
+name: Multi-Plugin Coexistence Proof
+
+# Runnable proof that all 4 plugins (tidalarr / qobuzarr / brainarr / applemusicarr)
+# load simultaneously into one Lidarr container and each appears in its expected
+# /api/v1/{indexer,downloadclient,importlist}/schema endpoint.
+#
+# This is the CI version of scripts/multi-plugin-coexistence-proof.ps1. It uses
+# the default GITHUB_TOKEN to clone the public sibling repos — no CROSS_REPO_PAT
+# required (that secret is only needed by the credentials-driven workflow at
+# multi-plugin-smoke-test.yml for the "configure indexers and run search"
+# heavy gates).
+#
+# Triggers:
+#   - workflow_dispatch (manual run on-demand)
+#   - push to main (continuously verify nothing regresses)
+#   - schedule weekly (catches transient infra drift)
+
+on:
+  workflow_dispatch:
+    inputs:
+      lidarr_tag:
+        description: Lidarr Docker tag (plugins branch; net8 only)
+        type: string
+        required: false
+        default: pr-plugins-3.1.2.4913
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/multi-plugin-coexistence-proof.ps1'
+      - 'src/**'
+      - 'testkit/**'
+      - '.github/workflows/multi-plugin-coexistence-proof.yml'
+  schedule:
+    - cron: '0 7 * * 1'  # Mondays 07:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  prove:
+    name: Prove all 4 plugins co-exist
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout common
+        uses: actions/checkout@v4
+        with:
+          path: lidarr.plugin.common
+          submodules: false
+
+      - name: Checkout tidalarr
+        uses: actions/checkout@v4
+        with:
+          repository: RicherTunes/tidalarr
+          path: tidalarr
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout qobuzarr
+        uses: actions/checkout@v4
+        with:
+          repository: RicherTunes/qobuzarr
+          path: qobuzarr
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout brainarr
+        uses: actions/checkout@v4
+        with:
+          repository: RicherTunes/brainarr
+          path: brainarr
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout applemusicarr
+        uses: actions/checkout@v4
+        with:
+          repository: RicherTunes/applemusicarr
+          path: applemusicarr
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Extract Lidarr host assemblies (per plugin)
+        shell: bash
+        run: |
+          set -e
+          # Each plugin has its own extract-lidarr-assemblies.sh / equivalent.
+          # Run them in parallel so we don't pay 4× the docker pull cost.
+          for plugin in tidalarr qobuzarr brainarr applemusicarr; do
+            if [ -f "$plugin/scripts/extract-lidarr-assemblies.sh" ]; then
+              (cd "$plugin" && bash scripts/extract-lidarr-assemblies.sh) &
+            fi
+          done
+          wait
+
+      - name: Run multi-plugin co-existence proof
+        shell: pwsh
+        run: |
+          # PluginsDir = the workspace root where the 4 sibling repos were cloned
+          pwsh lidarr.plugin.common/scripts/multi-plugin-coexistence-proof.ps1 `
+            -PluginsDir . `
+            -LidarrTag ${{ inputs.lidarr_tag || 'pr-plugins-3.1.2.4913' }}
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs --tail 500 multi-plugin-coexistence || true

--- a/scripts/multi-plugin-coexistence-proof.ps1
+++ b/scripts/multi-plugin-coexistence-proof.ps1
@@ -1,0 +1,238 @@
+<#
+.SYNOPSIS
+  Proof harness for multi-plugin co-existence in a single Lidarr host.
+
+.DESCRIPTION
+  Mounts the merged plugin DLLs of tidalarr / qobuzarr / brainarr / applemusicarr
+  into ONE Lidarr container simultaneously, waits for the API to become healthy,
+  then asserts each plugin's expected entry appears in the corresponding schema
+  endpoint(s). Exits 0 on full success, non-zero on any failure with diagnostics
+  + container logs.
+
+  This is the directly-runnable version of the `Multi-Plugin Smoke Test`
+  GitHub workflow. Use it to verify locally that the fixes in PR #483
+  (HttpClient metrics-filter suppression, Azure reflection-loading) actually
+  unblock multi-plugin loading — independent of the upstream Lidarr ALC
+  lifecycle bug documented in docs/ECOSYSTEM_PARITY_ROADMAP.md.
+
+.PARAMETER PluginsDir
+  Parent directory containing tidalarr/, qobuzarr/, brainarr/, applemusicarr/
+  sibling repos. Defaults to the parent of this script's repo.
+
+.PARAMETER LidarrTag
+  Lidarr Docker image tag. Must be a .NET 8 plugins-branch build.
+
+.PARAMETER ContainerName
+  Container name. Default 'multi-plugin-coexistence'.
+
+.PARAMETER HostPort
+  Host port that Lidarr 8686 binds to. Default 8688 (avoids per-plugin
+  single-instance ports 8690-8692).
+
+.PARAMETER StartupTimeoutSeconds
+  Seconds to wait for Lidarr to become healthy after `docker run`.
+
+.PARAMETER SkipBuild
+  Don't rebuild plugin DLLs — assume they already exist at the expected paths.
+
+.EXAMPLE
+  pwsh scripts/multi-plugin-coexistence-proof.ps1
+  pwsh scripts/multi-plugin-coexistence-proof.ps1 -SkipBuild
+  pwsh scripts/multi-plugin-coexistence-proof.ps1 -LidarrTag pr-plugins-3.1.2.4913
+#>
+[CmdletBinding()]
+param(
+    [string]$PluginsDir,
+    [string]$LidarrTag = 'pr-plugins-3.1.2.4913',
+    [string]$ContainerName = 'multi-plugin-coexistence',
+    [int]$HostPort = 8688,
+    [int]$StartupTimeoutSeconds = 120,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# ── Resolve paths ───────────────────────────────────────────────────
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+if (-not $PluginsDir) { $PluginsDir = Split-Path -Parent $repoRoot }
+$PluginsDir = (Resolve-Path -LiteralPath $PluginsDir).Path
+
+# ── Plugin manifest ─────────────────────────────────────────────────
+# (Owner, RepoDir, MergedDllRelative, MountPath, ExpectedSchemaSubstring,
+#  Schemas[]) — Schemas is the list of /api/v1/{name}/schema endpoints the
+# plugin should appear in.
+$plugins = @(
+    @{
+        Repo = 'tidalarr'
+        Dll  = 'src/Tidalarr/bin/Lidarr.Plugin.Tidalarr.dll'
+        Mount = '/config/plugins/RicherTunes/Tidalarr'
+        Substring = 'Tidal'
+        Schemas = @('indexer', 'downloadclient')
+        BuildCmd = { param($d) dotnet build "$d/src/Tidalarr/Tidalarr.csproj" -c Release -m:1 }
+    },
+    @{
+        Repo = 'qobuzarr'
+        Dll  = 'bin/Lidarr.Plugin.Qobuzarr.dll'
+        Mount = '/config/plugins/RicherTunes/Qobuzarr'
+        Substring = 'Qobuz'
+        Schemas = @('indexer', 'downloadclient')
+        BuildCmd = { param($d) dotnet build "$d/Qobuzarr.csproj" -c Release -m:1 }
+    },
+    @{
+        Repo = 'brainarr'
+        Dll  = 'Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll'
+        Mount = '/config/plugins/RicherTunes/Brainarr'
+        Substring = 'Brainarr'
+        Schemas = @('importlist')
+        BuildCmd = { param($d) dotnet build "$d/Brainarr.Plugin/Brainarr.Plugin.csproj" -c Release -m:1 }
+    },
+    @{
+        Repo = 'applemusicarr'
+        Dll  = 'src/AppleMusicarr.Plugin/bin/AppleMusicarr.Plugin.dll'
+        Mount = '/config/plugins/RicherTunes/AppleMusicarr'
+        Substring = 'AppleMusic'
+        Schemas = @('indexer', 'downloadclient')
+        BuildCmd = { param($d) dotnet build "$d/src/AppleMusicarr.Plugin/AppleMusicarr.Plugin.csproj" -c Release -m:1 }
+    }
+)
+
+# ── Preflight ───────────────────────────────────────────────────────
+$missing = @()
+foreach ($p in $plugins) {
+    $repoPath = Join-Path $PluginsDir $p.Repo
+    if (-not (Test-Path $repoPath -PathType Container)) {
+        $missing += "$($p.Repo) (looked for $repoPath)"
+    }
+}
+if ($missing.Count -gt 0) {
+    Write-Error "Missing plugin repos:`n - $($missing -join "`n - ")"
+    exit 2
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "docker not on PATH"
+    exit 2
+}
+docker info 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker engine not running. Start Docker Desktop and retry."
+    exit 2
+}
+
+# ── Build plugins ───────────────────────────────────────────────────
+if (-not $SkipBuild) {
+    foreach ($p in $plugins) {
+        $repoPath = Join-Path $PluginsDir $p.Repo
+        Write-Host "[build] $($p.Repo)" -ForegroundColor Cyan
+        & $p.BuildCmd $repoPath
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Build failed for $($p.Repo)"
+            exit 3
+        }
+    }
+}
+
+# Verify all DLLs exist post-build
+$dllPaths = @{}
+foreach ($p in $plugins) {
+    $abs = Join-Path (Join-Path $PluginsDir $p.Repo) $p.Dll
+    if (-not (Test-Path -LiteralPath $abs)) {
+        Write-Error "Plugin DLL not found: $abs (build with -SkipBuild=`$false or build manually)"
+        exit 3
+    }
+    $dllPaths[$p.Repo] = (Resolve-Path -LiteralPath $abs).Path
+}
+
+# ── Tear down any prior container ──────────────────────────────────
+docker rm -f $ContainerName 2>&1 | Out-Null
+
+# ── Spin up Lidarr with ALL plugins mounted ────────────────────────
+$mountArgs = @()
+foreach ($p in $plugins) {
+    $pluginDir = Split-Path -Parent $dllPaths[$p.Repo]
+    # Quote both sides for paths with spaces; container path is fixed shape so no quote needed.
+    $mountArgs += "-v"
+    $mountArgs += "${pluginDir}:$($p.Mount):ro"
+}
+
+Write-Host "[docker] starting $ContainerName from ghcr.io/hotio/lidarr:$LidarrTag with $($plugins.Count) plugins mounted" -ForegroundColor Cyan
+$dockerArgs = @('run', '-d', '--name', $ContainerName, '-p', "${HostPort}:8686") + $mountArgs + @("ghcr.io/hotio/lidarr:$LidarrTag")
+& docker @dockerArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "docker run failed"
+    exit 4
+}
+
+try {
+    # ── Wait for Lidarr to become healthy ──────────────────────────
+    $baseUrl = "http://localhost:$HostPort"
+    Write-Host "[wait] Lidarr startup at $baseUrl (timeout ${StartupTimeoutSeconds}s)" -ForegroundColor Cyan
+    $deadline = (Get-Date).AddSeconds($StartupTimeoutSeconds)
+    $apiKey = $null
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $initJson = (docker exec $ContainerName cat /config/initialize.json 2>$null)
+            if ($LASTEXITCODE -eq 0 -and $initJson) {
+                $obj = $initJson | ConvertFrom-Json
+                if ($obj.PSObject.Properties['apiKey'] -and $obj.apiKey) {
+                    $apiKey = $obj.apiKey
+                    break
+                }
+            }
+        } catch { }
+        Start-Sleep -Seconds 2
+    }
+    if (-not $apiKey) {
+        Write-Error "Lidarr did not become healthy within ${StartupTimeoutSeconds}s"
+        Write-Host "==== Container logs ====" -ForegroundColor Yellow
+        docker logs $ContainerName | Out-Host
+        exit 5
+    }
+    Write-Host "[ok] Lidarr healthy; apiKey acquired" -ForegroundColor Green
+
+    # ── Assert each plugin appears in expected schema endpoints ────
+    $headers = @{ 'X-Api-Key' = $apiKey }
+    $failures = @()
+
+    foreach ($p in $plugins) {
+        foreach ($schema in $p.Schemas) {
+            $url = "$baseUrl/api/v1/$schema/schema"
+            try {
+                $body = Invoke-RestMethod -Uri $url -Headers $headers -TimeoutSec 10 -ErrorAction Stop
+            } catch {
+                $failures += "$($p.Repo) /$schema/schema fetch failed: $($_.Exception.Message)"
+                continue
+            }
+            $hits = @($body | Where-Object {
+                ($_.name -and ($_.name -like "*$($p.Substring)*")) -or
+                ($_.implementation -and ($_.implementation -like "*$($p.Substring)*"))
+            })
+            if ($hits.Count -gt 0) {
+                Write-Host "[ok] $($p.Repo) ✓ /api/v1/$schema/schema (matched '$($p.Substring)' in $($hits.Count) entries)" -ForegroundColor Green
+            } else {
+                $failures += "$($p.Repo) NOT FOUND in /api/v1/$schema/schema (looked for '$($p.Substring)')"
+            }
+        }
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Host ""
+        Write-Host "==== FAILURES ====" -ForegroundColor Red
+        foreach ($f in $failures) { Write-Host "  - $f" -ForegroundColor Red }
+        Write-Host ""
+        Write-Host "==== Container logs (last 200 lines) ====" -ForegroundColor Yellow
+        docker logs --tail 200 $ContainerName | Out-Host
+        exit 6
+    }
+
+    Write-Host ""
+    Write-Host "==== ALL $($plugins.Count) PLUGINS CO-EXIST CLEANLY ====" -ForegroundColor Green
+    Write-Host "Lidarr loaded each plugin without conflict." -ForegroundColor Green
+    exit 0
+}
+finally {
+    Write-Host ""
+    Write-Host "[cleanup] removing $ContainerName" -ForegroundColor DarkGray
+    docker rm -f $ContainerName 2>&1 | Out-Null
+}

--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -142,10 +142,18 @@
     <None Include="..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\CHANGELOG.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <!-- Azure Key Vault integration for Data Protection -->
+  <!-- Azure Key Vault integration for Data Protection.
+       PrivateAssets="all" + ExcludeAssets="runtime" so the Azure assemblies are
+       AVAILABLE FOR BUILD (DataProtectionTokenProtector compiles, AKV-using tests
+       can resolve Azure types) but DON'T flow into consuming plugins' deps.json
+       or get copied into their bin/. AKV usage in production code is reflection-
+       based (see DataProtectionTokenProtector.TryConfigureAzureKeyVaultViaReflection)
+       so plugins that don't opt into AKV don't need to ship the Azure SDK
+       (~10 MB of dead weight; also breaks packaging closure when the merged
+       plugin DLL has a hard ref but the host doesn't ship Azure assemblies). -->
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" />
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.1" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <Target Name="PreparePublicApiBaselines"

--- a/src/Security/TokenProtection/DataProtectionTokenProtector.cs
+++ b/src/Security/TokenProtection/DataProtectionTokenProtector.cs
@@ -1,10 +1,15 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-#if NET8_0_OR_GREATER
-using Azure.Identity;
-#endif
+// NOTE: Do NOT add `using Azure.Identity;` or any Azure.* reference here.
+// The compile-time AssemblyRef would force every consuming plugin's merged DLL
+// to ship Azure.Identity + Azure.Extensions.AspNetCore.DataProtection.Keys
+// (transitively Azure.Core, Microsoft.Identity.Client, etc.) — ~10 MB of dead
+// weight when AKV isn't used (the default for every Lidarr plugin shipped today).
+// AKV setup below uses reflection so the assembly load is on-demand; without an
+// AKV key id the Azure assemblies are never resolved.
 using Lidarr.Plugin.Common.Interfaces;
 using Microsoft.AspNetCore.DataProtection;
 
@@ -60,14 +65,8 @@ namespace Lidarr.Plugin.Common.Security.TokenProtection
                 {
                     try
                     {
-#if NET8_0_OR_GREATER
                         var keyId = new Uri(akvKeyIdentifier);
-                        var cred = new DefaultAzureCredential();
-                        options.ProtectKeysWithAzureKeyVault(keyId, cred);
-                        akvConfigured = true;
-#else
-                        // AKV wrapping requires .NET 8+ in this library build; ignore on older TFMs
-#endif
+                        akvConfigured = TryConfigureAzureKeyVaultViaReflection(options, keyId);
                     }
                     catch
                     {
@@ -127,6 +126,54 @@ namespace Lidarr.Plugin.Common.Security.TokenProtection
             }
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             return Path.Combine(home, ".config", "lidarr.plugin.common", "keys");
+        }
+
+        /// <summary>
+        /// Configures `options.ProtectKeysWithAzureKeyVault(keyId, new DefaultAzureCredential())`
+        /// via reflection so the Azure.Identity / Azure.Extensions.AspNetCore.DataProtection.Keys
+        /// assemblies are only resolved when AKV is actually opted into. Without this indirection,
+        /// every consuming plugin's merged DLL has a hard AssemblyRef to Azure.Identity and ships
+        /// (or fails to load if stripped) ~10 MB of Azure SDK assemblies.
+        ///
+        /// Returns true when AKV configuration succeeded; false (without throwing) when the Azure
+        /// assemblies aren't on disk — the caller treats that as "AKV not available" and falls back
+        /// to the local DataProtection key store.
+        /// </summary>
+        private static bool TryConfigureAzureKeyVaultViaReflection(IDataProtectionBuilder options, Uri keyId)
+        {
+            // Resolve `Azure.Identity.DefaultAzureCredential`. Assembly load is on-demand and
+            // returns null cleanly when the DLL isn't present (rather than throwing FileNotFound).
+            var credentialType = Type.GetType("Azure.Identity.DefaultAzureCredential, Azure.Identity", throwOnError: false);
+            if (credentialType is null) return false;
+
+            // The extension method lives in Microsoft.AspNetCore.DataProtection.AzureKeyVault.AzureDataProtectionBuilderExtensions
+            // (shipped by Azure.Extensions.AspNetCore.DataProtection.Keys). Three overloads exist;
+            // we want the (IDataProtectionBuilder, Uri, TokenCredential) one. Bind by name +
+            // signature shape (parameter count + first parameter type) to be tolerant of refactors.
+            var extType = Type.GetType(
+                "Microsoft.AspNetCore.DataProtection.AzureKeyVault.AzureDataProtectionBuilderExtensions, Azure.Extensions.AspNetCore.DataProtection.Keys",
+                throwOnError: false);
+            if (extType is null) return false;
+
+            MethodInfo? extMethod = null;
+            foreach (var m in extType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (!string.Equals(m.Name, "ProtectKeysWithAzureKeyVault", StringComparison.Ordinal)) continue;
+                var ps = m.GetParameters();
+                if (ps.Length != 3) continue;
+                if (ps[0].ParameterType != typeof(IDataProtectionBuilder)) continue;
+                if (ps[1].ParameterType != typeof(Uri)) continue;
+                // Third parameter is Azure.Core.TokenCredential — match by name to avoid taking
+                // a hard dep on Azure.Core.dll just to grab the type.
+                if (ps[2].ParameterType.FullName != "Azure.Core.TokenCredential") continue;
+                extMethod = m;
+                break;
+            }
+            if (extMethod is null) return false;
+
+            var credential = Activator.CreateInstance(credentialType);
+            extMethod.Invoke(null, new object?[] { options, keyId, credential });
+            return true;
         }
     }
 }

--- a/src/Services/Registration/StreamingPluginModule.cs
+++ b/src/Services/Registration/StreamingPluginModule.cs
@@ -55,7 +55,35 @@ namespace Lidarr.Plugin.Common.Services.Registration
             var services = new ServiceCollection();
             ConfigureServices(services);
             configureServices?.Invoke(services);
+            SuppressHttpClientMetricsFilter(services);
             return services;
+        }
+
+        /// <summary>
+        /// Removes <c>Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter</c> from the
+        /// service collection. The filter is auto-registered by <c>AddHttpClient</c> via
+        /// <c>TryAddEnumerable</c> and calls <c>socketsHandler.MeterFactory ??= ...</c> on the
+        /// primary handler. After ILRepack internalizes M.E.Http into the merged plugin DLL and
+        /// the plugin loads in an isolated AssemblyLoadContext, the JIT lookup for
+        /// <c>SocketsHttpHandler.get_MeterFactory</c> throws MissingMethodException — the ALC's
+        /// System.Net.Http resolution path produces a metadata view in which that property
+        /// reference can't be bound, despite .NET 8 having the property on the BCL type.
+        /// We don't surface HttpClient metrics from plugins (Lidarr's host owns that telemetry),
+        /// so removing the filter is safe and keeps IHttpClientFactory's other functionality
+        /// (typed-client wiring, connection pooling, delegating-handler chains) intact.
+        /// Targets only the named filter type, so future Logging / PolicyHttpMessageHandler
+        /// filters added to M.E.Http are unaffected.
+        /// </summary>
+        private static void SuppressHttpClientMetricsFilter(IServiceCollection services)
+        {
+            for (int i = services.Count - 1; i >= 0; i--)
+            {
+                var implType = services[i].ImplementationType;
+                if (implType is not null && implType.FullName == "Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter")
+                {
+                    services.RemoveAt(i);
+                }
+            }
         }
 
         /// <summary>

--- a/tests/StreamingPluginModuleHttpClientFilterTests.cs
+++ b/tests/StreamingPluginModuleHttpClientFilterTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Net.Http;
 using Lidarr.Plugin.Abstractions.Capabilities;
 using Lidarr.Plugin.Common.Services.Registration;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/StreamingPluginModuleHttpClientFilterTests.cs
+++ b/tests/StreamingPluginModuleHttpClientFilterTests.cs
@@ -1,0 +1,52 @@
+using Lidarr.Plugin.Abstractions.Capabilities;
+using Lidarr.Plugin.Common.Services.Registration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+public class StreamingPluginModuleHttpClientFilterTests
+{
+    [Fact]
+    public void CreateServiceCollection_RemovesMetricsFactoryHttpMessageHandlerFilter()
+    {
+        // Regression guard: derived modules that call AddHttpClient must not leave the
+        // M.E.Http MetricsFactoryHttpMessageHandlerFilter in the service collection. The
+        // filter throws MissingMethodException for SocketsHttpHandler.get_MeterFactory at
+        // runtime in isolated plugin AssemblyLoadContexts (see SuppressHttpClientMetricsFilter
+        // doc-comment in StreamingPluginModule for the full backstory). The filter is
+        // auto-registered by AddHttpClient; the suppression in CreateServiceCollection runs
+        // after ConfigureServices and removes it.
+        ServiceCollection services = new ModuleThatCallsAddHttpClient().CreateServiceCollection();
+
+        bool filterPresent = services.Any(s =>
+            s.ImplementationType?.FullName == "Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter");
+
+        Assert.False(filterPresent,
+            "MetricsFactoryHttpMessageHandlerFilter must be suppressed by StreamingPluginModule.CreateServiceCollection. " +
+            "If this fails, SuppressHttpClientMetricsFilter was removed or stopped matching the filter type name.");
+    }
+
+    [Fact]
+    public void CreateServiceCollection_PreservesIHttpClientFactoryRegistration()
+    {
+        // The suppression must NOT remove anything else. IHttpClientFactory and the
+        // typed-client wiring registered by AddHttpClient must still be present so callers
+        // can resolve their HTTP clients normally.
+        ServiceCollection services = new ModuleThatCallsAddHttpClient().CreateServiceCollection();
+
+        Assert.Contains(services, s => s.ServiceType == typeof(IHttpClientFactory));
+    }
+
+    private sealed class ModuleThatCallsAddHttpClient : StreamingPluginModule
+    {
+        public override string ServiceName => "Test";
+        public override string Description => "Test module";
+        public override string Author => "Tests";
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHttpClient("named");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Mounts the merged DLLs of all 4 plugins (tidalarr / qobuzarr / brainarr / applemusicarr) into ONE Lidarr container, waits for the API to become healthy, then asserts each plugin's expected entry appears in its corresponding `/api/v1/{indexer,downloadclient,importlist}/schema` endpoint.

## Why

Direct answer to: "does multi-plugin co-existence work after the cross-ALC fixes in PR #483?" — separate from the upstream Lidarr ALC lifecycle bug documented in `docs/ECOSYSTEM_PARITY_ROADMAP.md` (the workaround for which has been "use single-plugin instances").

**Hypothesis:** PR #483's HttpClient metrics-filter suppression and Azure reflection-loading addressed two symptoms of plugin loading failures that may have manifested differently in single- vs multi-plugin runs. If true, this proof goes green and the upstream-bug workaround can relax to "single-plugin instances recommended for E2E test isolation, not for production reliability."

If it stays red, we know the upstream bug has separate causes beyond the metrics-filter / Azure issues — useful signal either way.

## What's in this PR

- `scripts/multi-plugin-coexistence-proof.ps1` — runnable local harness
- `.github/workflows/multi-plugin-coexistence-proof.yml` — CI version (uses default `GITHUB_TOKEN`, no `CROSS_REPO_PAT` needed since this only checks schema presence, not credentials-driven indexer/download gates)

Triggers on push-to-main, weekly schedule, and manual dispatch.

## Test plan

- [ ] CI run on this PR shows whether all 4 plugins co-exist or which fail
- [ ] If proof passes: docs/ECOSYSTEM_PARITY_ROADMAP.md gets updated to reflect the new state
- [ ] Local: `pwsh scripts/multi-plugin-coexistence-proof.ps1` works on a dev machine with Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)