### PR TITLE
cleanup: drop cargo-cult catches around type-safe TryGetValue

### DIFF
--- a/src/Utilities/HttpClientExtensions.cs
+++ b/src/Utilities/HttpClientExtensions.cs
@@ -1136,30 +1136,14 @@ namespace Lidarr.Plugin.Common.Utilities
             string canonical = string.Empty;
             string scope = string.Empty;
 
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.EndpointKey, out string? ep) && ep != null)
-                    endpoint = ep;
-            }
-            catch (Exception swallowEx) { SwallowToTrace(swallowEx); }
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ProfileKey, out string? pr) && pr != null)
-                    profile = pr;
-            }
-            catch (Exception swallowEx) { SwallowToTrace(swallowEx); }
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ParametersKey, out string? ca) && ca != null)
-                    canonical = ca;
-            }
-            catch (Exception swallowEx) { SwallowToTrace(swallowEx); }
-            try
-            {
-                if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.AuthScopeKey, out string? sc) && sc != null)
-                    scope = sc;
-            }
-            catch (Exception swallowEx) { SwallowToTrace(swallowEx); }
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.EndpointKey, out string? ep) && ep != null)
+                endpoint = ep;
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ProfileKey, out string? pr) && pr != null)
+                profile = pr;
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.ParametersKey, out string? ca) && ca != null)
+                canonical = ca;
+            if (request.Options.TryGetValue(Services.Http.PluginHttpOptions.AuthScopeKey, out string? sc) && sc != null)
+                scope = sc;
 
             var parts = new[] { method, authority, endpoint, canonical, scope, profile };
             return HashingUtility.ComputeSHA256(string.Join("\n", parts));


### PR DESCRIPTION
## Summary
Re-baselined clean replay of #491 on top of Wave-22-28 mega-merge.

Four consecutive `try/catch` blocks wrapped `HttpRequestOptions.TryGetValue` calls in `BuildRequestDedupKey`. The keys are strongly-typed `HttpRequestOptionsKey<string>` and `TryGetValue` returns `false` on a missing key — there is no exception path to catch. The catches only added noise (routing a non-existent exception to `SwallowToTrace`).

Removing them restores the diagnostic surface: if the framework ever does throw here, we want to know rather than silently swallow.

`SwallowToTrace` itself is retained — it has ~30 legitimate call sites elsewhere in the file.

## Rebase note
Original #491 was based pre-Wave-22-28. Current main had already converted the bare `catch {}` to `catch (Exception swallowEx) { SwallowToTrace(swallowEx); }`, but the try/catch wrappers were still unnecessary. Cherry-picked the substantive commit onto current main and resolved the 3-way conflict in favour of the PR intent (drop the wrappers entirely).

## Test plan
- [x] `src/Lidarr.Plugin.Common.csproj` builds clean (0 errors, 0 warnings — note `TreatWarningsAsErrors` + extended analyzers active).
- [ ] CI: full build + tests.

Supersedes #491.