### PR TITLE
fix(packaging): surface dotnet build output on failure (was Out-Null'd)

### DIFF
--- a/tools/PluginPack.psm1
+++ b/tools/PluginPack.psm1
@@ -26,10 +26,14 @@ function Get-PluginOutput {
     $buildArgs = @($projectPath, '-c', $Configuration, '-f', $Framework, '-o', $publishDirectory,
         '/p:CopyLocalLockFileAssemblies=true', '/p:ContinuousIntegrationBuild=true')
     if ($ExtraBuildArgs) { $buildArgs += $ExtraBuildArgs }
-    dotnet build @buildArgs | Out-Null
+    # Capture build output so failures are diagnosable. Previously piped to Out-Null,
+    # which made CI packaging failures impossible to triage (generic "dotnet build failed"
+    # with no compiler/MSBuild error). On failure, replay the captured output to stderr.
+    $buildOutput = & dotnet build @buildArgs 2>&1
 
     if ($LASTEXITCODE -ne 0) {
-        throw "dotnet build failed for $Csproj ($Framework|$Configuration)."
+        $buildOutput | ForEach-Object { Write-Host $_ }
+        throw "dotnet build failed for $Csproj ($Framework|$Configuration). See build output above."
     }
 
     return $publishDirectory


### PR DESCRIPTION
## Summary

`New-PluginPackage` piped `dotnet build` output to `Out-Null`, so any packaging-gates CI failure threw a generic `dotnet build failed` with **zero diagnostic detail**. This is why the recent brainarr Packaging Gates failures were impossible to triage. Now the output is captured and replayed on failure before throwing.

## Context

While investigating brainarr Packaging Gates failures (the only non-billing-blocked plugin), I confirmed:
- Host assembly extraction works (394 assemblies extracted)
- Packaging succeeds locally via `New-PluginPackage` (both 9-DLL and 396-DLL host sets)
- CI fails at `dotnet build` with the error hidden by `Out-Null`

This change makes the next CI run show the actual compiler/MSBuild error (likely a `nullable`/`CS0618` warning-as-error against the `pr-plugins-3.1.2.4913` Lidarr assemblies).

## Test plan

- [x] Module loads after edit
- [x] Local packaging still succeeds and produces a valid zip
- [ ] Next CI run surfaces the real build error

🤖 Generated with [Claude Code](https://claude.com/claude-code)