### PR TITLE
cleanup: drop cargo-cult catches around type-safe TryGetValue

### DIFF
--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
     <!-- For stable releases, keep PackageVersion omitted or equal to Version -->
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.7.1: See CHANGELOG.md for release details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.8.0: Multi-plugin co-existence fix (ALC). See docs/dev-guide/ALC_MULTIPLUGIN_FIX.md and CHANGELOG.md.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->

--- a/src/Utilities/HttpClientExtensions.cs
+++ b/src/Utilities/HttpClientExtensions.cs
@@ -1113,30 +1113,14 @@ namespace Lidarr.Plugin.Common.Utilities
             string canonical = string.Empty;
             string scope = string.Empty;
 
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.EndpointKey, out string? ep) && ep != null)
-                    endpoint = ep;
-            }
-            catch { }
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ProfileKey, out string? pr) && pr != null)
-                    profile = pr;
-            }
-            catch { }
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ParametersKey, out string? ca) && ca != null)
-                    canonical = ca;
-            }
-            catch { }
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.AuthScopeKey, out string? sc) && sc != null)
-                    scope = sc;
-            }
-            catch { }
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.EndpointKey, out string? ep) && ep != null)
+                endpoint = ep;
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ProfileKey, out string? pr) && pr != null)
+                profile = pr;
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ParametersKey, out string? ca) && ca != null)
+                canonical = ca;
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.AuthScopeKey, out string? sc) && sc != null)
+                scope = sc;
 
             var parts = new[] { method, authority, endpoint, canonical, scope, profile };
             return HashingUtility.ComputeSHA256(string.Join("\n", parts));


### PR DESCRIPTION
## Summary
Removes four consecutive \`try { … } catch { }\` wrappers around \`HttpRequestOptions.TryGetValue\` calls in the request-signing helper.

## Why
The keys (\`EndpointKey\`, \`ProfileKey\`, \`ParametersKey\`, \`AuthScopeKey\`) are all \`HttpRequestOptionsKey<string>\` — type-safe at compile time. \`TryGetValue\` returns \`false\` on a missing key; there is no exception path the catches could meaningfully cover.

The result is 16 net lines removed, restored diagnostic surface (if the framework ever does throw here, we want to know rather than silently producing a wrong cache key), and zero behavioral change.

## Audit trail
Found by the 2026-05-10 dead-wire / dead-defense audit (HIGH item in common's leg). Sibling cleanups this week:

- tidalarr [PR #276](https://github.com/RicherTunes/tidalarr/pull/276) — orphan NRS + interface-correct rate-limit handler.
- qobuzarr [PR #261](https://github.com/RicherTunes/qobuzarr/pull/261) — \`AdaptiveQobuzApiClient\` deletion (424 lines).
- brainarr [PR #561](https://github.com/RicherTunes/brainarr/pull/561) — \`EnhancedRateLimiter\` deletion (1648 lines).

## Test plan
- [x] \`src/Lidarr.Plugin.Common.csproj\` builds clean.
- [ ] CI: full build + tests + downstream consumer probes.