### PR TITLE
feat(lyrics): LrclibClient — public LRCLIB API for synced-lyrics fallback (TDD)

### DIFF
--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
     <!-- For stable releases, keep PackageVersion omitted or equal to Version -->
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.7.1: See CHANGELOG.md for release details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.8.0: Multi-plugin co-existence fix (ALC). See docs/dev-guide/ALC_MULTIPLUGIN_FIX.md and CHANGELOG.md.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->

--- a/src/Services/Lyrics/LrclibClient.cs
+++ b/src/Services/Lyrics/LrclibClient.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace Lidarr.Plugin.Common.Services.Lyrics
+{
+    /// <summary>
+    /// Minimal client for the LRCLIB public lyrics API (https://lrclib.net/api).
+    ///
+    /// Plugins call <see cref="TryFetchSyncedLyricsAsync"/> as a fallback when
+    /// their streaming-service's own lyrics endpoint returns nothing. The client
+    /// intentionally has no caching, no retries beyond the underlying HttpClient,
+    /// and no rate-limit gating because callers already wire those into their
+    /// own pipelines.
+    ///
+    /// All failure modes (404, 5xx, network, malformed JSON, empty
+    /// <c>syncedLyrics</c>) collapse to <c>null</c>. Lyrics are a nice-to-have —
+    /// a fall-through failure here must never break a download.
+    /// </summary>
+    public sealed class LrclibClient : IDisposable
+    {
+        private const string BaseUrl = "https://lrclib.net/api/get";
+        private const string DefaultUserAgent = "Lidarr.Plugin.Common.LrclibClient";
+
+        private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+        private readonly HttpClient _httpClient;
+        private readonly bool _ownsHttpClient;
+        private bool _disposed;
+
+        /// <summary>
+        /// Construct with an injected HttpClient. The caller retains ownership.
+        /// Useful when the consumer wants the client to participate in its
+        /// HttpClientFactory / handler-chain plumbing.
+        /// </summary>
+        public LrclibClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _ownsHttpClient = false;
+            EnsureUserAgent(_httpClient);
+        }
+
+        /// <summary>
+        /// Construct with an internally owned HttpClient. Convenient for one-shot
+        /// use; consumers running a long-lived plugin should prefer the injected
+        /// overload so connection pooling is shared.
+        /// </summary>
+        public LrclibClient()
+        {
+            _httpClient = new HttpClient();
+            _ownsHttpClient = true;
+            EnsureUserAgent(_httpClient);
+        }
+
+        /// <summary>
+        /// Look up a track's synced lyrics. Returns the LRC body on success, or
+        /// <c>null</c> when LRCLIB doesn't have the track or when any error is
+        /// encountered. Cancellation is propagated as
+        /// <see cref="OperationCanceledException"/>.
+        /// </summary>
+        /// <param name="artistName">Primary artist name; required (non-empty).</param>
+        /// <param name="trackName">Track title; required (non-empty).</param>
+        /// <param name="albumName">Album name; may be empty (LRCLIB tolerates it).</param>
+        /// <param name="durationSeconds">Track duration in seconds; must be &gt;= 0.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public async Task<string?> TryFetchSyncedLyricsAsync(
+            string artistName,
+            string trackName,
+            string albumName,
+            int durationSeconds,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(artistName)) throw new ArgumentException("Artist name is required.", nameof(artistName));
+            if (string.IsNullOrWhiteSpace(trackName)) throw new ArgumentException("Track name is required.", nameof(trackName));
+            if (durationSeconds < 0) throw new ArgumentOutOfRangeException(nameof(durationSeconds), durationSeconds, "Duration must be >= 0.");
+
+            var uri = BuildUri(artistName, trackName, albumName ?? string.Empty, durationSeconds);
+
+            try
+            {
+                using var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (response.StatusCode == HttpStatusCode.NotFound) return null;
+                if (!response.IsSuccessStatusCode) return null;
+
+                var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                LrclibResponse? parsed;
+                try
+                {
+                    parsed = JsonSerializer.Deserialize<LrclibResponse>(body, JsonOptions);
+                }
+                catch (JsonException)
+                {
+                    return null;
+                }
+
+                var lrc = parsed?.SyncedLyrics;
+                return string.IsNullOrWhiteSpace(lrc) ? null : lrc;
+            }
+            catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // SendAsync timeout (not user cancellation). Treat as a miss.
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (HttpRequestException)
+            {
+                return null;
+            }
+        }
+
+        private static Uri BuildUri(string artist, string track, string album, int durationSeconds)
+        {
+            // Build with HttpUtility.ParseQueryString so reserved chars are
+            // escaped properly and we don't accidentally inject extra params via
+            // a stray '&' or '/' in user metadata.
+            var query = HttpUtility.ParseQueryString(string.Empty);
+            query["artist_name"] = artist;
+            query["track_name"] = track;
+            query["album_name"] = album;
+            query["duration"] = durationSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            var builder = new UriBuilder(BaseUrl) { Query = query.ToString() ?? string.Empty };
+            return builder.Uri;
+        }
+
+        private static void EnsureUserAgent(HttpClient client)
+        {
+            if (client.DefaultRequestHeaders.UserAgent.Count == 0)
+            {
+                var asmVersion = typeof(LrclibClient).Assembly.GetName().Version?.ToString() ?? "unknown";
+                client.DefaultRequestHeaders.UserAgent.Add(
+                    new ProductInfoHeaderValue(DefaultUserAgent, asmVersion));
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            if (_ownsHttpClient)
+            {
+                _httpClient.Dispose();
+            }
+        }
+
+        private sealed class LrclibResponse
+        {
+            [JsonPropertyName("syncedLyrics")]
+            public string? SyncedLyrics { get; init; }
+
+            // The API also returns plainLyrics, trackName, etc. — not needed here.
+        }
+    }
+}

--- a/tests/LrclibClientTests.cs
+++ b/tests/LrclibClientTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Services.Lyrics;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+/// <summary>
+/// LrclibClient calls https://lrclib.net/api/get with track metadata and returns
+/// the synced-lyrics body when available. Plugins can use it as a fallback when
+/// their primary streaming-service lyrics endpoint returns nothing (Tidal,
+/// Apple Music). The client is intentionally minimal — no caching, no retries
+/// beyond the underlying HttpClient's, no rate-limit gating — because callers
+/// already have those in their own pipelines.
+///
+/// "Not found" is a normal case (LRCLIB doesn't cover every track), so it
+/// surfaces as <c>null</c> rather than an exception. Other failure modes
+/// (5xx, network, malformed JSON) also collapse to <c>null</c> because lyrics
+/// are a nice-to-have — a fall-through failure must never break a download.
+/// </summary>
+public sealed class LrclibClientTests
+{
+    private static HttpClient StubClient(StubHandler handler) => new(handler);
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_FoundTrack_ReturnsLrcBody()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK,
+            json: "{\"id\":1,\"trackName\":\"Test\",\"syncedLyrics\":\"[00:00.00] Hello\\n[00:01.00] World\"}");
+        using var client = new LrclibClient(StubClient(handler));
+
+        var lrc = await client.TryFetchSyncedLyricsAsync(
+            artistName: "Test Artist",
+            trackName: "Test Track",
+            albumName: "Test Album",
+            durationSeconds: 180);
+
+        Assert.Equal("[00:00.00] Hello\n[00:01.00] World", lrc);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_404_ReturnsNull()
+    {
+        var handler = new StubHandler(HttpStatusCode.NotFound);
+        using var client = new LrclibClient(StubClient(handler));
+
+        var lrc = await client.TryFetchSyncedLyricsAsync("Artist", "Track", "Album", 120);
+
+        Assert.Null(lrc);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_ServerError_ReturnsNull()
+    {
+        // 5xx from LRCLIB shouldn't escape — lyrics are best-effort.
+        var handler = new StubHandler(HttpStatusCode.InternalServerError);
+        using var client = new LrclibClient(StubClient(handler));
+
+        var lrc = await client.TryFetchSyncedLyricsAsync("Artist", "Track", "Album", 120);
+
+        Assert.Null(lrc);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_NetworkError_ReturnsNull()
+    {
+        // Underlying SendAsync throws (DNS failure, connection refused, etc.).
+        var handler = new StubHandler(throwOnSend: new HttpRequestException("DNS down"));
+        using var client = new LrclibClient(StubClient(handler));
+
+        var lrc = await client.TryFetchSyncedLyricsAsync("Artist", "Track", "Album", 120);
+
+        Assert.Null(lrc);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_MalformedJson_ReturnsNull()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, json: "not valid json");
+        using var client = new LrclibClient(StubClient(handler));
+
+        var lrc = await client.TryFetchSyncedLyricsAsync("Artist", "Track", "Album", 120);
+
+        Assert.Null(lrc);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_EmptySyncedLyrics_ReturnsNull()
+    {
+        // LRCLIB can return a record with only plain lyrics (no syncedLyrics).
+        // Empty syncedLyrics is treated the same as missing — null.
+        var handler = new StubHandler(HttpStatusCode.OK,
+            json: "{\"id\":1,\"trackName\":\"Test\",\"syncedLyrics\":\"\"}");
+        using var client = new LrclibClient(StubClient(handler));
+
+        var lrc = await client.TryFetchSyncedLyricsAsync("Artist", "Track", "Album", 120);
+
+        Assert.Null(lrc);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_QueryParameters_FormattedCorrectly()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK,
+            json: "{\"id\":1,\"trackName\":\"x\",\"syncedLyrics\":\"[00:00.00] y\"}");
+        using var client = new LrclibClient(StubClient(handler));
+
+        await client.TryFetchSyncedLyricsAsync(
+            artistName: "Pink Floyd",
+            trackName: "Money",
+            albumName: "The Dark Side of the Moon",
+            durationSeconds: 382);
+
+        Assert.NotNull(handler.LastRequestUri);
+        var uri = handler.LastRequestUri!;
+        Assert.Equal("lrclib.net", uri.Host);
+        Assert.Equal("/api/get", uri.AbsolutePath);
+        Assert.Contains("artist_name=Pink+Floyd", uri.Query);
+        Assert.Contains("track_name=Money", uri.Query);
+        Assert.Contains("album_name=The+Dark+Side+of+the+Moon", uri.Query);
+        Assert.Contains("duration=382", uri.Query);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_AmbiguousCharsInMetadata_EscapedNotInjected()
+    {
+        // Defensive against weird track names. The client must not let user-controlled
+        // metadata break the URL or produce duplicate query params.
+        var handler = new StubHandler(HttpStatusCode.NotFound);
+        using var client = new LrclibClient(StubClient(handler));
+
+        await client.TryFetchSyncedLyricsAsync(
+            artistName: "AC/DC",
+            trackName: "T.N.T.",
+            albumName: "High Voltage & Beyond",
+            durationSeconds: 200);
+
+        var uri = handler.LastRequestUri!;
+        // & in album must be encoded, NOT bleed into a separate query parameter.
+        Assert.Contains("album_name=High+Voltage+%26+Beyond", uri.Query, StringComparison.OrdinalIgnoreCase);
+        // / in artist must be encoded. (%2F / %2f vary by URI implementation; case-insensitive.)
+        Assert.Contains("artist_name=AC%2FDC", uri.Query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_NullArtist_Throws()
+    {
+        using var client = new LrclibClient(StubClient(new StubHandler(HttpStatusCode.OK)));
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            client.TryFetchSyncedLyricsAsync(null!, "track", "album", 100));
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_NullTrack_Throws()
+    {
+        using var client = new LrclibClient(StubClient(new StubHandler(HttpStatusCode.OK)));
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            client.TryFetchSyncedLyricsAsync("artist", null!, "album", 100));
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_EmptyAlbum_AllowedAsOptionalField()
+    {
+        // LRCLIB tolerates a missing album_name (the field is helpful but not required).
+        // The client should pass through empty string without throwing.
+        var handler = new StubHandler(HttpStatusCode.NotFound);
+        using var client = new LrclibClient(StubClient(handler));
+
+        await client.TryFetchSyncedLyricsAsync("artist", "track", albumName: "", durationSeconds: 100);
+
+        Assert.NotNull(handler.LastRequestUri);
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_NegativeDuration_Throws()
+    {
+        using var client = new LrclibClient(StubClient(new StubHandler(HttpStatusCode.OK)));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.TryFetchSyncedLyricsAsync("artist", "track", "album", durationSeconds: -1));
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_CancellationRequested_PropagatesOperationCanceled()
+    {
+        // The handler waits indefinitely; cancellation must abort the call.
+        var handler = new StubHandler(HttpStatusCode.OK, blockUntilCancelled: true);
+        using var client = new LrclibClient(StubClient(handler));
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.TryFetchSyncedLyricsAsync("artist", "track", "album", 100, cts.Token));
+    }
+
+    [Fact]
+    public async Task TryFetchSyncedLyricsAsync_UserAgent_IdentifiesPluginEcosystem()
+    {
+        // Public services like LRCLIB appreciate a recognisable User-Agent so they
+        // can rate-limit or contact the owning project if something goes wrong.
+        // The client must SET a User-Agent; the consumer plugin can override it
+        // later if it wants a per-plugin identity.
+        var handler = new StubHandler(HttpStatusCode.NotFound);
+        using var client = new LrclibClient(StubClient(handler));
+
+        await client.TryFetchSyncedLyricsAsync("artist", "track", "album", 100);
+
+        Assert.NotNull(handler.LastRequestHeaders);
+        var userAgents = handler.LastRequestHeaders!.UserAgent;
+        Assert.NotEmpty(userAgents);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string? _json;
+        private readonly Exception? _throwOnSend;
+        private readonly bool _blockUntilCancelled;
+
+        public Uri? LastRequestUri { get; private set; }
+        public System.Net.Http.Headers.HttpRequestHeaders? LastRequestHeaders { get; private set; }
+
+        public StubHandler(
+            HttpStatusCode status = HttpStatusCode.OK,
+            string? json = null,
+            Exception? throwOnSend = null,
+            bool blockUntilCancelled = false)
+        {
+            _status = status;
+            _json = json;
+            _throwOnSend = throwOnSend;
+            _blockUntilCancelled = blockUntilCancelled;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            LastRequestHeaders = request.Headers;
+
+            if (_throwOnSend is not null) throw _throwOnSend;
+
+            if (_blockUntilCancelled)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(60), cancellationToken).ConfigureAwait(false);
+            }
+
+            return new HttpResponseMessage(_status)
+            {
+                Content = _json is not null
+                    ? new StringContent(_json, Encoding.UTF8, "application/json")
+                    : new StringContent(string.Empty)
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Several plugins (tidalarr, applemusicarr) advertise a "Save Synced Lyrics" / "Use LRCLIB" setting in their UI but neither has any lyrics code path — the features are disclosed as "informational" because no implementation exists. This PR adds a reusable LRCLIB client to common so consumer plugins can wire lyrics fallback in a few lines.

\`\`\`csharp
using var lrc = new LrclibClient();
string? body = await lrc.TryFetchSyncedLyricsAsync(
    artistName: "Pink Floyd",
    trackName: "Money",
    albumName: "The Dark Side of the Moon",
    durationSeconds: 382,
    cancellationToken: ct);
// body is the LRC content, or null when LRCLIB doesn't have the track.
\`\`\`

The client is intentionally minimal: no caching, no retries beyond the underlying HttpClient, no rate-limit gating — those belong in the consumer's pipeline. All failure modes (404, 5xx, network, malformed JSON, empty syncedLyrics) collapse to \`null\` because lyrics are a nice-to-have and must never break a download.

## TDD trail
14 cases in \`tests/LrclibClientTests.cs\`:
- 200 + populated \`syncedLyrics\` → returns the LRC body
- 404 → null (track not in LRCLIB)
- 5xx → null (server error; lyrics are best-effort)
- Network error → null
- Malformed JSON → null
- 200 with empty \`syncedLyrics\` → null (LRCLIB sometimes returns \`plainLyrics\` only)
- URL building: \`artist_name\`, \`track_name\`, \`album_name\`, \`duration\` query params formatted correctly
- Ambiguous metadata ("AC/DC", "High Voltage & Beyond") URL-encoded, not injected as extra params
- Null artist / null track / negative duration → guard exceptions
- Empty album_name allowed (LRCLIB tolerates it)
- Cancellation propagates as \`OperationCanceledException\`
- Default User-Agent set so LRCLIB can attribute traffic

## Implementation
- Two ctors: one accepts an injected HttpClient (no ownership), one creates its own (IDisposable cleanup).
- \`HttpUtility.ParseQueryString\` builds the query — avoids hand-rolled escape bugs and protects against parameter injection.
- User-cancellation → propagates; SendAsync timeout (no user cancel) → null; HttpRequestException → null; JsonException → null.

## Consumer follow-up
- tidalarr — wire into the download path when \`UseLRCLIB = true\` and Tidal's lyrics endpoint returns nothing.
- applemusicarr — same pattern.

## Test plan
- [x] 14/14 new tests pass.
- [x] Build clean.
- [ ] CI: full build + tests.