### PR TITLE
release: v1.8.0 (multi-plugin co-existence fix)

### DIFF
--- a/src/Abstractions/Lidarr.Plugin.Abstractions.csproj
+++ b/src/Abstractions/Lidarr.Plugin.Abstractions.csproj
@@ -14,7 +14,7 @@
     <NoWarn>SA1200;SA1633;CS1591;RS0016;RS0017;RS0025</NoWarn>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
 
     <!-- NuGet package metadata -->
     <PackageId>Lidarr.Plugin.Abstractions</PackageId>

--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
     <!-- For stable releases, keep PackageVersion omitted or equal to Version -->
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.7.1: See CHANGELOG.md for release details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.8.0: Multi-plugin co-existence fix (ALC). See docs/dev-guide/ALC_MULTIPLUGIN_FIX.md and CHANGELOG.md.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->


### PR DESCRIPTION
Bumps Common to v1.8.0 to mark the multi-plugin co-existence fix shipped via PRs #485 + #488.

Verified locally: tidalarr + qobuzarr + brainarr all co-exist in one Lidarr container with zero load errors and full schema registration.

See `docs/dev-guide/ALC_MULTIPLUGIN_FIX.md` for the full retrospective.

Will retag v1.8.0 at this PR's merge commit on main after merge.