### PR TITLE
feat(diagnostics): HttpExceptionClassifier — categorised connection-test failures (TDD)

### DIFF
--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
     <!-- For stable releases, keep PackageVersion omitted or equal to Version -->
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.7.1: See CHANGELOG.md for release details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.8.0: Multi-plugin co-existence fix (ALC). See docs/dev-guide/ALC_MULTIPLUGIN_FIX.md and CHANGELOG.md.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->

--- a/src/Services/Diagnostics/HttpExceptionClassifier.cs
+++ b/src/Services/Diagnostics/HttpExceptionClassifier.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Lidarr.Plugin.Common.Services.Diagnostics
+{
+    /// <summary>
+    /// What kind of HTTP failure did we hit? Plugin <c>Test()</c> methods and
+    /// connection-validation flows use this to pick an actionable error message
+    /// instead of bubbling up CLR-flavoured exception text.
+    /// </summary>
+    public enum HttpFailureCategory
+    {
+        Unknown,
+        Network,        // DNS, connection refused, network unreachable, transport-level IOException
+        Timeout,        // Request never received a response within the window
+        Cancelled,      // The caller's CancellationToken fired
+        Auth,           // 401 / 403
+        RateLimit,      // 429
+        ClientRequest,  // 4xx other than auth / rate-limit (e.g. malformed query)
+        Server          // 5xx
+    }
+
+    /// <summary>
+    /// Categorised result from <see cref="HttpExceptionClassifier.Classify"/>.
+    /// </summary>
+    public readonly record struct HttpFailureClassification(HttpFailureCategory Category, string Hint);
+
+    /// <summary>
+    /// Maps exceptions thrown during HTTP calls into a categorical failure +
+    /// user-readable hint. Plugin Test() methods historically caught generic
+    /// <see cref="Exception"/> and surfaced "Test failed: {ex.Message}" which
+    /// leaked CLR type names ("SocketException", "HttpRequestException") that
+    /// aren't actionable for end users.
+    ///
+    /// This classifier replaces that pattern with:
+    /// <code>
+    /// catch (Exception ex)
+    /// {
+    ///     var (category, hint) = HttpExceptionClassifier.Classify(ex);
+    ///     failures.Add(new ValidationFailure("Test", hint));
+    /// }
+    /// </code>
+    ///
+    /// Hints are intentionally short and free of CLR type names; they describe
+    /// what the user can DO. Specifics (status code, URL) are out of scope —
+    /// plugins should log those separately for operators.
+    /// </summary>
+    public static class HttpExceptionClassifier
+    {
+        public static HttpFailureClassification Classify(Exception exception)
+        {
+            if (exception is null)
+            {
+                return new HttpFailureClassification(HttpFailureCategory.Unknown, FallbackHint);
+            }
+
+            // Order matters — user-cancellation must win over the
+            // TaskCanceledException-is-also-OperationCanceledException ambiguity.
+            if (exception is OperationCanceledException oce && !(exception is TaskCanceledException))
+            {
+                return new HttpFailureClassification(HttpFailureCategory.Cancelled, "The test was cancelled.");
+            }
+
+            if (exception is TaskCanceledException)
+            {
+                // SendAsync timeout (no user cancellation observed at the call site).
+                return new HttpFailureClassification(
+                    HttpFailureCategory.Timeout,
+                    "The request timed out before the server responded. The service may be slow or unreachable; try again.");
+            }
+
+            if (exception is HttpRequestException hre)
+            {
+                return ClassifyHttpRequest(hre);
+            }
+
+            if (exception is SocketException)
+            {
+                return new HttpFailureClassification(HttpFailureCategory.Network, NetworkHint);
+            }
+
+            if (exception is IOException)
+            {
+                // Connection-reset / read-failure mid-transfer typically surfaces
+                // as IOException ("Unable to read data from the transport connection").
+                return new HttpFailureClassification(HttpFailureCategory.Network, NetworkHint);
+            }
+
+            return new HttpFailureClassification(HttpFailureCategory.Unknown, FallbackHint);
+        }
+
+        private static HttpFailureClassification ClassifyHttpRequest(HttpRequestException hre)
+        {
+            if (hre.InnerException is SocketException || hre.InnerException is IOException)
+            {
+                return new HttpFailureClassification(HttpFailureCategory.Network, NetworkHint);
+            }
+
+            // .NET 5+ populates HttpRequestException.StatusCode on transport-success failures.
+            // No status code typically means the request never reached a server.
+            if (hre.StatusCode is null)
+            {
+                return new HttpFailureClassification(HttpFailureCategory.Network, NetworkHint);
+            }
+
+            var status = (int)hre.StatusCode.Value;
+            return status switch
+            {
+                401 or 403 => new HttpFailureClassification(
+                    HttpFailureCategory.Auth,
+                    "The server rejected the credentials. Re-check the configured credentials and try again."),
+                429 => new HttpFailureClassification(
+                    HttpFailureCategory.RateLimit,
+                    "The service is rate-limiting requests. Wait a few minutes and try again, or lower the requests-per-second setting."),
+                >= 400 and < 500 => new HttpFailureClassification(
+                    HttpFailureCategory.ClientRequest,
+                    "The server rejected the request. Check the configured settings (e.g. region, market, search term) for an invalid value."),
+                >= 500 => new HttpFailureClassification(
+                    HttpFailureCategory.Server,
+                    "The service returned a temporary server error. Try again in a few minutes."),
+                _ => new HttpFailureClassification(HttpFailureCategory.Unknown, FallbackHint)
+            };
+        }
+
+        private const string NetworkHint =
+            "Could not reach the service over the network. Check connectivity, DNS, and any firewall or proxy between Lidarr and the service.";
+
+        private const string FallbackHint =
+            "An unexpected error occurred during the test. Check the Lidarr log for details.";
+    }
+}

--- a/tests/HttpExceptionClassifierTests.cs
+++ b/tests/HttpExceptionClassifierTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Services.Diagnostics;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+/// <summary>
+/// Plugin Test() / connection-validation methods have historically caught any
+/// Exception and surfaced "Test failed: {ex.Message}" to the user. That hides
+/// the real failure category — a 401 looks like a 503 looks like a DNS error.
+/// HttpExceptionClassifier converts an exception into a categorical
+/// <see cref="HttpFailureCategory"/> plus a user-readable hint, so plugin UIs
+/// can show actionable text like "Could not reach &lt;service&gt; — the server
+/// returned a temporary error; try again in a few minutes." rather than
+/// "Test failed: System.Net.Sockets.SocketException: No such host is known".
+/// </summary>
+public sealed class HttpExceptionClassifierTests
+{
+    [Fact]
+    public void Classify_NullException_ReturnsUnknown()
+    {
+        // Defensive — a missing exception shouldn't crash the classifier.
+        var result = HttpExceptionClassifier.Classify(null!);
+        Assert.Equal(HttpFailureCategory.Unknown, result.Category);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_Unauthorized_ReturnsAuth()
+    {
+        var ex = new HttpRequestException("Unauthorized", inner: null, statusCode: HttpStatusCode.Unauthorized);
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Auth, result.Category);
+        Assert.Contains("credentials", result.Hint, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_Forbidden_ReturnsAuth()
+    {
+        var ex = new HttpRequestException("Forbidden", inner: null, statusCode: HttpStatusCode.Forbidden);
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Auth, result.Category);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_TooManyRequests_ReturnsRateLimit()
+    {
+        var ex = new HttpRequestException("Too Many Requests", inner: null, statusCode: HttpStatusCode.TooManyRequests);
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.RateLimit, result.Category);
+        Assert.Contains("rate", result.Hint, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_5xx_ReturnsServer()
+    {
+        foreach (var status in new[] {
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.BadGateway,
+            HttpStatusCode.ServiceUnavailable,
+            HttpStatusCode.GatewayTimeout })
+        {
+            var ex = new HttpRequestException("Boom", inner: null, statusCode: status);
+            var result = HttpExceptionClassifier.Classify(ex);
+            Assert.Equal(HttpFailureCategory.Server, result.Category);
+        }
+    }
+
+    [Fact]
+    public void Classify_HttpRequestException_NoStatusCode_FallsBackToNetworkOrServer()
+    {
+        // No status means we never got a response — typically a connection
+        // failure. Route to Network, not Server.
+        var ex = new HttpRequestException("Connection refused");
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Network, result.Category);
+    }
+
+    [Fact]
+    public void Classify_TaskCanceledException_NoCancelToken_ReturnsTimeout()
+    {
+        // SendAsync timeout (no user cancellation) — should be classified as
+        // a timeout, distinct from genuine user cancellation.
+        var ex = new TaskCanceledException("A task was canceled.");
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Timeout, result.Category);
+        Assert.Contains("timed out", result.Hint, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Classify_OperationCanceledException_WithToken_ReturnsCancelled()
+    {
+        // Genuine user cancellation isn't really a "failure" — surface it as a
+        // separate category so plugin UIs can suppress the test result rather
+        // than showing an error.
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ex = new OperationCanceledException(cts.Token);
+
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Cancelled, result.Category);
+    }
+
+    [Fact]
+    public void Classify_SocketException_ReturnsNetwork()
+    {
+        var ex = new SocketException((int)SocketError.HostNotFound);
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Network, result.Category);
+        Assert.Contains("network", result.Hint, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Classify_HttpRequestExceptionWithSocketInner_ReturnsNetwork()
+    {
+        var inner = new SocketException((int)SocketError.NetworkUnreachable);
+        var ex = new HttpRequestException("send failed", inner);
+
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Network, result.Category);
+    }
+
+    [Fact]
+    public void Classify_IOException_ReturnsNetwork()
+    {
+        // IO errors mid-transfer (connection reset, socket closed) — treat as
+        // network rather than misleading the user with "auth" / "server".
+        var ex = new IOException("Unable to read data from the transport connection");
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Network, result.Category);
+    }
+
+    [Fact]
+    public void Classify_UnknownException_ReturnsUnknown()
+    {
+        var ex = new InvalidOperationException("something obscure");
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.Unknown, result.Category);
+    }
+
+    [Fact]
+    public void Classify_HintNeverContainsRawCLRType()
+    {
+        // The hint is end-user-facing. It must not leak raw type names like
+        // "System.Net.Http.HttpRequestException" or "System.Exception" — those
+        // were the very strings the classifier exists to replace.
+        var inputs = new Exception[]
+        {
+            new HttpRequestException("x", null, HttpStatusCode.Unauthorized),
+            new HttpRequestException("x", null, HttpStatusCode.TooManyRequests),
+            new HttpRequestException("x", null, HttpStatusCode.InternalServerError),
+            new TaskCanceledException("timeout"),
+            new SocketException(11001),
+            new InvalidOperationException("opaque")
+        };
+
+        foreach (var ex in inputs)
+        {
+            var result = HttpExceptionClassifier.Classify(ex);
+            Assert.False(result.Hint.Contains("System.", StringComparison.Ordinal),
+                $"Hint leaked CLR type: '{result.Hint}'");
+            Assert.False(result.Hint.Contains("Exception", StringComparison.Ordinal),
+                $"Hint leaked 'Exception': '{result.Hint}'");
+        }
+    }
+
+    [Fact]
+    public void Classify_400_ReturnsClient()
+    {
+        // 4xx that isn't 401/403/429 — typically a malformed request (bad
+        // query, missing required param). Distinct from auth so the user
+        // can investigate their config rather than re-typing credentials.
+        var ex = new HttpRequestException("Bad Request", inner: null, statusCode: HttpStatusCode.BadRequest);
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.ClientRequest, result.Category);
+    }
+
+    [Fact]
+    public void Classify_404_ReturnsClient()
+    {
+        var ex = new HttpRequestException("Not Found", inner: null, statusCode: HttpStatusCode.NotFound);
+        var result = HttpExceptionClassifier.Classify(ex);
+
+        Assert.Equal(HttpFailureCategory.ClientRequest, result.Category);
+    }
+}


### PR DESCRIPTION
## Summary
Plugin \`Test()\` / connection-validation methods have historically caught any \`Exception\` and surfaced \`"Test failed: {ex.Message}"\` to the user. That leaks CLR type names ("System.Net.Sockets.SocketException: No such host is known") and hides the failure category — a 401 looks like a 503 looks like DNS failure looks like a timeout.

\`\`\`csharp
var (category, hint) = HttpExceptionClassifier.Classify(ex);
failures.Add(new ValidationFailure("Test", hint));
\`\`\`

## Categories (HttpFailureCategory)
| Category | Trigger | Example hint fragment |
|---|---|---|
| \`Network\` | DNS, connection refused, SocketException, transport IOException, HttpRequestException with no status | "Could not reach the service over the network…" |
| \`Timeout\` | TaskCanceledException without user-cancel | "The request timed out before the server responded…" |
| \`Cancelled\` | OperationCanceledException with user-cancel token | "The test was cancelled." |
| \`Auth\` | 401 / 403 | "The server rejected the credentials…" |
| \`RateLimit\` | 429 | "The service is rate-limiting requests…" |
| \`ClientRequest\` | Other 4xx | "The server rejected the request. Check the configured settings…" |
| \`Server\` | 5xx | "The service returned a temporary server error…" |
| \`Unknown\` | Anything else | "An unexpected error occurred during the test. Check the Lidarr log…" |

## TDD trail (15 cases)
- null exception → \`Unknown\` (defensive)
- 401/403 → \`Auth\` (+ "credentials" in hint)
- 429 → \`RateLimit\` (+ "rate" in hint)
- 500/502/503/504 → \`Server\`
- HttpRequestException with no status → \`Network\` (request never reached server)
- HttpRequestException with SocketException inner → \`Network\` (transport)
- 400 / 404 → \`ClientRequest\` (4xx not auth/rate-limit)
- TaskCanceledException without user-cancel → \`Timeout\`
- OperationCanceledException with user-cancel token → \`Cancelled\` (distinct from Timeout)
- SocketException directly → \`Network\`
- IOException → \`Network\` (mid-transfer connection reset)
- InvalidOperationException → \`Unknown\`
- **Critical regression guard**: hint never contains \`"System."\` or \`"Exception"\` (the strings the classifier exists to replace)

## Implementation
Pure static; no state. Plugins copy 3 lines into their \`Test()\` method to swap \`"Test failed: {ex.Message}"\` for a categorised hint. Future cycle will adopt across each plugin's connection-test path.

## Test plan
- [x] 15/15 new tests pass.
- [x] Build clean.
- [ ] CI: full build + tests.