### PR TITLE
fix(testkit): null-guard body parameter in HttpResponseFactory.Error

### DIFF
--- a/testkit/Http/HttpResponseFactory.cs
+++ b/testkit/Http/HttpResponseFactory.cs
@@ -58,7 +58,7 @@ public static class HttpResponseFactory
     /// Creates an error response using the given request context.
     /// </summary>
     public static HttpResponse Error(HttpRequest req, HttpStatusCode status, string body = "")
-        => new(req, new HttpHeader(), Encoding.UTF8.GetBytes(body), status);
+        => new(req, new HttpHeader(), Encoding.UTF8.GetBytes(body ?? string.Empty), status);
 
     /// <summary>
     /// Creates an error response with raw byte body using the given request context.


### PR DESCRIPTION
## Summary
`Encoding.UTF8.GetBytes(body)` threw `ArgumentNullException` when callers passed null via `CreateResponse(null, statusCode)` — the default `body=""` only protects direct callers of `Error()`, not indirect paths through `CreateResponse` which passes content verbatim.

## Fix
One-token change: `body` → `body ?? string.Empty` at line 61. Matches the existing null-guard pattern in `Ok()` (line 38).

## Validation
Validated via brainarr's ModelDetectionServiceTests (5 cases that previously failed with ArgumentNullException). brainarr already has a shim-side workaround (`c5091ce`); this fixes the root cause in Common.

:robot: Generated with [Claude Code](https://claude.com/claude-code)