### PR TITLE
feat(testkit): lift PluginVersionContract + PluginPackagingContract + PublishedReleaseInstallability

### DIFF
--- a/scripts/multi-plugin-coexistence-proof.ps1
+++ b/scripts/multi-plugin-coexistence-proof.ps1
@@ -92,8 +92,11 @@ $plugins = @(
         # applemusicarr keeps the standard SDK output layout (Release/net8.0/...),
         # unlike tidalarr/qobuzarr which set AppendTargetFrameworkToOutputPath=false.
         DllCandidates = @(
-            'src/AppleMusicarr.Plugin/bin/Release/net8.0/AppleMusicarr.Plugin.dll',
-            'src/AppleMusicarr.Plugin/bin/Debug/net8.0/AppleMusicarr.Plugin.dll'
+            # Post-rename (May 2026): applemusicarr DLL filename now matches Lidarr's PluginLoader
+            # glob "Lidarr.Plugin.*.dll" (NzbDrone.Common/Extensions/PathExtensions.cs:334).
+            # Before this, the plugin loaded silently into nothing.
+            'src/AppleMusicarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.AppleMusicarr.dll',
+            'src/AppleMusicarr.Plugin/bin/Debug/net8.0/Lidarr.Plugin.AppleMusicarr.dll'
         )
         Mount = '/config/plugins/RicherTunes/AppleMusicarr'
         Substring = 'AppleMusic'

--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <!-- NuGet Package Configuration -->
     <PackageId>Lidarr.Plugin.Common</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.8.0</Version>
     <!-- For stable releases, keep PackageVersion omitted or equal to Version -->
     <!-- Package Metadata -->
     <Title>Lidarr Plugin Common Library</Title>
@@ -26,7 +26,7 @@
     <RepositoryUrl>https://github.com/RicherTunes/Lidarr.Plugin.Common.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>lidarr;plugin;streaming;music;utilities;qobuz;tidal;spotify</PackageTags>
-    <PackageReleaseNotes>v1.7.1: See CHANGELOG.md for release details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.8.0: Multi-plugin co-existence fix (ALC). See docs/dev-guide/ALC_MULTIPLUGIN_FIX.md and CHANGELOG.md.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <!-- Build Configuration -->

--- a/testkit/Compliance/PluginPackagingContract.cs
+++ b/testkit/Compliance/PluginPackagingContract.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.TestKit.Compliance;
+
+/// <summary>
+/// Declarative shape of what a Lidarr plugin's release zip must contain.
+/// </summary>
+/// <param name="MainDllName">
+/// The plugin's main DLL (e.g. <c>"Lidarr.Plugin.Brainarr.dll"</c>). Must be present in
+/// the zip; also subject to the <see cref="MainDllMinimumBytes"/> sanity check.
+/// </param>
+/// <param name="RequiredFiles">
+/// All files that MUST be present in the zip (filenames only — paths are stripped).
+/// Should include <see cref="MainDllName"/> + <c>plugin.json</c> at minimum.
+/// </param>
+/// <param name="ForbiddenAssemblies">
+/// Filenames that MUST NOT be present. Shipping these causes type-identity conflicts
+/// (host contract DLLs like FluentValidation, NLog, Microsoft.Extensions.*.Abstractions)
+/// or regresses multi-plugin co-existence (sidecar Lidarr.Plugin.Abstractions/Common).
+/// </param>
+/// <param name="MainDllMinimumBytes">
+/// Minimum size of <see cref="MainDllName"/>. For ILRepack-merged plugins this should
+/// be ≥2MB — a smaller DLL means the merge didn't run and the runtime will fail with
+/// "Could not load Lidarr.Plugin.Common / Abstractions" because the (correctly omitted)
+/// sidecars aren't there to load. Set to <c>0</c> for sidecar-packaged plugins.
+/// </param>
+public sealed record PluginPackagePolicy(
+    string MainDllName,
+    IReadOnlyList<string> RequiredFiles,
+    IReadOnlyList<string> ForbiddenAssemblies,
+    long MainDllMinimumBytes = 0);
+
+/// <summary>
+/// Static assertions catching packaging-policy violations against a built plugin zip.
+///
+/// <para>Usage (merged-DLL plugin, e.g. brainarr/qobuzarr/tidalarr):</para>
+/// <code>
+/// var policy = PluginPackagingContract.MergedDllPolicy("Lidarr.Plugin.Brainarr",
+///     extraRequired: ["manifest.json", ".lidarr.plugin"]);
+/// PluginPackagingContract.AssertZipMatchesPolicy(zipPath, policy);
+/// </code>
+///
+/// <para>Usage (sidecar plugin, e.g. applemusicarr):</para>
+/// <code>
+/// var policy = new PluginPackagePolicy(
+///     MainDllName: "AppleMusicarr.Plugin.dll",
+///     RequiredFiles: ["AppleMusicarr.Plugin.dll", "AppleMusicarr.Core.dll",
+///                     "Lidarr.Plugin.Common.dll", "Lidarr.Plugin.Abstractions.dll",
+///                     "plugin.json", "manifest.json"],
+///     ForbiddenAssemblies: PluginPackagingContract.DefaultForbiddenHostAssemblies,
+///     MainDllMinimumBytes: 0);
+/// PluginPackagingContract.AssertZipMatchesPolicy(zipPath, policy);
+/// </code>
+/// </summary>
+public static class PluginPackagingContract
+{
+    /// <summary>
+    /// Host-provided contract assemblies + Lidarr/NzbDrone host assemblies that must
+    /// never ship in a plugin zip — shipping them causes type-identity conflicts that
+    /// surface as "Method 'Test' does not have an implementation" /
+    /// "Could not load file or assembly" at runtime.
+    /// </summary>
+    public static readonly IReadOnlyList<string> DefaultForbiddenHostAssemblies = new[]
+    {
+        // Host-provided contract assemblies — type-identity conflicts if shipped
+        "FluentValidation.dll",
+        "NLog.dll",
+        "System.Text.Json.dll",
+        "Newtonsoft.Json.dll",
+        "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
+        "Microsoft.Extensions.Logging.Abstractions.dll",
+        "Microsoft.Extensions.Caching.Abstractions.dll",
+        "Microsoft.Extensions.Caching.Memory.dll",
+        "Microsoft.Extensions.Options.dll",
+        "Microsoft.Extensions.Primitives.dll",
+        // Lidarr host assemblies — host provides them; shipping triggers loader conflicts
+        "Lidarr.Core.dll",
+        "Lidarr.Common.dll",
+        "Lidarr.Http.dll",
+        "Lidarr.Api.V1.dll",
+        "Lidarr.Host.dll",
+        "NzbDrone.Core.dll",
+        "NzbDrone.Common.dll",
+        "NzbDrone.SignalR.dll",
+    };
+
+    /// <summary>
+    /// Forbidden list for ILRepack-merged plugins (brainarr/qobuzarr/tidalarr):
+    /// host assemblies AS WELL AS Lidarr.Plugin.{Abstractions,Common}.dll, since those
+    /// are merged + internalized into the plugin DLL. Shipping them as sidecars
+    /// reintroduces the COR_E_INVALIDOPERATION cross-ALC conflict the merge fixed.
+    /// </summary>
+    public static readonly IReadOnlyList<string> MergedPluginForbiddenAssemblies =
+        DefaultForbiddenHostAssemblies
+            .Concat(new[] { "Lidarr.Plugin.Abstractions.dll", "Lidarr.Plugin.Common.dll" })
+            .ToArray();
+
+    /// <summary>
+    /// Convenience constructor for ILRepack-merged plugins.
+    /// </summary>
+    /// <param name="mainAssemblyName">
+    /// Bare assembly name (no .dll) e.g. <c>"Lidarr.Plugin.Brainarr"</c>.
+    /// </param>
+    /// <param name="extraRequired">
+    /// Additional required filenames beyond the main DLL + <c>plugin.json</c>.
+    /// Pass <c>"manifest.json"</c> here if the plugin ships one.
+    /// </param>
+    /// <param name="minBytes">
+    /// Override the 2MB merged-DLL minimum. Pass 0 to skip the size check.
+    /// </param>
+    public static PluginPackagePolicy MergedDllPolicy(
+        string mainAssemblyName,
+        IEnumerable<string>? extraRequired = null,
+        long minBytes = 2_000_000)
+    {
+        var mainDll = mainAssemblyName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            ? mainAssemblyName
+            : mainAssemblyName + ".dll";
+
+        var required = new List<string> { mainDll, "plugin.json" };
+        if (extraRequired is not null) required.AddRange(extraRequired);
+
+        return new PluginPackagePolicy(
+            MainDllName: mainDll,
+            RequiredFiles: required,
+            ForbiddenAssemblies: MergedPluginForbiddenAssemblies,
+            MainDllMinimumBytes: minBytes);
+    }
+
+    /// <summary>
+    /// Asserts the zip at <paramref name="zipPath"/> satisfies the policy:
+    /// every <see cref="PluginPackagePolicy.RequiredFiles"/> is present (case-insensitive),
+    /// every <see cref="PluginPackagePolicy.ForbiddenAssemblies"/> is absent,
+    /// and the main DLL meets the size minimum.
+    /// </summary>
+    public static void AssertZipMatchesPolicy(string zipPath, PluginPackagePolicy policy)
+    {
+        if (string.IsNullOrWhiteSpace(zipPath))
+            throw new ArgumentException("zipPath must be non-empty.", nameof(zipPath));
+        if (!File.Exists(zipPath))
+            throw new FileNotFoundException("Plugin zip not found.", zipPath);
+        if (policy is null)
+            throw new ArgumentNullException(nameof(policy));
+
+        using var archive = ZipFile.OpenRead(zipPath);
+
+        var fileNames = archive.Entries
+            .Select(e => Path.GetFileName(e.FullName))
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var inventory = string.Join(", ", fileNames.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+
+        foreach (var required in policy.RequiredFiles)
+        {
+            Assert.True(fileNames.Contains(required),
+                $"Plugin zip at '{zipPath}' is missing required file '{required}'.\n" +
+                $"Contents: {inventory}");
+        }
+
+        foreach (var forbidden in policy.ForbiddenAssemblies)
+        {
+            Assert.False(fileNames.Contains(forbidden),
+                $"Plugin zip at '{zipPath}' ships FORBIDDEN '{forbidden}' — " +
+                $"this would cause type-identity conflicts or regress multi-plugin co-existence.\n" +
+                $"Contents: {inventory}");
+        }
+
+        if (policy.MainDllMinimumBytes > 0)
+        {
+            var mainEntry = archive.Entries.FirstOrDefault(e =>
+                Path.GetFileName(e.FullName).Equals(policy.MainDllName, StringComparison.OrdinalIgnoreCase));
+
+            Assert.True(mainEntry is not null,
+                $"Main DLL '{policy.MainDllName}' must be in the zip.");
+
+            Assert.True(mainEntry!.Length >= policy.MainDllMinimumBytes,
+                $"Main DLL '{policy.MainDllName}' is only {mainEntry.Length} bytes; " +
+                $"policy requires ≥{policy.MainDllMinimumBytes} bytes. " +
+                $"For ILRepack-merged plugins a sub-threshold DLL means the merge didn't run " +
+                $"and runtime will fail with 'Could not load Lidarr.Plugin.Common / Abstractions'.");
+        }
+    }
+}

--- a/testkit/Compliance/PluginPackagingContract.cs
+++ b/testkit/Compliance/PluginPackagingContract.cs
@@ -45,17 +45,10 @@ public sealed record PluginPackagePolicy(
 /// PluginPackagingContract.AssertZipMatchesPolicy(zipPath, policy);
 /// </code>
 ///
-/// <para>Usage (sidecar plugin, e.g. applemusicarr):</para>
-/// <code>
-/// var policy = new PluginPackagePolicy(
-///     MainDllName: "AppleMusicarr.Plugin.dll",
-///     RequiredFiles: ["AppleMusicarr.Plugin.dll", "AppleMusicarr.Core.dll",
-///                     "Lidarr.Plugin.Common.dll", "Lidarr.Plugin.Abstractions.dll",
-///                     "plugin.json", "manifest.json"],
-///     ForbiddenAssemblies: PluginPackagingContract.DefaultForbiddenHostAssemblies,
-///     MainDllMinimumBytes: 0);
-/// PluginPackagingContract.AssertZipMatchesPolicy(zipPath, policy);
-/// </code>
+/// <para>Note on naming: <c>MainDllName</c> MUST start with <c>"Lidarr.Plugin."</c>
+/// — Lidarr's PluginLoader globs <c>Lidarr.Plugin.*.dll</c> and silently ignores
+/// any other filename (see <see cref="AssertMainDllMatchesLoaderNamingConvention"/>).
+/// This is enforced by <see cref="AssertZipMatchesPolicy"/>.</para>
 /// </summary>
 public static class PluginPackagingContract
 {
@@ -133,10 +126,38 @@ public static class PluginPackagingContract
     }
 
     /// <summary>
+    /// Lidarr's PluginLoader globs <c>Lidarr.Plugin.*.dll</c> when scanning
+    /// <c>/config/plugins/&lt;owner&gt;/&lt;name&gt;/</c>
+    /// (<c>NzbDrone.Common/Extensions/PathExtensions.cs:334</c>). Any DLL whose filename
+    /// does NOT start with <c>"Lidarr.Plugin."</c> is silently ignored at host bootstrap —
+    /// no error, no warning, no log line; the plugin just never appears in
+    /// <c>/api/v1/system/plugins</c> and never registers any services.
+    /// </summary>
+    /// <remarks>
+    /// Caught the May 2026 AppleMusicarr incident: install worked, files were on disk,
+    /// but <c>AppleMusicarr.Plugin.dll</c> didn't match the glob → plugin invisible.
+    /// Fix: <c>&lt;AssemblyName&gt;Lidarr.Plugin.AppleMusicarr&lt;/AssemblyName&gt;</c>.
+    /// </remarks>
+    public static void AssertMainDllMatchesLoaderNamingConvention(PluginPackagePolicy policy)
+    {
+        if (policy is null) throw new ArgumentNullException(nameof(policy));
+
+        Assert.True(
+            policy.MainDllName.StartsWith("Lidarr.Plugin.", StringComparison.OrdinalIgnoreCase) &&
+                policy.MainDllName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase),
+            $"Main DLL '{policy.MainDllName}' does not match Lidarr's PluginLoader glob " +
+            $"'Lidarr.Plugin.*.dll' (NzbDrone.Common/Extensions/PathExtensions.cs:334). " +
+            $"Set <AssemblyName>Lidarr.Plugin.<Name></AssemblyName> in the .Plugin .csproj. " +
+            $"Without this the plugin loads silently into nothing — it won't appear in " +
+            $"/api/v1/system/plugins and won't register any services.");
+    }
+
+    /// <summary>
     /// Asserts the zip at <paramref name="zipPath"/> satisfies the policy:
     /// every <see cref="PluginPackagePolicy.RequiredFiles"/> is present (case-insensitive),
     /// every <see cref="PluginPackagePolicy.ForbiddenAssemblies"/> is absent,
-    /// and the main DLL meets the size minimum.
+    /// the main DLL meets the size minimum, and the main DLL filename satisfies the
+    /// PluginLoader naming convention (<see cref="AssertMainDllMatchesLoaderNamingConvention"/>).
     /// </summary>
     public static void AssertZipMatchesPolicy(string zipPath, PluginPackagePolicy policy)
     {
@@ -146,6 +167,8 @@ public static class PluginPackagingContract
             throw new FileNotFoundException("Plugin zip not found.", zipPath);
         if (policy is null)
             throw new ArgumentNullException(nameof(policy));
+
+        AssertMainDllMatchesLoaderNamingConvention(policy);
 
         using var archive = ZipFile.OpenRead(zipPath);
 

--- a/testkit/Compliance/PluginVersionContract.cs
+++ b/testkit/Compliance/PluginVersionContract.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.TestKit.Compliance;
+
+/// <summary>
+/// Static assertions catching version drift between sources of truth that exist
+/// in every Lidarr plugin in the RicherTunes family.
+///
+/// <para>Background:</para> sibling plugins have hit silent version drift in
+/// multiple ways:
+/// <list type="bullet">
+///   <item>brainarr's <c>AssemblyInfo.cs</c> hardcoded <c>[assembly: AssemblyVersion("1.3.2.0")]</c>
+///         literal stayed through 1.4.0 and 1.4.1 releases (because
+///         <c>&lt;GenerateAssemblyInfo&gt;false&lt;/GenerateAssemblyInfo&gt;</c> made
+///         Directory.Build.props' VERSION-file-driven version inert). Result:
+///         <c>/api/v1/system/plugins</c> reported installedVersion=1.3.2 while the
+///         actual release was 1.4.1.</item>
+///   <item>tidalarr's <c>TidalModule.Version = "1.1.0"</c> const literal stayed through
+///         1.1.1 (caught by VersionContract).</item>
+///   <item>applemusicarr's <c>manifest.json</c> "0.3.0-beta.2" stayed through 0.4.0
+///         (also caught by VersionContract).</item>
+/// </list>
+///
+/// <para>Usage:</para> per-plugin test class becomes ~5 lines per assertion:
+/// <code>
+/// public class BrainarrVersionContractTests
+/// {
+///     [Fact] public void AssemblyMatchesPluginJson() =>
+///         PluginVersionContract.AssertAssemblyVersionMatchesPluginJson(typeof(BrainarrInstalledPlugin));
+///
+///     [Fact] public void VersionFileMatchesPluginJson() =>
+///         PluginVersionContract.AssertVersionFileMatchesPluginJson(typeof(BrainarrInstalledPlugin));
+///
+///     [Fact] public void ManifestMatchesPluginJson() =>
+///         PluginVersionContract.AssertManifestMatchesPluginJson(typeof(BrainarrInstalledPlugin));
+/// }
+/// </code>
+///
+/// Plugins that don't ship a <c>manifest.json</c> (e.g. qobuzarr) simply omit the
+/// <c>AssertManifestMatchesPluginJson</c> call.
+/// </summary>
+public static class PluginVersionContract
+{
+    /// <summary>
+    /// Assert the plugin assembly's <see cref="AssemblyName.Version"/> (3-part) equals
+    /// <c>plugin.json</c>'s top-level <c>"version"</c> field.
+    /// </summary>
+    /// <param name="pluginTypeAnchor">Any type from the plugin assembly. Used to locate
+    /// <c>plugin.json</c> via <see cref="AppContext.BaseDirectory"/> or via repo walk
+    /// from the assembly's location.</param>
+    /// <param name="pluginJsonPath">Optional explicit path to <c>plugin.json</c>.</param>
+    public static void AssertAssemblyVersionMatchesPluginJson(Type pluginTypeAnchor, string? pluginJsonPath = null)
+    {
+        var asm = pluginTypeAnchor.Assembly;
+        var asmVersion = asm.GetName().Version?.ToString(3);
+        Assert.False(string.IsNullOrWhiteSpace(asmVersion),
+            $"Assembly {asm.GetName().Name} must declare a non-empty Version.");
+
+        pluginJsonPath ??= LocatePluginJson(asm);
+        Skip.If(pluginJsonPath is null, "plugin.json not found in AppContext.BaseDirectory or any parent directory.");
+
+        var pluginJsonVersion = ReadJsonVersion(pluginJsonPath!);
+        Assert.False(string.IsNullOrWhiteSpace(pluginJsonVersion),
+            $"plugin.json at {pluginJsonPath} must declare a top-level \"version\" field.");
+
+        Assert.Equal(pluginJsonVersion, asmVersion);
+    }
+
+    /// <summary>
+    /// Assert the top-level <c>VERSION</c> file's contents equal <c>plugin.json</c>'s
+    /// top-level <c>"version"</c> field.
+    /// </summary>
+    public static void AssertVersionFileMatchesPluginJson(Type pluginTypeAnchor)
+    {
+        var asm = pluginTypeAnchor.Assembly;
+        var versionFilePath = LocateRepoFile(asm, "VERSION");
+        var pluginJsonPath = LocatePluginJson(asm);
+        Skip.If(versionFilePath is null || pluginJsonPath is null,
+            "VERSION or plugin.json not found — only enforced for repo-rooted runs.");
+
+        var versionFileContent = File.ReadAllText(versionFilePath!).Trim();
+        var pluginJsonVersion = ReadJsonVersion(pluginJsonPath!);
+
+        Assert.Equal(versionFileContent, pluginJsonVersion);
+    }
+
+    /// <summary>
+    /// Assert <c>manifest.json</c>'s top-level <c>"version"</c> field equals
+    /// <c>plugin.json</c>'s top-level <c>"version"</c> field.
+    /// </summary>
+    /// <param name="manifestRelativePath">
+    /// Path to manifest.json relative to the repo root. Defaults to <c>"manifest.json"</c>;
+    /// pass e.g. <c>"src/AppleMusicarr.Plugin/manifest.json"</c> when the manifest lives in
+    /// a project subdirectory rather than the repo root.
+    /// </param>
+    /// <param name="pluginJsonRelativePath">Same convention; defaults to <c>"plugin.json"</c>.</param>
+    public static void AssertManifestMatchesPluginJson(
+        Type pluginTypeAnchor,
+        string manifestRelativePath = "manifest.json",
+        string pluginJsonRelativePath = "plugin.json")
+    {
+        var asm = pluginTypeAnchor.Assembly;
+        var manifestPath = LocateRepoFile(asm, manifestRelativePath);
+        var pluginJsonPath = LocateRepoFile(asm, pluginJsonRelativePath);
+        Skip.If(manifestPath is null || pluginJsonPath is null,
+            $"{manifestRelativePath} or {pluginJsonRelativePath} not found — only enforced for repo-rooted runs.");
+
+        var manifestVersion = ReadJsonVersion(manifestPath!);
+        var pluginJsonVersion = ReadJsonVersion(pluginJsonPath!);
+
+        Assert.Equal(pluginJsonVersion, manifestVersion);
+    }
+
+    // -- helpers -------------------------------------------------------------
+
+    /// <summary>
+    /// Locate <c>plugin.json</c> by walking up from the SDK's default output dir
+    /// (the test's <see cref="AppContext.BaseDirectory"/>) — production builds copy
+    /// plugin.json next to the test DLL, and CI runs from a repo root.
+    /// </summary>
+    private static string? LocatePluginJson(Assembly _) =>
+        Path.Combine(AppContext.BaseDirectory, "plugin.json") switch
+        {
+            var p when File.Exists(p) => p,
+            _ => LocateRepoFile(_, "plugin.json"),
+        };
+
+    /// <summary>Walks parents from <see cref="AppContext.BaseDirectory"/> looking for <paramref name="relativePath"/>.</summary>
+    private static string? LocateRepoFile(Assembly _, string relativePath)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, relativePath);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static string ReadJsonVersion(string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        return doc.RootElement.GetProperty("version").GetString() ?? string.Empty;
+    }
+}

--- a/testkit/Compliance/PublishedReleaseInstallabilityContract.cs
+++ b/testkit/Compliance/PublishedReleaseInstallabilityContract.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.TestKit.Compliance;
+
+/// <summary>
+/// Static assertions that exercise the LIVE GitHub releases of a plugin repo through
+/// Lidarr's <c>PluginService.GetRemotePlugin</c> filter — the exact code path that
+/// users hit when clicking "Install" on a GitHub URL in Lidarr.
+///
+/// <para>What this catches that the local <see cref="PluginPackagingContract"/> can't:</para>
+/// the local PackagingContract covers the BUILD artifact; this covers the PUBLISHED
+/// artifact. Catches the case where the publish step diverges from the build —
+/// someone hand-uploads a stale zip, renames one in a release rebuild, or
+/// release.yml's <c>files:</c> list points at the wrong artifact.
+///
+/// <para>Usage:</para>
+/// <code>
+/// public class BrainarrPublishedReleaseTests
+/// {
+///     [SkippableFact, Trait("Category", "ReleaseE2E")]
+///     public Task LatestRelease_PassesLidarrFilter() =>
+///         PublishedReleaseInstallabilityContract.AssertLatestReleasePassesLidarrInstallFilterAsync(
+///             owner: "RicherTunes", repo: "Brainarr");
+///
+///     [SkippableFact, Trait("Category", "ReleaseE2E")]
+///     public Task LatestRelease_ContentsMatchPolicy() =>
+///         PublishedReleaseInstallabilityContract.AssertLatestReleaseZipMatchesPolicyAsync(
+///             owner: "RicherTunes", repo: "Brainarr",
+///             policy: PluginPackagingContract.MergedDllPolicy("Lidarr.Plugin.Brainarr",
+///                 extraRequired: new[] { "manifest.json" }));
+/// }
+/// </code>
+///
+/// <para>Each assertion <c>Skip.If</c>s when GitHub is unreachable or rate-limited
+/// — the tests are opt-in via <c>[Trait("Category", "ReleaseE2E")]</c> and tolerant
+/// of network conditions. Honors <c>GITHUB_TOKEN</c> env var for authenticated
+/// requests (higher rate limits in CI).</para>
+/// </summary>
+public static class PublishedReleaseInstallabilityContract
+{
+    /// <summary>
+    /// Source-of-truth Lidarr install filter mirrored from
+    /// <c>src/NzbDrone.Core/Plugins/PluginService.cs::GetRemotePlugin</c> on the plugins branch:
+    /// <list type="number">
+    ///   <item><c>!Draft</c></item>
+    ///   <item><c>target_commitish</c> ∈ <c>{main, master}</c> (case-insensitive)</item>
+    ///   <item>at least one asset's name contains the framework token (e.g. <c>net8.0.zip</c>)</item>
+    /// </list>
+    /// Asserts at least one release in <c>{owner}/{repo}</c> satisfies all three —
+    /// if none does, the UI Install button silently no-ops (the failure mode behind
+    /// the May 2026 install bug).
+    /// </summary>
+    public static async Task AssertLatestReleasePassesLidarrInstallFilterAsync(
+        string owner, string repo, string framework = "net8.0", HttpClient? http = null)
+    {
+        var ownedClient = http is null;
+        http ??= CreateClient(repo);
+        try
+        {
+            var releases = await TryGetReleasesAsync(http, owner, repo).ConfigureAwait(false);
+            Skip.If(releases is null, $"GitHub releases for {owner}/{repo} unavailable — network down or rate-limited.");
+
+            var installable = releases!.Value.EnumerateArray()
+                .Where(r => !r.GetProperty("draft").GetBoolean())
+                .Where(r => IsDefaultTree(r.GetProperty("target_commitish").GetString()))
+                .Where(r => r.GetProperty("assets").EnumerateArray()
+                    .Any(a => a.GetProperty("name").GetString()?
+                        .Contains($"{framework}.zip", StringComparison.OrdinalIgnoreCase) == true))
+                .ToList();
+
+            Assert.True(installable.Count > 0,
+                $"No release in {owner}/{repo} passes Lidarr's PluginService filter. " +
+                $"At least one non-draft release on main/master with an asset whose name contains " +
+                $"'{framework}.zip' is required. UI Install on https://github.com/{owner}/{repo} " +
+                $"would silently fail.");
+        }
+        finally
+        {
+            if (ownedClient) http.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Downloads the most recent installable release's matching asset (per the filter
+    /// above) and delegates to <see cref="PluginPackagingContract.AssertZipMatchesPolicy"/>.
+    /// </summary>
+    public static async Task AssertLatestReleaseZipMatchesPolicyAsync(
+        string owner, string repo, PluginPackagePolicy policy,
+        string framework = "net8.0", HttpClient? http = null)
+    {
+        if (policy is null) throw new ArgumentNullException(nameof(policy));
+
+        var ownedClient = http is null;
+        http ??= CreateClient(repo);
+        try
+        {
+            var releases = await TryGetReleasesAsync(http, owner, repo).ConfigureAwait(false);
+            Skip.If(releases is null, $"GitHub releases for {owner}/{repo} unavailable — network down or rate-limited.");
+
+            var topRelease = releases!.Value.EnumerateArray()
+                .Where(r => !r.GetProperty("draft").GetBoolean())
+                .Where(r => IsDefaultTree(r.GetProperty("target_commitish").GetString()))
+                .FirstOrDefault(r => r.GetProperty("assets").EnumerateArray()
+                    .Any(a => a.GetProperty("name").GetString()?
+                        .Contains($"{framework}.zip", StringComparison.OrdinalIgnoreCase) == true));
+
+            Skip.If(topRelease.ValueKind == JsonValueKind.Undefined,
+                $"No installable release found in {owner}/{repo} (see the install-filter test).");
+
+            var asset = topRelease.GetProperty("assets").EnumerateArray()
+                .First(a => a.GetProperty("name").GetString()?
+                    .Contains($"{framework}.zip", StringComparison.OrdinalIgnoreCase) == true);
+
+            var downloadUrl = asset.GetProperty("browser_download_url").GetString()
+                ?? throw new InvalidOperationException("Asset has no browser_download_url.");
+
+            // Download to temp file (instead of holding the whole zip in memory) so
+            // PluginPackagingContract.AssertZipMatchesPolicy can open it with ZipFile.OpenRead.
+            var tempPath = Path.Combine(Path.GetTempPath(),
+                $"lpcommon-relE2E-{Guid.NewGuid():N}-{asset.GetProperty("name").GetString()}");
+            try
+            {
+                await using (var src = await http.GetStreamAsync(downloadUrl).ConfigureAwait(false))
+                await using (var dst = File.Create(tempPath))
+                {
+                    await src.CopyToAsync(dst).ConfigureAwait(false);
+                }
+
+                PluginPackagingContract.AssertZipMatchesPolicy(tempPath, policy);
+            }
+            finally
+            {
+                try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+            }
+        }
+        finally
+        {
+            if (ownedClient) http.Dispose();
+        }
+    }
+
+    // -- helpers -------------------------------------------------------------
+
+    private static bool IsDefaultTree(string? target) =>
+        string.Equals(target, "main", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(target, "master", StringComparison.OrdinalIgnoreCase);
+
+    private static HttpClient CreateClient(string repo)
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd($"{repo}-tests/1.0");
+        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        return client;
+    }
+
+    private static async Task<JsonElement?> TryGetReleasesAsync(HttpClient http, string owner, string repo)
+    {
+        try
+        {
+            using var response = await http
+                .GetAsync($"https://api.github.com/repos/{owner}/{repo}/releases?per_page=30")
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) return null;
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            // Clone so the JsonElement survives the using-scope.
+            return doc.RootElement.Clone();
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Compliance/PluginPackagingContractNamingTests.cs
+++ b/tests/Compliance/PluginPackagingContractNamingTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Lidarr.Plugin.Common.TestKit.Compliance;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Lidarr.Plugin.Common.Tests.Compliance;
+
+/// <summary>
+/// Unit tests for <see cref="PluginPackagingContract.AssertMainDllMatchesLoaderNamingConvention"/>.
+/// Covers the Lidarr PluginLoader naming contract (Lidarr.Plugin.*.dll glob) that caught
+/// the May 2026 AppleMusicarr incident where a misnamed plugin DLL silently failed to load.
+/// </summary>
+public class PluginPackagingContractNamingTests
+{
+    [Theory]
+    [InlineData("Lidarr.Plugin.Brainarr.dll")]
+    [InlineData("Lidarr.Plugin.AppleMusicarr.dll")]
+    [InlineData("lidarr.plugin.lowercase.dll")] // case-insensitive
+    [InlineData("LIDARR.PLUGIN.UPPER.DLL")]
+    public void AssertMainDllMatchesLoaderNamingConvention_AcceptsCompliantNames(string dllName)
+    {
+        var policy = MakePolicy(dllName);
+        PluginPackagingContract.AssertMainDllMatchesLoaderNamingConvention(policy);
+    }
+
+    [Theory]
+    [InlineData("AppleMusicarr.Plugin.dll")] // the May 2026 incident
+    [InlineData("MyPlugin.dll")]
+    [InlineData("Plugin.dll")]
+    [InlineData("Lidarr.Plugin")] // missing .dll
+    [InlineData("Lidarr.Plugin.")] // technically matches but no name component — accepted by glob though
+    public void AssertMainDllMatchesLoaderNamingConvention_RejectsNonCompliantNames(string dllName)
+    {
+        var policy = MakePolicy(dllName);
+        // Lidarr.Plugin. (with trailing dot, no name, no .dll) IS rejected because
+        // it does not end with .dll. Pure-string check: starts with prefix AND ends with .dll.
+        Assert.Throws<TrueException>(
+            () => PluginPackagingContract.AssertMainDllMatchesLoaderNamingConvention(policy));
+    }
+
+    [Fact]
+    public void AssertMainDllMatchesLoaderNamingConvention_ErrorMessageMentionsLoaderSource()
+    {
+        var policy = MakePolicy("AppleMusicarr.Plugin.dll");
+        var ex = Assert.Throws<TrueException>(
+            () => PluginPackagingContract.AssertMainDllMatchesLoaderNamingConvention(policy));
+        Assert.Contains("Lidarr.Plugin.*.dll", ex.Message);
+        Assert.Contains("PathExtensions.cs:334", ex.Message);
+        Assert.Contains("AssemblyName", ex.Message);
+    }
+
+    [Fact]
+    public void AssertMainDllMatchesLoaderNamingConvention_NullPolicy_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => PluginPackagingContract.AssertMainDllMatchesLoaderNamingConvention(null!));
+    }
+
+    private static PluginPackagePolicy MakePolicy(string mainDll) => new(
+        MainDllName: mainDll,
+        RequiredFiles: new List<string> { mainDll, "plugin.json" },
+        ForbiddenAssemblies: Array.Empty<string>(),
+        MainDllMinimumBytes: 0);
+}


### PR DESCRIPTION
## Summary

Three static-assertion helpers in `testkit/Compliance/` that lift ~500 lines of duplicated test-contract code currently spread across the four RicherTunes plugins (brainarr/qobuzarr/tidalarr/applemusicarr). Each plugin's per-contract test class becomes ~10 lines of glue instead of ~70-194 lines.

## Contracts added

1. **`PluginVersionContract`** — catches drift between AssemblyVersion / plugin.json / VERSION file / manifest.json. Each plugin's previous `VersionContractTests` was a copy-paste of the same 3 `LocatePluginJson`/`LocateRepoFile` helpers plus 2-3 assertions.

2. **`PluginPackagingContract`** — declarative `PluginPackagePolicy` record + `AssertZipMatchesPolicy` helper. Ships two presets:
   - `DefaultForbiddenHostAssemblies` (host contracts + Lidarr.*.dll + NzbDrone.*.dll — applies to ALL plugins)
   - `MergedPluginForbiddenAssemblies` (above + `Lidarr.Plugin.{Common,Abstractions}.dll` — for ILRepack-merged plugins; sidecars regress multi-plugin co-existence)
   - `MergedDllPolicy(name)` convenience constructor

3. **`PublishedReleaseInstallabilityContract`** — simulates Lidarr's `PluginService.GetRemotePlugin` filter against the LIVE GitHub releases API, then downloads the matching asset and delegates zip validation to `PluginPackagingContract`. Tests are opt-in via `[Trait("Category", "ReleaseE2E")]` and `Skip` cleanly on network/rate-limit issues. Honors `GITHUB_TOKEN`.

The contracts intentionally use **static helpers** (not abstract test bases) so a plugin can pick-and-choose which assertions apply — e.g. qobuzarr has no manifest.json so skips that assertion; applemusicarr has no merged DLL so sets `MergedDllPolicy(... minBytes: 0)`.

## Test plan

- [x] Common TestKit builds clean (0 errors / 0 warnings)
- [ ] Adoption PR in each of the 4 plugins follows; each plugin's existing VersionContract / PackagingPolicy / PublishedReleaseInstallability tests collapse to ~10-line glue files

## Background

This is the next step in the May 2026 install-failure post-mortem. The contracts codify the exact failure modes that broke install:
- Asset name didn't contain `net8.0.zip` → install spinner hangs forever
- Asset shipped sidecar host DLLs → install completes but plugin crashes with "Could not load Lidarr.Plugin.Abstractions / Common"
- AssemblyVersion drifted from VERSION → `/api/v1/system/plugins` reports stale installedVersion

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>