### PR TITLE
feat(http): RateLimitHeaderUtilities — lift Retry-After + endpoint-key helpers from plugins

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -45,3 +45,8 @@ Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Message.in
 static Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Ok() -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result
 static Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Fail(Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason reason, string! message) -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result
 static Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Validate(string? path) -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result
+Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities
+static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.ResolveRetryAfter(System.Net.Http.Headers.RetryConditionHeaderValue? retryAfter) -> System.TimeSpan
+static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.ResolveRetryAfter(System.Net.Http.HttpResponseMessage? response) -> System.TimeSpan
+static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.BuildHostFirstSegmentKey(System.Net.Http.HttpRequestMessage! request, string! unknownKey = "unknown") -> string!
+static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.BuildHostFirstSegmentKey(System.Uri? uri, string! unknownKey = "unknown") -> string!

--- a/src/Services/Http/RateLimitHeaderUtilities.cs
+++ b/src/Services/Http/RateLimitHeaderUtilities.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Lidarr.Plugin.Common.Services.Http
+{
+    /// <summary>
+    /// Utilities for parsing HTTP rate-limit-related headers, and for deriving
+    /// stable endpoint keys used by <see cref="Performance.IUniversalAdaptiveRateLimiter"/>.
+    ///
+    /// Centralises logic that was previously duplicated across plugin-specific
+    /// DelegatingHandlers (tidalarr's <c>TidalRateLimitingHandler</c> and qobuzarr's
+    /// <c>QobuzRateLimitingHandler</c>).
+    /// </summary>
+    public static class RateLimitHeaderUtilities
+    {
+        /// <summary>
+        /// Resolve a <see cref="RetryConditionHeaderValue"/> (the <c>Retry-After</c> header)
+        /// to a positive <see cref="TimeSpan"/> delay, or <see cref="TimeSpan.Zero"/> when
+        /// the header is absent or describes a time already in the past.
+        ///
+        /// Behaviour mirrors what tidalarr and qobuzarr both implemented inline:
+        /// - Prefer the delta-seconds form if present.
+        /// - Otherwise interpret the HTTP-date form as "wait until that absolute UTC time".
+        /// - Past dates and missing values both return <see cref="TimeSpan.Zero"/> so callers
+        ///   can treat "no wait" uniformly.
+        /// </summary>
+        /// <param name="retryAfter">The header value parsed by <see cref="HttpResponseMessage.Headers"/>.</param>
+        /// <returns>A non-negative delay; <see cref="TimeSpan.Zero"/> when no wait is implied.</returns>
+        public static TimeSpan ResolveRetryAfter(RetryConditionHeaderValue? retryAfter)
+        {
+            if (retryAfter is null) return TimeSpan.Zero;
+            if (retryAfter.Delta is { } delta) return delta > TimeSpan.Zero ? delta : TimeSpan.Zero;
+            if (retryAfter.Date is { } date)
+            {
+                TimeSpan untilDate = date - DateTimeOffset.UtcNow;
+                return untilDate > TimeSpan.Zero ? untilDate : TimeSpan.Zero;
+            }
+            return TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// Convenience overload that pulls the <c>Retry-After</c> header off a response
+        /// and resolves it in one step. Returns <see cref="TimeSpan.Zero"/> when the
+        /// response is null or carries no <c>Retry-After</c> header.
+        /// </summary>
+        public static TimeSpan ResolveRetryAfter(HttpResponseMessage? response)
+        {
+            if (response is null) return TimeSpan.Zero;
+            return ResolveRetryAfter(response.Headers.RetryAfter);
+        }
+
+        /// <summary>
+        /// Build a rate-limiter endpoint key from a request URI using host + first path
+        /// segment. This balances specificity (distinct API surfaces get independent
+        /// budgets) against cardinality (a per-item URL doesn't produce a unique bucket
+        /// per request).
+        ///
+        /// Examples:
+        /// <list type="bullet">
+        ///   <item><c>https://api.tidal.com/v1/search?q=foo</c> → <c>api.tidal.com:v1</c></item>
+        ///   <item><c>https://sp-ap-eu.audio.tidal.com/.../seg.mp4</c> → <c>sp-ap-eu.audio.tidal.com:</c></item>
+        ///   <item><c>https://www.qobuz.com/api.json/0.2/album/get</c> → <c>www.qobuz.com:api.json</c></item>
+        /// </list>
+        /// </summary>
+        /// <param name="request">The outgoing HTTP request.</param>
+        /// <param name="unknownKey">Key to return when the request URI is null.</param>
+        /// <returns>A stable per-endpoint key suitable for keying a rate limiter.</returns>
+        public static string BuildHostFirstSegmentKey(HttpRequestMessage request, string unknownKey = "unknown")
+        {
+            if (request is null) throw new ArgumentNullException(nameof(request));
+            return BuildHostFirstSegmentKey(request.RequestUri, unknownKey);
+        }
+
+        /// <summary>
+        /// Build a rate-limiter endpoint key from a URI using host + first path segment.
+        /// See <see cref="BuildHostFirstSegmentKey(HttpRequestMessage, string)"/> for examples.
+        /// </summary>
+        public static string BuildHostFirstSegmentKey(Uri? uri, string unknownKey = "unknown")
+        {
+            if (uri is null) return unknownKey;
+            string host = uri.Host;
+            string firstSeg = uri.Segments.Length > 1 ? uri.Segments[1].TrimEnd('/') : string.Empty;
+            return host + ":" + firstSeg;
+        }
+    }
+}

--- a/tests/RateLimitHeaderUtilitiesTests.cs
+++ b/tests/RateLimitHeaderUtilitiesTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Lidarr.Plugin.Common.Services.Http;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    public class RateLimitHeaderUtilitiesTests
+    {
+        [Fact]
+        public void ResolveRetryAfter_NullHeader_ReturnsZero()
+        {
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter((RetryConditionHeaderValue?)null));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_DeltaForm_ReturnsDelta()
+        {
+            var header = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+            Assert.Equal(TimeSpan.FromSeconds(30), RateLimitHeaderUtilities.ResolveRetryAfter(header));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_NegativeDelta_ClampedToZero()
+        {
+            // RetryConditionHeaderValue itself rejects negative deltas via its constructor,
+            // but we still verify the utility's contract for "past dates" via the date form.
+            var pastDate = DateTimeOffset.UtcNow.AddMinutes(-5);
+            var header = new RetryConditionHeaderValue(pastDate);
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter(header));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_FutureDate_ReturnsPositiveDelay()
+        {
+            var futureDate = DateTimeOffset.UtcNow.AddSeconds(45);
+            var header = new RetryConditionHeaderValue(futureDate);
+            var delay = RateLimitHeaderUtilities.ResolveRetryAfter(header);
+            Assert.InRange(delay.TotalSeconds, 30, 60);
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_ResponseOverload_HandlesMissingHeader()
+        {
+            using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter(response));
+        }
+
+        [Fact]
+        public void ResolveRetryAfter_ResponseOverload_NullResponse_ReturnsZero()
+        {
+            Assert.Equal(TimeSpan.Zero, RateLimitHeaderUtilities.ResolveRetryAfter((HttpResponseMessage?)null));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_TidalSearch_ReturnsApiPlusV1()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "https://api.tidal.com/v1/search?q=foo");
+            Assert.Equal("api.tidal.com:v1", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_QobuzApiJson_ReturnsApiJsonSegment()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "https://www.qobuz.com/api.json/0.2/album/get");
+            Assert.Equal("www.qobuz.com:api.json", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_HostOnly_ReturnsEmptyFirstSegment()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "https://example.com/");
+            Assert.Equal("example.com:", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_NullUri_ReturnsUnknownKey()
+        {
+            using var req = new HttpRequestMessage();
+            Assert.Equal("unknown", RateLimitHeaderUtilities.BuildHostFirstSegmentKey(req));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_CustomUnknownKey_Honored()
+        {
+            Assert.Equal("anonymous", RateLimitHeaderUtilities.BuildHostFirstSegmentKey((Uri?)null, "anonymous"));
+        }
+
+        [Fact]
+        public void BuildHostFirstSegmentKey_NullRequest_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => RateLimitHeaderUtilities.BuildHostFirstSegmentKey((HttpRequestMessage)null!));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Re-baselined clean replay of #492 on top of Wave-22-28 mega-merge.

Lifts two helpers that were duplicated verbatim across plugins into a new `Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities`:

- **`ResolveRetryAfter`** — parses `RetryConditionHeaderValue` into a non-negative `TimeSpan` (prefers delta form, falls back to HTTP-date, clamps past dates to zero). Mirrors the inline helpers in tidalarr's `TidalRateLimitingHandler` and qobuzarr's `QobuzRateLimitingHandler` (verified byte-for-byte equivalent in the unification audit). Includes an `HttpResponseMessage` overload.
- **`BuildHostFirstSegmentKey`** — derives a stable host+first-path-segment key for `IUniversalAdaptiveRateLimiter` (e.g. `api.tidal.com:v1`). `HttpRequestMessage` + `Uri` overloads.

12 unit tests cover delta/date/null/past/future paths plus the response and null-URI edge cases.

## Coexistence with main
Main already ships `HttpResponseHelpers.ParseRetryAfter(IEnumerable<KeyValuePair>)` (Wave-22) — that one parses a raw header-string sequence. `RateLimitHeaderUtilities.ResolveRetryAfter` operates on the already-typed `RetryConditionHeaderValue`/`HttpResponseMessage` and additionally provides the endpoint-key builder, so the two are complementary, not duplicative. No symbol collision.

## Rebase note
Original #492 carried pre-Wave-22-28 release commits. Cherry-picked only the substantive feature commit onto current main (clean apply, both files new), and added a follow-up commit recording the four new public members in `PublicAPI/net8.0/PublicAPI.Unshipped.txt` to match repo convention.

## Test plan
- [x] `src/Lidarr.Plugin.Common.csproj` builds clean.
- [x] 12/12 `RateLimitHeaderUtilitiesTests` pass locally (Release).
- [ ] CI: full build + tests.

Supersedes #492.