### PR TITLE
cleanup: remove StreamingIndexerMixin.ApplyRateLimitAsync (deadlock-prone, zero callers)

### DIFF
--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
     <!-- For stable releases, keep PackageVersion omitted or equal to Version -->
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.7.1: See CHANGELOG.md for release details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.8.0: Multi-plugin co-existence fix (ALC). See docs/dev-guide/ALC_MULTIPLUGIN_FIX.md and CHANGELOG.md.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->

--- a/src/Services/Http/RateLimitHeaderUtilities.cs
+++ b/src/Services/Http/RateLimitHeaderUtilities.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Lidarr.Plugin.Common.Services.Http
+{
+    /// <summary>
+    /// Utilities for parsing HTTP rate-limit-related headers, and for deriving
+    /// stable endpoint keys used by <see cref="Performance.IUniversalAdaptiveRateLimiter"/>.
+    ///
+    /// Centralises logic that was previously duplicated across plugin-specific
+    /// DelegatingHandlers (tidalarr's <c>TidalRateLimitingHandler</c> and qobuzarr's
+    /// <c>QobuzRateLimitingHandler</c>).
+    /// </summary>
+    public static class RateLimitHeaderUtilities
+    {
+        /// <summary>
+        /// Resolve a <see cref="RetryConditionHeaderValue"/> (the <c>Retry-After</c> header)
+        /// to a positive <see cref="TimeSpan"/> delay, or <see cref="TimeSpan.Zero"/> when
+        /// the header is absent or describes a time already in the past.
+        ///
+        /// Behaviour mirrors what tidalarr and qobuzarr both implemented inline:
+        /// - Prefer the delta-seconds form if present.
+        /// - Otherwise interpret the HTTP-date form as "wait until that absolute UTC time".
+        /// - Past dates and missing values both return <see cref="TimeSpan.Zero"/> so callers
+        ///   can treat "no wait" uniformly.
+        /// </summary>
+        /// <param name="retryAfter">The header value parsed by <see cref="HttpResponseMessage.Headers"/>.</param>
+        /// <returns>A non-negative delay; <see cref="TimeSpan.Zero"/> when no wait is implied.</returns>
+        public static TimeSpan ResolveRetryAfter(RetryConditionHeaderValue? retryAfter)
+        {
+            if (retryAfter is null) return TimeSpan.Zero;
+            if (retryAfter.Delta is { } delta) return delta > TimeSpan.Zero ? delta : TimeSpan.Zero;
+            if (retryAfter.Date is { } date)
+            {
+                TimeSpan untilDate = date - DateTimeOffset.UtcNow;
+                return untilDate > TimeSpan.Zero ? untilDate : TimeSpan.Zero;
+            }
+            return TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// Convenience overload that pulls the <c>Retry-After</c> header off a response
+        /// and resolves it in one step. Returns <see cref="TimeSpan.Zero"/> when the
+        /// response is null or carries no <c>Retry-After</c> header.
+        /// </summary>
+        public static TimeSpan ResolveRetryAfter(HttpResponseMessage? response)
+        {
+            if (response is null) return TimeSpan.Zero;
+            return ResolveRetryAfter(response.Headers.RetryAfter);
+        }
+
+        /// <summary>
+        /// Build a rate-limiter endpoint key from a request URI using host + first path
+        /// segment. This balances specificity (distinct API surfaces get independent
+        /// budgets) against cardinality (a per-item URL doesn't produce a unique bucket
+        /// per request).
+        ///
+        /// Examples:
+        /// <list type="bullet">
+        ///   <item><c>https://api.tidal.com/v1/search?q=foo</c> → <c>api.tidal.com:v1</c></item>
+        ///   <item><c>https://sp-ap-eu.audio.tidal.com/.../seg.mp4</c> → <c>sp-ap-eu.audio.tidal.com:</c></item>
+        ///   <item><c>https://www.qobuz.com/api.json/0.2/album/get</c> → <c>www.qobuz.com:api.json</c></item>
+        /// </list>
+        /// </summary>
+        /// <param name="request">The outgoing HTTP request.</param>
+        /// <param name="unknownKey">Key to return when the request URI is null.</param>
+        /// <returns>A stable per-endpoint key suitable for keying a rate limiter.</returns>
+        public static string BuildHostFirstSegmentKey(HttpRequestMessage request, string unknownKey = "unknown")
+        {
+            if (request is null) throw new ArgumentNullException(nameof(request));
+            return BuildHostFirstSegmentKey(request.RequestUri, unknownKey);
+        }
+
+        /// <summary>
+        /// Build a rate-limiter endpoint key from a URI using host + first path segment.
+        /// See <see cref="BuildHostFirstSegmentKey(HttpRequestMessage, string)"/> for examples.
+        /// </summary>
+        public static string BuildHostFirstSegmentKey(Uri? uri, string unknownKey = "unknown")
+        {
+            if (uri is null) return unknownKey;
+            string host = uri.Host;
+            string firstSeg = uri.Segments.Length > 1 ? uri.Segments[1].TrimEnd('/') : string.Empty;
+            return host + ":" + firstSeg;
+        }
+    }
+}

--- a/src/Services/StreamingPluginMixins.cs
+++ b/src/Services/StreamingPluginMixins.cs
@@ -17,8 +17,6 @@ namespace Lidarr.Plugin.Common.Services
     {
         private readonly string _serviceName;
         private readonly StreamingCacheHelper _cache;
-        private readonly object _rateLimitLock = new object();
-        private DateTime _lastRequestTime = DateTime.MinValue;
 
         public StreamingIndexerMixin(string serviceName, StreamingCacheHelper cache = null)
         {
@@ -26,31 +24,13 @@ namespace Lidarr.Plugin.Common.Services
             _cache = cache;
         }
 
-        /// <summary>
-        /// Applies rate limiting using shared patterns.
-        /// Call this before making API requests.
-        /// </summary>
-        public async Task ApplyRateLimitAsync(int requestsPerMinute)
-        {
-            if (requestsPerMinute <= 0) return;
-
-            await Task.Run(() =>
-            {
-                lock (_rateLimitLock)
-                {
-                    var timeSinceLastRequest = DateTime.UtcNow - _lastRequestTime;
-                    var minInterval = TimeSpan.FromMinutes(1.0 / requestsPerMinute);
-
-                    if (timeSinceLastRequest < minInterval)
-                    {
-                        var waitTime = minInterval - timeSinceLastRequest;
-                        Task.Delay(waitTime).Wait();
-                    }
-
-                    _lastRequestTime = DateTime.UtcNow;
-                }
-            });
-        }
+        // Note: a per-instance ApplyRateLimitAsync helper was removed (2026-05-10).
+        // It had zero callers ecosystem-wide and used a Task.Run+lock+.Wait pattern
+        // that defeats async on the thread-pool. Plugins that need rate limiting
+        // should resolve IUniversalAdaptiveRateLimiter from DI (see common's
+        // Services.Performance) — it provides per-service/per-endpoint budgets,
+        // adaptive backoff, and Retry-After handling, none of which a per-mixin
+        // last-request-stamp helper could match.
 
         /// <summary>
         /// Gets cached search results if available.

--- a/tests/RateLimitHeaderUtilitiesTests.cs
+++ b/tests/RateLimitHeaderUtilitiesTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Lidarr.Plugin.Common.Services.Http;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    public class RateLimitHeaderUtilitiesTests
+    {
+        [Fact]
+        public void ResolveRetryAfter_NullHeader_ReturnsZero()
+        {
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter((RetryConditionHeaderValue?)null));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_DeltaForm_ReturnsDelta()
+        {
+            var header = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+            Assert.Equal(TimeSpan.FromSeconds(30), RateLimitHeaderUtilities.ResolveRetryAfter(header));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_NegativeDelta_ClampedToZero()
+        {
+            // RetryConditionHeaderValue itself rejects negative deltas via its constructor,
+            // but we still verify the utility's contract for "past dates" via the date form.
+            var pastDate = DateTimeOffset.UtcNow.AddMinutes(-5);
+            var header = new RetryConditionHeaderValue(pastDate);
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter(header));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_FutureDate_ReturnsPositiveDelay()
+        {
+            var futureDate = DateTimeOffset.UtcNow.AddSeconds(45);
+            var header = new RetryConditionHeaderValue(futureDate);
+            var delay = RateLimitHeaderUtilities.ResolveRetryAfter(header);
+            Assert.InRange(delay.TotalSeconds, 30, 60);
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_ResponseOverload_HandlesMissingHeader()
+        {
+            using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter(response));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_ResponseOverload_NullResponse_ReturnsZero()
+        {
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter((HttpResponseMessage?)null));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_TidalSearch_ReturnsApiPlusV1()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "https://api.tidal.com/v1/search?q=foo");
+            Assert.Equal("api.tidal.com:v1", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_QobuzApiJson_ReturnsApiJsonSegment()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "https://www.qobuz.com/api.json/0.2/album/get");
+            Assert.Equal("www.qobuz.com:api.json", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_HostOnly_ReturnsEmptyFirstSegment()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
+            Assert.Equal("example.com:", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_NullUri_ReturnsUnknownKey()
+        {
+            using var req = new HttpRequestMessage();
+            Assert.Equal("unknown", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_CustomUnknownKey_Honored()
+        {
+            Assert.Equal("anonymous", RateLimitHeaderUtilities.BuildHostFirstSegmentKey((Uri?)null, "anonymous"));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_NullRequest_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => RateLimitHeaderUtilities.BuildHostFirstSegmentKey((HttpRequestMessage)null!));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Deletes \`StreamingIndexerMixin.ApplyRateLimitAsync\` — a 16-line async method with a triple-bad concurrency pattern and zero callers anywhere in the ecosystem.

## The anti-pattern
\`\`\`csharp
await Task.Run(() =>
{
    lock (_rateLimitLock)
    {
        ...
        Task.Delay(waitTime).Wait();   // blocking wait inside lock inside Task.Run
        ...
    }
});
\`\`\`

What this gets wrong:
1. \`.Wait()\` on \`Task.Delay\` **inside a lock** blocks a thread-pool thread for the delay duration AND holds a lock the entire time. Concurrent callers serialise on the lock, each one blocking another thread-pool thread synchronously.
2. The \`Task.Run\` wrapper exists to "make sync work look async" but the lambda still blocks (\`.Wait()\`) — it just shifts the blocking from the caller's thread to a thread-pool thread. Under thread-pool starvation this deadlocks.
3. No \`CancellationToken\` parameter — non-cancellable.

## Why deletion (not rewrite)
Searched the entire ecosystem (common src + tests + all 4 plugins) for callers: **zero**. The method was registered API surface but nothing depended on it. Rewriting to \`await Task.Delay(waitTime, ct)\` would still be inferior to common's \`IUniversalAdaptiveRateLimiter\` (per-endpoint adaptive budgets, Retry-After handling, observability) — the canonical primitive consumer plugins now use.

## Comment left in place
A short comment is left where the method used to be, pointing future contributors at \`IUniversalAdaptiveRateLimiter\` so this dead-but-tempting API doesn't get re-added.

## Audit trail
Found by the 2026-05-10 defect-hunt audit (HIGH item in common's leg). Sibling cleanups this week: [common #491](https://github.com/RicherTunes/Lidarr.Plugin.Common/pull/491) (cargo-cult catches), [common #492](https://github.com/RicherTunes/Lidarr.Plugin.Common/pull/492) (lifted Retry-After + endpoint-key utilities).

## Test plan
- [x] \`src/Lidarr.Plugin.Common.csproj\` builds clean (0 errors, 0 warnings).
- [ ] CI: full build + tests + downstream consumer probes.