### PR TITLE
fix(scripts): initialize resolvedFlags in local-ci.ps1 (strict-mode fix)

### DIFF
--- a/scripts/local-ci.ps1
+++ b/scripts/local-ci.ps1
@@ -488,6 +488,7 @@ if ($SkipTests) {
 
             # Restore test project with build flags (separate from plugin csproj restore)
             $testRestoreArgs = @($testProj)
+            $resolvedFlags = @()
             if ($buildFlags) {
                 $resolvedFlags = $buildFlags | ForEach-Object {
                     $_ -replace '\{HOST_PATH\}', $hostPathAbsolute


### PR DESCRIPTION
One-liner: adds ` = @()` before the conditional block that may skip its assignment. Fixes applemusicarr verify-local.ps1 E2E stage failure.