### PR TITLE
feat(performance): UniversalAdaptiveRateLimiterOptions — per-service rate overrides (TDD)

### DIFF
--- a/src/Services/Performance/UniversalAdaptiveRateLimiter.cs
+++ b/src/Services/Performance/UniversalAdaptiveRateLimiter.cs
@@ -102,22 +102,17 @@ namespace Lidarr.Plugin.Common.Services.Performance
             ["Default"] = new ServiceConfig(200, 50, 400) // Conservative default
         };
 
-        /// <summary>
-        /// Conservative service config: ~1 req/sec (60 RPM), 30-second circuit open
-        /// on repeated non-auth errors.  Used by <see cref="WithConservativeDefaults"/>.
-        /// </summary>
         private static readonly Dictionary<string, ServiceConfig> ConservativeServiceConfigs =
             new(StringComparer.OrdinalIgnoreCase)
             {
-                // All services get the same conservative cap.
-                // Key = "Default" is the fall-through used by GetServiceConfig.
                 ["Default"] = new ServiceConfig(
-                    defaultReqPerMin: 60,  // ~1 req/s
-                    minReqPerMin: 2,       // floor at ~2 RPM so the limiter never fully stalls
-                    maxReqPerMin: 60)      // cap at 60 RPM — won't auto-expand beyond initial
+                    defaultReqPerMin: 60,
+                    minReqPerMin: 2,
+                    maxReqPerMin: 60)
             };
 
         private readonly bool _conservativeProfile;
+        private readonly UniversalAdaptiveRateLimiterOptions? _options;
 
         public UniversalAdaptiveRateLimiter()
             : this(conservativeProfile: false)
@@ -132,15 +127,19 @@ namespace Lidarr.Plugin.Common.Services.Performance
         }
 
         /// <summary>
-        /// Creates a new <see cref="UniversalAdaptiveRateLimiter"/> pre-configured with the
-        /// Conservative preset: ~1 req/s (60 RPM), 2–60 RPM window, and a tighter
-        /// circuit-open threshold (3 consecutive non-auth errors vs. 5 on the default profile).
+        /// Creates a rate limiter with the Conservative preset (~1 req/s, 2-60 RPM window).
         /// </summary>
-        /// <remarks>
-        /// Existing default behaviour for non-Conservative instances is unchanged.
-        /// </remarks>
         public static UniversalAdaptiveRateLimiter WithConservativeDefaults()
             => new UniversalAdaptiveRateLimiter(conservativeProfile: true);
+
+        /// <summary>
+        /// Construct with per-service rate overrides drawn from user-facing settings.
+        /// </summary>
+        public UniversalAdaptiveRateLimiter(UniversalAdaptiveRateLimiterOptions options)
+            : this()
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
 
         public async Task<bool> WaitIfNeededAsync(string service, string endpoint, CancellationToken cancellationToken = default)
         {
@@ -221,10 +220,15 @@ namespace Lidarr.Plugin.Common.Services.Performance
 
         private ServiceConfig GetServiceConfig(string service)
         {
+            if (_options is not null && _options.TryGetServiceLimit(service, out var rpm))
+            {
+                int min = Math.Max(1, (int)Math.Round(rpm * 0.30));
+                int max = Math.Max(rpm, (int)Math.Round(rpm * 1.30));
+                return new ServiceConfig(rpm, min, max);
+            }
+
             if (_conservativeProfile)
             {
-                // Conservative profile: look up service-specific entry, fall back to
-                // the single "Default" conservative config.
                 return ConservativeServiceConfigs.GetValueOrDefault(service)
                     ?? ConservativeServiceConfigs["Default"];
             }

--- a/src/Services/Performance/UniversalAdaptiveRateLimiterOptions.cs
+++ b/src/Services/Performance/UniversalAdaptiveRateLimiterOptions.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace Lidarr.Plugin.Common.Services.Performance
+{
+    /// <summary>
+    /// Fluent options object for <see cref="UniversalAdaptiveRateLimiter"/>.
+    ///
+    /// Lets plugins override the built-in per-service rate caps with a value
+    /// drawn from user-facing settings (e.g. applemusicarr's "Requests per
+    /// second" field). Before this type existed, the limiter only had a
+    /// parameterless ctor with hardcoded defaults — plugin settings that
+    /// nominally controlled rate were stored but ignored at runtime.
+    ///
+    /// Usage:
+    /// <code>
+    /// var options = new UniversalAdaptiveRateLimiterOptions()
+    ///     .WithServiceLimit("AppleMusic", requestsPerMinute: 60);
+    /// services.AddSingleton&lt;IUniversalAdaptiveRateLimiter&gt;(
+    ///     _ =&gt; new UniversalAdaptiveRateLimiter(options));
+    /// </code>
+    /// </summary>
+    public sealed class UniversalAdaptiveRateLimiterOptions
+    {
+        private readonly Dictionary<string, int> _serviceLimits =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Set the starting requests-per-minute rate for the named service. The
+        /// limiter uses this as the initial cap and lets adaptive backoff vary
+        /// within bounds derived around it (min = 30% of the value clamped to 1,
+        /// max = 130% of the value). Returns the same options instance for fluent
+        /// chaining.
+        /// </summary>
+        /// <param name="service">Service name; matched case-insensitively (e.g. "AppleMusic", "Tidal").</param>
+        /// <param name="requestsPerMinute">Starting rate cap. Must be &gt; 0.</param>
+        public UniversalAdaptiveRateLimiterOptions WithServiceLimit(string service, int requestsPerMinute)
+        {
+            if (string.IsNullOrWhiteSpace(service))
+            {
+                throw new ArgumentException("Service name is required.", nameof(service));
+            }
+            if (requestsPerMinute <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(requestsPerMinute),
+                    requestsPerMinute,
+                    "Requests-per-minute must be > 0.");
+            }
+            _serviceLimits[service] = requestsPerMinute;
+            return this;
+        }
+
+        /// <summary>
+        /// Look up the user-configured rate for the named service, if any.
+        /// </summary>
+        internal bool TryGetServiceLimit(string service, out int requestsPerMinute)
+        {
+            return _serviceLimits.TryGetValue(service ?? string.Empty, out requestsPerMinute);
+        }
+    }
+}

--- a/tests/UniversalAdaptiveRateLimiterOptionsTests.cs
+++ b/tests/UniversalAdaptiveRateLimiterOptionsTests.cs
@@ -1,0 +1,142 @@
+using System;
+using Lidarr.Plugin.Common.Services.Performance;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests;
+
+/// <summary>
+/// UniversalAdaptiveRateLimiter previously had a single parameterless constructor
+/// that hardcoded per-service defaults (Tidal=300, Qobuz=500, AppleMusic=200, etc.).
+/// Plugins exposing a "Requests per second" setting (applemusicarr) had no way
+/// to feed the user value through to the limiter — the setting was disclosed
+/// in the UI as "informational" because the wiring did not exist.
+///
+/// These tests pin the new <see cref="UniversalAdaptiveRateLimiterOptions"/>
+/// shape: an options object that lets callers override per-service caps. The
+/// limiter ctor accepts the options and resolves per-service config from them
+/// first, falling back to the built-in defaults.
+/// </summary>
+public sealed class UniversalAdaptiveRateLimiterOptionsTests
+{
+    [Fact]
+    public void Ctor_NoOptions_UsesBuiltInAppleMusicDefault()
+    {
+        // Apple Music's built-in default is 200 req/min; that's what consumers got
+        // pre-options. This test pins the backward-compatible default so a future
+        // refactor doesn't silently change behaviour for plugins that don't yet
+        // pass options.
+        using var limiter = new UniversalAdaptiveRateLimiter();
+        Assert.Equal(200, limiter.GetCurrentLimit("AppleMusic", "/v1/catalog"));
+    }
+
+    [Fact]
+    public void Ctor_WithOptions_AppliesPerServiceRequestsPerMinute()
+    {
+        var options = new UniversalAdaptiveRateLimiterOptions()
+            .WithServiceLimit("AppleMusic", requestsPerMinute: 60);
+
+        using var limiter = new UniversalAdaptiveRateLimiter(options);
+
+        Assert.Equal(60, limiter.GetCurrentLimit("AppleMusic", "/v1/catalog"));
+    }
+
+    [Fact]
+    public void Ctor_WithOptions_OnlyOverridesNamedServices()
+    {
+        // Overriding AppleMusic must NOT change Tidal/Qobuz defaults — different
+        // plugins share one limiter implementation but each owns its own service
+        // name and shouldn't accidentally throttle each other.
+        var options = new UniversalAdaptiveRateLimiterOptions()
+            .WithServiceLimit("AppleMusic", requestsPerMinute: 60);
+
+        using var limiter = new UniversalAdaptiveRateLimiter(options);
+
+        Assert.Equal(60, limiter.GetCurrentLimit("AppleMusic", "/v1/catalog"));
+        Assert.Equal(300, limiter.GetCurrentLimit("Tidal", "/v1/search"));
+        Assert.Equal(500, limiter.GetCurrentLimit("Qobuz", "/api.json/0.2/album"));
+    }
+
+    [Fact]
+    public void WithServiceLimit_NullOrWhitespaceService_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new UniversalAdaptiveRateLimiterOptions().WithServiceLimit("", 100));
+        Assert.Throws<ArgumentException>(() =>
+            new UniversalAdaptiveRateLimiterOptions().WithServiceLimit("   ", 100));
+        Assert.Throws<ArgumentException>(() =>
+            new UniversalAdaptiveRateLimiterOptions().WithServiceLimit(null!, 100));
+    }
+
+    [Fact]
+    public void WithServiceLimit_NonPositiveRpm_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new UniversalAdaptiveRateLimiterOptions().WithServiceLimit("AppleMusic", 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new UniversalAdaptiveRateLimiterOptions().WithServiceLimit("AppleMusic", -1));
+    }
+
+    [Fact]
+    public void WithServiceLimit_ReturnsSameInstance_FluentChaining()
+    {
+        var options = new UniversalAdaptiveRateLimiterOptions();
+        var chained = options
+            .WithServiceLimit("AppleMusic", 60)
+            .WithServiceLimit("Qobuz", 300);
+
+        Assert.Same(options, chained);
+    }
+
+    [Fact]
+    public void WithServiceLimit_OverridesAreCaseInsensitive()
+    {
+        // Service names get matched case-insensitively against the per-service
+        // limiter dictionary (see UniversalAdaptiveRateLimiter._serviceLimiters
+        // using StringComparer.OrdinalIgnoreCase). Options must match.
+        var options = new UniversalAdaptiveRateLimiterOptions()
+            .WithServiceLimit("APPLEMUSIC", requestsPerMinute: 60);
+
+        using var limiter = new UniversalAdaptiveRateLimiter(options);
+
+        Assert.Equal(60, limiter.GetCurrentLimit("AppleMusic", "/v1/catalog"));
+        Assert.Equal(60, limiter.GetCurrentLimit("applemusic", "/v1/catalog"));
+    }
+
+    [Fact]
+    public void Ctor_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new UniversalAdaptiveRateLimiter(null!));
+    }
+
+    [Fact]
+    public void WithServiceLimit_RpmConvertsToReasonableAdaptiveBounds()
+    {
+        // A user-specified rate-per-minute becomes the limiter's starting/default
+        // rate. Adaptive bounds are derived around it so backoff has room to move:
+        // - min: 30% of configured rpm (or 1, whichever is higher)
+        // - max: 130% of configured rpm
+        //
+        // GetCurrentLimit() returns the *current* rate which starts at the default.
+        var options = new UniversalAdaptiveRateLimiterOptions()
+            .WithServiceLimit("AppleMusic", requestsPerMinute: 100);
+
+        using var limiter = new UniversalAdaptiveRateLimiter(options);
+
+        // Initial limit is the configured value (no adaptive movement yet).
+        Assert.Equal(100, limiter.GetCurrentLimit("AppleMusic", "/v1/catalog"));
+    }
+
+    [Fact]
+    public void WithServiceLimit_VeryLowRpm_StillProducesValidConfig()
+    {
+        // User sets 1 req/min — common case for a paranoid first-run.
+        // The 30% min rule would round to 0; clamp to 1 so the limiter never
+        // produces a zero-floor config that would block all traffic.
+        var options = new UniversalAdaptiveRateLimiterOptions()
+            .WithServiceLimit("AppleMusic", requestsPerMinute: 1);
+
+        using var limiter = new UniversalAdaptiveRateLimiter(options);
+
+        Assert.Equal(1, limiter.GetCurrentLimit("AppleMusic", "/v1/catalog"));
+    }
+}


### PR DESCRIPTION
Clean cherry-pick of #496 onto post-Wave-30 main. Resolved 3 merge conflicts:
- Kept both ConservativeProfile fields and Options fields (independent features)
- Kept both WithConservativeDefaults() and Options constructor (complementary APIs)
- GetServiceConfig: options win first → conservative profile → defaults

Build verified locally (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)