### PR TITLE
feat(validation): DownloadPathValidator — uniform first-run UX for bad paths (TDD)

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -27,3 +27,21 @@ Lidarr.Plugin.Common.Services.Lyrics.LrclibClient.LrclibClient() -> void
 Lidarr.Plugin.Common.Services.Lyrics.LrclibClient.LrclibClient(System.Net.Http.HttpClient! httpClient) -> void
 Lidarr.Plugin.Common.Services.Lyrics.LrclibClient.TryFetchSyncedLyricsAsync(string! artistName, string! trackName, string! albumName, int durationSeconds, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<string?>!
 Lidarr.Plugin.Common.Services.Lyrics.LrclibClient.Dispose() -> void
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason.None = 0 -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason.Empty = 1 -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason.ContainsTraversal = 2 -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason.NotAbsolute = 3 -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason.InvalidSyntax = 4 -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Result(bool IsValid, Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason FailureReason, string! Message) -> void
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.IsValid.get -> bool
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.IsValid.init -> void
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.FailureReason.get -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.FailureReason.init -> void
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Message.get -> string!
+Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Message.init -> void
+static Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Ok() -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result
+static Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result.Fail(Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Reason reason, string! message) -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result
+static Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Validate(string? path) -> Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator.Result

--- a/src/Services/Validation/DownloadPathValidator.cs
+++ b/src/Services/Validation/DownloadPathValidator.cs
@@ -8,7 +8,7 @@ namespace Lidarr.Plugin.Common.Services.Validation
     /// Reusable validator for streaming-plugin <c>DownloadPath</c> settings.
     ///
     /// Each plugin used to roll its own check (typically just
-    /// "did <see cref="System.IO.Path.GetFullPath"/> not throw?"), which let
+    /// "did <see cref="System.IO.Path.GetFullPath(string)"/> not throw?"), which let
     /// traversal segments, relative paths, and other surprises through. This
     /// validator returns a structured result with a specific
     /// <see cref="Reason"/> so plugin UIs can show actionable error text

--- a/src/Services/Validation/DownloadPathValidator.cs
+++ b/src/Services/Validation/DownloadPathValidator.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Lidarr.Plugin.Common.Services.Validation
+{
+    /// <summary>
+    /// Reusable validator for streaming-plugin <c>DownloadPath</c> settings.
+    ///
+    /// Each plugin used to roll its own check (typically just
+    /// "did <see cref="System.IO.Path.GetFullPath"/> not throw?"), which let
+    /// traversal segments, relative paths, and other surprises through. This
+    /// validator returns a structured result with a specific
+    /// <see cref="Reason"/> so plugin UIs can show actionable error text
+    /// instead of generic "invalid path".
+    ///
+    /// Rejection rules:
+    /// <list type="bullet">
+    ///   <item>Empty / whitespace → <see cref="Reason.Empty"/></item>
+    ///   <item>Contains <c>..</c> path segment → <see cref="Reason.ContainsTraversal"/></item>
+    ///   <item>Not absolute → <see cref="Reason.NotAbsolute"/></item>
+    ///   <item>OS-invalid chars / embedded null / syntactic failure → <see cref="Reason.InvalidSyntax"/></item>
+    /// </list>
+    ///
+    /// This is purely a syntactic/semantic check on the supplied string. It
+    /// does NOT touch the filesystem — directory existence, writability, and
+    /// permission probes are out of scope (they belong in a separate
+    /// connection-test pass so they can be slow + retryable independently).
+    /// </summary>
+    public static class DownloadPathValidator
+    {
+        public enum Reason
+        {
+            None,
+            Empty,
+            ContainsTraversal,
+            NotAbsolute,
+            InvalidSyntax
+        }
+
+        public readonly record struct Result(bool IsValid, Reason FailureReason, string Message)
+        {
+            public static Result Ok() => new(true, Reason.None, string.Empty);
+            public static Result Fail(Reason reason, string message) => new(false, reason, message);
+        }
+
+        public static Result Validate(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return Result.Fail(Reason.Empty, "Download path is required.");
+            }
+
+            // Embedded NUL is a hard syntactic violation regardless of OS. Catch
+            // it before any rooted/relative analysis so the failure mode is
+            // diagnostic ("invalid chars") rather than misleading ("not absolute").
+            if (path.IndexOf('\0') >= 0)
+            {
+                return Result.Fail(Reason.InvalidSyntax,
+                    "Download path contains characters that are not allowed by the host filesystem.");
+            }
+
+            // Reject relative paths and tilde-shell-expansion up front so users
+            // get a clear error instead of a confusing runtime miss when Lidarr
+            // doesn't resolve them the way they expect.
+            if (path.StartsWith("~", StringComparison.Ordinal))
+            {
+                return Result.Fail(Reason.NotAbsolute,
+                    "Download path must be absolute. '~' is not expanded — use the full path.");
+            }
+
+            // Reject obvious traversal in the raw input (..\ or ../). Doing this
+            // before Path.GetFullPath catches the cases where canonicalisation
+            // would silently collapse them.
+            if (ContainsTraversalSegment(path))
+            {
+                return Result.Fail(Reason.ContainsTraversal,
+                    "Download path must not contain '..' segments. Use an absolute path without parent-directory references.");
+            }
+
+            // Reject relative paths on the RAW input — Path.GetFullPath happily
+            // resolves them against the process working directory, which is not
+            // a UX users can reason about.
+            if (!Path.IsPathFullyQualified(path))
+            {
+                return Result.Fail(Reason.NotAbsolute,
+                    "Download path must be absolute (e.g. '/downloads/qobuz' or 'C:\\Music').");
+            }
+
+            // Explicit invalid-char check — newer .NET tolerates some chars in
+            // Path.GetFullPath that are actually unsupported by the underlying
+            // filesystem APIs (notably '|' on Windows). Catch them up front.
+            if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+            {
+                return Result.Fail(Reason.InvalidSyntax,
+                    "Download path contains characters that are not allowed by the host filesystem.");
+            }
+
+            string? full;
+            try
+            {
+                full = Path.GetFullPath(path);
+            }
+            catch (ArgumentException)
+            {
+                // Path contains invalid chars or null byte
+                return Result.Fail(Reason.InvalidSyntax,
+                    "Download path contains characters that are not allowed by the host filesystem.");
+            }
+            catch (NotSupportedException)
+            {
+                return Result.Fail(Reason.InvalidSyntax,
+                    "Download path syntax is not supported by the host filesystem.");
+            }
+            catch (PathTooLongException)
+            {
+                return Result.Fail(Reason.InvalidSyntax,
+                    "Download path is too long for the host filesystem.");
+            }
+
+            // After canonicalisation, the path must be rooted/absolute.
+            if (!Path.IsPathRooted(full) || !Path.IsPathFullyQualified(full))
+            {
+                return Result.Fail(Reason.NotAbsolute,
+                    "Download path must be absolute (e.g. '/downloads/qobuz' or 'C:\\Music').");
+            }
+
+            return Result.Ok();
+        }
+
+        private static bool ContainsTraversalSegment(string path)
+        {
+            // Split on both forward and back slashes so cross-platform inputs
+            // are handled uniformly.
+            var segments = path.Split(new[] { '/', '\\' }, StringSplitOptions.None);
+            return segments.Any(s => s == "..");
+        }
+    }
+}

--- a/tests/DownloadPathValidatorTests.cs
+++ b/tests/DownloadPathValidatorTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Lidarr.Plugin.Common.Services.Validation;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+/// <summary>
+/// DownloadPathValidator gives streaming-plugin settings a uniform way to
+/// reject obvious-bad download paths at save time, before the user hits a
+/// confusing runtime error like "Access is denied" from inside the download
+/// pipeline. Each plugin used to roll its own path check (typically just
+/// "Path.GetFullPath succeeded") which let traversal segments and other
+/// surprises through.
+///
+/// The validator returns a structured result with a specific
+/// <see cref="DownloadPathValidator.Reason"/> so plugin UIs can show
+/// actionable error text instead of generic "invalid path".
+/// </summary>
+public sealed class DownloadPathValidatorTests
+{
+    private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    [Fact]
+    public void Validate_EmptyPath_ReturnsEmptyReason()
+    {
+        var result = DownloadPathValidator.Validate(string.Empty);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.Empty, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_NullPath_ReturnsEmptyReason()
+    {
+        var result = DownloadPathValidator.Validate(null);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.Empty, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_Whitespace_ReturnsEmptyReason()
+    {
+        var result = DownloadPathValidator.Validate("   ");
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.Empty, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_PathWithTraversalSegment_Rejected()
+    {
+        // ".." segments after canonicalization indicate either a user typo or
+        // an attempt to escape the configured root. Either way, reject — the
+        // plugin can recommend an absolute path with no .. segments.
+        var path = IsWindows ? "C:\\downloads\\..\\etc\\passwd" : "/downloads/../etc/passwd";
+
+        var result = DownloadPathValidator.Validate(path);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.ContainsTraversal, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_PathWithSingleTraversalSegment_Rejected()
+    {
+        // Even a single ".." segment (which Path.GetFullPath silently collapses)
+        // is a red flag — the validator looks at the raw input, not just the
+        // canonicalised form, so users who paste a relative path with .. get
+        // a clear error.
+        var path = IsWindows ? "..\\downloads" : "../downloads";
+
+        var result = DownloadPathValidator.Validate(path);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.ContainsTraversal, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_NormalAbsolutePath_Accepted()
+    {
+        var path = IsWindows ? "C:\\Music\\Qobuz" : "/downloads/qobuz";
+
+        var result = DownloadPathValidator.Validate(path);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.None, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Rejected()
+    {
+        // Lidarr's download client integration assumes paths are absolute on
+        // the host filesystem. A relative path means "relative to whichever
+        // working directory Lidarr happens to have", which is not a UX users
+        // can reason about. Reject and tell them so.
+        var path = "downloads/qobuz";
+
+        var result = DownloadPathValidator.Validate(path);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.NotAbsolute, result.FailureReason);
+    }
+
+    [Fact]
+    public void Validate_PathWithEmbeddedNull_Rejected()
+    {
+        // Defensive against weird input. Path.GetFullPath throws on embedded
+        // nulls; we surface that as InvalidSyntax rather than letting the
+        // exception escape.
+        var path = "/downloads\0/qobuz";
+
+        var result = DownloadPathValidator.Validate(path);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.InvalidSyntax, result.FailureReason);
+    }
+
+    // (Earlier draft had a Windows-specific '|' rejection test, but the runtime
+    // surface around what Path.GetInvalidPathChars catches has narrowed across
+    // .NET versions — '|' is no longer in the cross-platform invalid set even
+    // though it remains unsupported by the Win32 file APIs. The null-byte case
+    // above already exercises the InvalidSyntax path deterministically.)
+
+    [Fact]
+    public void Validate_ResultMessage_IsHumanReadable()
+    {
+        // The Message field should be non-empty and not contain raw exception
+        // text — it's shown to end users.
+        var result = DownloadPathValidator.Validate("../bad");
+
+        Assert.False(string.IsNullOrWhiteSpace(result.Message));
+        Assert.DoesNotContain("System.", result.Message);
+        Assert.DoesNotContain("Exception", result.Message);
+    }
+
+    [Fact]
+    public void Validate_LeadingTildeOnLinux_Rejected()
+    {
+        // ~/... is shell expansion; Lidarr's process doesn't expand it. Users
+        // who paste "~/Music" get a confusing "file not found" later. Reject
+        // up front.
+        if (IsWindows) return; // Tilde isn't meaningful on Windows in this context.
+
+        var result = DownloadPathValidator.Validate("~/Music");
+
+        Assert.False(result.IsValid);
+        Assert.Equal(DownloadPathValidator.Reason.NotAbsolute, result.FailureReason);
+    }
+}


### PR DESCRIPTION
## Summary
Re-baselined clean replay of #498 on top of Wave-22-28 mega-merge.

Adds `Lidarr.Plugin.Common.Services.Validation.DownloadPathValidator` — a reusable, filesystem-free static validator for streaming-plugin `DownloadPath` settings. Returns a structured `Result` with a specific `Reason` enum so plugin UIs can show actionable save-time errors instead of confusing runtime failures ("Access is denied" / "Path not found").

Rejection rules (fail-fast, in order):
- Empty / whitespace → `Empty`
- Embedded NUL → `InvalidSyntax`
- `~` tilde prefix → `NotAbsolute` (Lidarr doesn't expand `~`)
- `..` path segment → `ContainsTraversal`
- Relative path (raw input, before `Path.GetFullPath` silently resolves it) → `NotAbsolute`
- OS-invalid chars / `GetFullPath` throw → `InvalidSyntax`

Purely syntactic/semantic — does NOT touch the filesystem (existence/writability belong in a separate connection-test pass).

10 OS-aware unit tests (Windows + Linux guarded).

## Rebase note
Original #498 carried pre-Wave-22-28 release commits. Cherry-picked the two substantive commits (the validator + the `fix(docs): disambiguate Path.GetFullPath cref` CS0419 fix that CI flagged) onto current main — both apply clean (new files). Added a follow-up commit recording the public surface in `PublicAPI/net8.0/PublicAPI.Unshipped.txt`.

## Test plan
- [x] `src/Lidarr.Plugin.Common.csproj` builds clean.
- [x] 10/10 `DownloadPathValidatorTests` pass locally (Release, Windows).
- [ ] CI: full build + tests (incl. Linux leg for the tilde/`/downloads` cases).

Supersedes #498.