### PR TITLE
fix(packaging): make PluginPackaging.targets work on Linux

### DIFF
--- a/build/Inject-PluginBuildMetadata.ps1
+++ b/build/Inject-PluginBuildMetadata.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Injects gitSha + buildTimestamp into a plugin manifest (plugin.json).
+.DESCRIPTION
+    Extracted from an inline MSBuild Exec command. Inline pwsh commands break on
+    Linux because MSBuild runs them through /bin/sh, which expands the PowerShell
+    `$variable` sigils as (empty) shell variables before pwsh parses them — e.g.
+    `$manifest | Add-Member` becomes ` | Add-Member` ("empty pipe element").
+    Passing the values as -File parameters avoids that entirely.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$ManifestPath,
+    [Parameter(Mandatory = $true)][string]$GitSha,
+    [Parameter(Mandatory = $true)][string]$BuildTimestamp
+)
+
+$ErrorActionPreference = 'Stop'
+
+$manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+$manifest | Add-Member -NotePropertyName 'gitSha' -NotePropertyValue $GitSha -Force
+$manifest | Add-Member -NotePropertyName 'buildTimestamp' -NotePropertyValue $BuildTimestamp -Force
+$manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $ManifestPath -Encoding UTF8

--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -205,17 +205,21 @@
       <_PluginBuildTimestamp>$([System.DateTime]::UtcNow.ToString("o"))</_PluginBuildTimestamp>
     </PropertyGroup>
 
-    <!-- Inject gitSha and buildTimestamp into plugin.json using PowerShell (cross-platform) -->
-    <Exec Command="pwsh -NoProfile -NonInteractive -Command &quot;$manifest = Get-Content -LiteralPath '$(_PluginManifestPath)' -Raw | ConvertFrom-Json; $manifest | Add-Member -NotePropertyName 'gitSha' -NotePropertyValue '$(_PluginGitSha)' -Force; $manifest | Add-Member -NotePropertyName 'buildTimestamp' -NotePropertyValue '$(_PluginBuildTimestamp)' -Force; $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath '$(_PluginManifestPath)' -Encoding UTF8&quot;"
+    <!-- Inject gitSha and buildTimestamp into plugin.json via pwsh -File (cross-platform).
+         -File (not -Command) keeps the PowerShell $variables inside the .ps1 so /bin/sh on
+         Linux cannot expand them as empty shell variables — inline -Command corrupts to e.g.
+         " | Add-Member" ("empty pipe element") because $manifest is stripped before pwsh sees it. -->
+    <Exec Command="pwsh -NoProfile -NonInteractive -File &quot;$(MSBuildThisFileDirectory)Inject-PluginBuildMetadata.ps1&quot; -ManifestPath &quot;$(_PluginManifestPath)&quot; -GitSha &quot;$(_PluginGitSha)&quot; -BuildTimestamp &quot;$(_PluginBuildTimestamp)&quot;"
           Condition="Exists('$(_PluginManifestPath)')"
           StandardOutputImportance="low"
           IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_PwshExitCode" />
     </Exec>
 
-    <!-- Fallback to powershell.exe on Windows if pwsh is not available -->
-    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;$manifest = Get-Content -LiteralPath '$(_PluginManifestPath)' -Raw | ConvertFrom-Json; $manifest | Add-Member -NotePropertyName 'gitSha' -NotePropertyValue '$(_PluginGitSha)' -Force; $manifest | Add-Member -NotePropertyName 'buildTimestamp' -NotePropertyValue '$(_PluginBuildTimestamp)' -Force; $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath '$(_PluginManifestPath)' -Encoding UTF8&quot;"
-          Condition="Exists('$(_PluginManifestPath)') and '$(_PwshExitCode)' != '0'"
+    <!-- Fallback to Windows PowerShell, but ONLY on Windows — `powershell` does not exist on
+         Linux/macOS, so an unconditional fallback fails the build with "powershell: not found". -->
+    <Exec Command="powershell -NoProfile -NonInteractive -File &quot;$(MSBuildThisFileDirectory)Inject-PluginBuildMetadata.ps1&quot; -ManifestPath &quot;$(_PluginManifestPath)&quot; -GitSha &quot;$(_PluginGitSha)&quot; -BuildTimestamp &quot;$(_PluginBuildTimestamp)&quot;"
+          Condition="'$(OS)' == 'Windows_NT' and Exists('$(_PluginManifestPath)') and '$(_PwshExitCode)' != '0'"
           StandardOutputImportance="low"
           IgnoreExitCode="true" />
 
@@ -242,31 +246,44 @@
   <Target Name="ValidatePackageClosure" AfterTargets="InjectPluginBuildMetadata" Condition="'$(PluginPackagingDisable)' != 'true'">
     <PropertyGroup>
       <_VpcOutputDir>$(TargetDir)</_VpcOutputDir>
+      <!-- Trailing-separator-stripped form for use as a quoted command-line argument.
+           $(TargetDir) ends in a separator; on Windows a quoted "C:\dir\" makes the trailing
+           \" an ESCAPED quote, corrupting the path passed to pwsh (the closure check would
+           then find nothing and silently pass). Strip the trailing separator so the quoted
+           argument is well-formed. Join-Path in the script re-adds the separator. -->
+      <_VpcOutputDirArg>$(_VpcOutputDir.TrimEnd('\').TrimEnd('/'))</_VpcOutputDirArg>
       <!-- Path to parity-spec.json relative to this targets file -->
       <_VpcParitySpecPath>$(MSBuildThisFileDirectory)../scripts/parity-spec.json</_VpcParitySpecPath>
     </PropertyGroup>
 
     <!--
-      Use PowerShell to parse parity-spec.json and check for forbidden DLLs.
-      We use pwsh (cross-platform) with a fallback to powershell.exe on Windows.
-      The script exits 1 if any forbidden DLL is found, causing the build to fail.
+      Run the package-closure check via pwsh -File (cross-platform). -File keeps the script's
+      $variables inside the .ps1 so /bin/sh on Linux cannot expand them as empty shell variables
+      (inline -Command corrupted to e.g. " = .versionContract..." on Linux). IgnoreExitCode lets
+      us capture the exit code and emit a clean <Error> below instead of a raw MSB3073, and lets
+      the Windows-only powershell fallback run when pwsh is unavailable.
     -->
-    <Exec Command="pwsh -NoProfile -NonInteractive -Command &quot;$spec = Get-Content -LiteralPath '$(_VpcParitySpecPath)' -Raw | ConvertFrom-Json; $forbidden = $spec.versionContract.forbiddenPackageContents; $found = @(); foreach ($name in $forbidden) { $candidate = Join-Path '$(_VpcOutputDir)' $name; if (Test-Path -LiteralPath $candidate) { $found += $name } }; if ($found.Count -gt 0) { Write-Error ('FORBIDDEN DLLs in plugin output: ' + ($found -join ', ') + '. Add PrivateAssets=all ExcludeAssets=runtime to PackageReference or ILRepack-merge them. See docs/MULTI_PLUGIN_ALC_VALIDATION.md'); exit 1 } else { Write-Host ('[ValidatePackageClosure] OK - no forbidden DLLs found in ' + '$(_VpcOutputDir)') }&quot;"
+    <Exec Command="pwsh -NoProfile -NonInteractive -File &quot;$(MSBuildThisFileDirectory)Test-PackageClosure.ps1&quot; -ParitySpecPath &quot;$(_VpcParitySpecPath)&quot; -OutputDir &quot;$(_VpcOutputDirArg)&quot;"
           Condition="Exists('$(_VpcParitySpecPath)') and Exists('$(_VpcOutputDir)')"
           StandardOutputImportance="normal"
-          StandardErrorImportance="high">
+          StandardErrorImportance="high"
+          IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_VpcPwshExitCode" />
     </Exec>
 
-    <!-- Fallback to powershell.exe on Windows if pwsh is unavailable -->
-    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;$spec = Get-Content -LiteralPath '$(_VpcParitySpecPath)' -Raw | ConvertFrom-Json; $forbidden = $spec.versionContract.forbiddenPackageContents; $found = @(); foreach ($name in $forbidden) { $candidate = Join-Path '$(_VpcOutputDir)' $name; if (Test-Path -LiteralPath $candidate) { $found += $name } }; if ($found.Count -gt 0) { Write-Error ('FORBIDDEN DLLs in plugin output: ' + ($found -join ', ') + '. Add PrivateAssets=all ExcludeAssets=runtime to PackageReference or ILRepack-merge them. See docs/MULTI_PLUGIN_ALC_VALIDATION.md'); exit 1 } else { Write-Host ('[ValidatePackageClosure] OK - no forbidden DLLs found in ' + '$(_VpcOutputDir)') }&quot;"
-          Condition="Exists('$(_VpcParitySpecPath)') and Exists('$(_VpcOutputDir)') and '$(_VpcPwshExitCode)' != '0'"
+    <!-- Fallback to Windows PowerShell, but ONLY on Windows — `powershell` does not exist on
+         Linux/macOS, so an unconditional fallback fails the build with "powershell: not found". -->
+    <Exec Command="powershell -NoProfile -NonInteractive -File &quot;$(MSBuildThisFileDirectory)Test-PackageClosure.ps1&quot; -ParitySpecPath &quot;$(_VpcParitySpecPath)&quot; -OutputDir &quot;$(_VpcOutputDirArg)&quot;"
+          Condition="'$(OS)' == 'Windows_NT' and Exists('$(_VpcParitySpecPath)') and Exists('$(_VpcOutputDir)') and '$(_VpcPwshExitCode)' != '0'"
           StandardOutputImportance="normal"
-          StandardErrorImportance="high">
+          StandardErrorImportance="high"
+          IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_VpcPsExitCode" />
     </Exec>
 
-    <!-- Emit a hard MSBuild Error if forbidden DLLs were found (exit code != 0 from either shell) -->
+    <!-- Emit a hard MSBuild Error if forbidden DLLs were found (exit code != 0 from pwsh, and
+         the Windows-only fallback either didn't run or also failed). On Linux _VpcPsExitCode is
+         always empty (fallback is Windows-only), so the gate keys off _VpcPwshExitCode there. -->
     <Error
       Condition="'$(_VpcPwshExitCode)' != '' and '$(_VpcPwshExitCode)' != '0' and ('$(_VpcPsExitCode)' == '' or '$(_VpcPsExitCode)' != '0')"
       Text="[ValidatePackageClosure] FORBIDDEN assemblies found in plugin package output '$(_VpcOutputDir)'. These are host-provided DLLs that cause COR_E_INVALIDOPERATION type-identity conflicts when multiple plugins are installed. FIX: add PrivateAssets=&quot;all&quot; ExcludeAssets=&quot;runtime&quot; to the PackageReference for the offending package, or ILRepack-merge it. See docs/MULTI_PLUGIN_ALC_VALIDATION.md for the full explanation." />

--- a/build/Test-PackageClosure.ps1
+++ b/build/Test-PackageClosure.ps1
@@ -1,0 +1,44 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Fails (exit 1) if any forbidden host-provided DLL is present in the plugin
+    package output directory.
+.DESCRIPTION
+    Reads versionContract.forbiddenPackageContents from parity-spec.json and checks
+    the output directory for each entry. Forbidden DLLs are host-provided assemblies
+    that cause COR_E_INVALIDOPERATION type-identity conflicts when multiple plugins
+    are installed simultaneously.
+
+    Extracted from an inline MSBuild Exec command. Inline pwsh commands break on
+    Linux because MSBuild runs them through /bin/sh, which expands the PowerShell
+    `$variable` sigils as (empty) shell variables before pwsh parses them, corrupting
+    the command. Passing the paths as -File parameters avoids that entirely.
+.OUTPUTS
+    Exit 0 when the package closure is clean; exit 1 (with Write-Error) when forbidden
+    DLLs are found.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$ParitySpecPath,
+    [Parameter(Mandatory = $true)][string]$OutputDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$spec = Get-Content -LiteralPath $ParitySpecPath -Raw | ConvertFrom-Json
+$forbidden = $spec.versionContract.forbiddenPackageContents
+
+$found = @()
+foreach ($name in $forbidden) {
+    $candidate = Join-Path $OutputDir $name
+    if (Test-Path -LiteralPath $candidate) {
+        $found += $name
+    }
+}
+
+if ($found.Count -gt 0) {
+    Write-Error ('FORBIDDEN DLLs in plugin output: ' + ($found -join ', ') + '. Add PrivateAssets=all ExcludeAssets=runtime to the PackageReference or ILRepack-merge them. See docs/MULTI_PLUGIN_ALC_VALIDATION.md')
+    exit 1
+}
+
+Write-Host ('[ValidatePackageClosure] OK - no forbidden DLLs found in ' + $OutputDir)
+exit 0

--- a/tests/PackagingTargetScriptTests.cs
+++ b/tests/PackagingTargetScriptTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// Guards the cross-platform packaging helpers extracted from
+    /// <c>build/PluginPackaging.targets</c>:
+    ///   - <c>build/Inject-PluginBuildMetadata.ps1</c>
+    ///   - <c>build/Test-PackageClosure.ps1</c>
+    ///
+    /// These were previously inline <c>pwsh -Command</c> strings inside MSBuild Exec tasks.
+    /// On Linux MSBuild runs the command through /bin/sh, which expanded the PowerShell
+    /// <c>$variable</c> sigils as empty shell variables before pwsh parsed them — corrupting
+    /// <c>$manifest | Add-Member</c> into <c>| Add-Member</c> ("empty pipe element") and
+    /// blanking the closure check. Moving the logic into <c>.ps1</c> files invoked via
+    /// <c>pwsh -File</c> (paths passed as parameters) fixes that. These tests run on Linux CI
+    /// and Windows alike, exercising the scripts directly.
+    /// </summary>
+    public class PackagingTargetScriptTests
+    {
+        private static string RepoRoot => GetRepoRoot();
+
+        [Fact]
+        public async Task Inject_AddsGitShaAndBuildTimestamp_PreservingExistingFields()
+        {
+            using var dir = new TempDir();
+            var manifest = Path.Combine(dir.Path, "plugin.json");
+            var original = new { id = "test", name = "Test", version = "1.2.3" };
+            await File.WriteAllTextAsync(manifest, JsonSerializer.Serialize(original));
+
+            const string sha = "abc12345";
+            const string timestamp = "2026-05-28T00:00:00.0000000Z";
+
+            var (code, stdout, stderr) = await RunPwshAsync(
+                "build/Inject-PluginBuildMetadata.ps1",
+                $"-ManifestPath \"{manifest}\" -GitSha \"{sha}\" -BuildTimestamp \"{timestamp}\"");
+
+            Assert.True(code == 0, $"Expected exit 0 but got {code}.\nSTDOUT:{stdout}\nSTDERR:{stderr}");
+
+            using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(manifest));
+            var root = doc.RootElement;
+            Assert.Equal(sha, root.GetProperty("gitSha").GetString());
+            Assert.Equal(timestamp, root.GetProperty("buildTimestamp").GetString());
+            // Existing fields preserved.
+            Assert.Equal("test", root.GetProperty("id").GetString());
+            Assert.Equal("Test", root.GetProperty("name").GetString());
+            Assert.Equal("1.2.3", root.GetProperty("version").GetString());
+        }
+
+        [Fact]
+        public async Task Inject_OverwritesExistingMetadata_OnRebuild()
+        {
+            using var dir = new TempDir();
+            var manifest = Path.Combine(dir.Path, "plugin.json");
+            var original = new { id = "test", version = "1.0.0", gitSha = "stale", buildTimestamp = "1999-01-01T00:00:00Z" };
+            await File.WriteAllTextAsync(manifest, JsonSerializer.Serialize(original));
+
+            var (code, stdout, stderr) = await RunPwshAsync(
+                "build/Inject-PluginBuildMetadata.ps1",
+                $"-ManifestPath \"{manifest}\" -GitSha \"fresh123\" -BuildTimestamp \"2026-05-28T12:00:00.0000000Z\"");
+
+            Assert.True(code == 0, $"Expected exit 0 but got {code}.\nSTDOUT:{stdout}\nSTDERR:{stderr}");
+
+            using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(manifest));
+            Assert.Equal("fresh123", doc.RootElement.GetProperty("gitSha").GetString());
+            Assert.Equal("2026-05-28T12:00:00.0000000Z", doc.RootElement.GetProperty("buildTimestamp").GetString());
+        }
+
+        [Fact]
+        public async Task Closure_CleanOutputDir_ExitsZero()
+        {
+            using var dir = new TempDir();
+            // Only an allowed plugin DLL present.
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "Lidarr.Plugin.Foo.dll"), "x");
+
+            var spec = Path.Combine(RepoRoot, "scripts", "parity-spec.json");
+            var (code, stdout, stderr) = await RunPwshAsync(
+                "build/Test-PackageClosure.ps1",
+                $"-ParitySpecPath \"{spec}\" -OutputDir \"{dir.Path}\"");
+
+            Assert.True(code == 0, $"Expected exit 0 for a clean dir but got {code}.\nSTDOUT:{stdout}\nSTDERR:{stderr}");
+            Assert.Contains("no forbidden DLLs", stdout + stderr, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task Closure_ForbiddenDll_ExitsNonZero_AndNamesOffender()
+        {
+            using var dir = new TempDir();
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "Lidarr.Plugin.Foo.dll"), "x");
+            // A host-provided assembly that must never ship inside a plugin package.
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "FluentValidation.dll"), "x");
+
+            var spec = Path.Combine(RepoRoot, "scripts", "parity-spec.json");
+            var (code, stdout, stderr) = await RunPwshAsync(
+                "build/Test-PackageClosure.ps1",
+                $"-ParitySpecPath \"{spec}\" -OutputDir \"{dir.Path}\"");
+
+            Assert.True(code != 0, $"Expected non-zero exit when a forbidden DLL is present but got {code}.\nSTDOUT:{stdout}\nSTDERR:{stderr}");
+            Assert.Contains("FluentValidation.dll", stdout + stderr, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("FORBIDDEN", stdout + stderr, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Regression guard for the original Linux bug: the packaging targets must invoke the
+        /// helpers via <c>-File</c>, never via an inline <c>-Command</c> string with PowerShell
+        /// <c>$variables</c> (which /bin/sh expands and corrupts on Linux).
+        /// </summary>
+        [Fact]
+        public void Targets_InvokeScriptsViaFile_NotInlineCommand()
+        {
+            var targets = File.ReadAllText(Path.Combine(RepoRoot, "build", "PluginPackaging.targets"));
+
+            Assert.Contains("Inject-PluginBuildMetadata.ps1", targets);
+            Assert.Contains("Test-PackageClosure.ps1", targets);
+            Assert.Contains("-File", targets);
+
+            // The corrupted-on-Linux inline form must not return.
+            Assert.DoesNotContain("-Command &quot;$manifest", targets);
+            Assert.DoesNotContain("-Command &quot;$spec", targets);
+        }
+
+        /// <summary>
+        /// The Windows-only <c>powershell</c> fallbacks must be guarded by an OS check so they
+        /// never run on Linux/macOS (where <c>powershell</c> does not exist → "powershell: not found").
+        /// </summary>
+        [Fact]
+        public void Targets_PowershellFallbacks_AreWindowsOnly()
+        {
+            var targets = File.ReadAllText(Path.Combine(RepoRoot, "build", "PluginPackaging.targets"));
+
+            // Each `powershell` (Windows PowerShell) fallback Exec must be paired with a
+            // Windows_NT OS guard on its Condition so it never runs on Linux/macOS.
+            var powershellCount = CountOccurrences(targets, "powershell -NoProfile");
+            var windowsGuardCount = CountOccurrences(targets, "'$(OS)' == 'Windows_NT'");
+            Assert.True(powershellCount > 0, "Expected at least one `powershell` fallback Exec in the targets.");
+            Assert.True(
+                windowsGuardCount >= powershellCount,
+                $"Expected at least {powershellCount} Windows_NT guards (one per powershell fallback) " +
+                $"but found {windowsGuardCount}. Each `powershell` fallback must be guarded by '$(OS)' == 'Windows_NT'.");
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            var idx = 0;
+            while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                idx += needle.Length;
+            }
+            return count;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────
+        // Behavioral checks through real MSBuild — exercises the Exec → pwsh -File path
+        // that broke on Linux. These run inside the main dotnet-test lane (ubuntu + windows).
+        // ─────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Targets_InjectMetadata_ViaMsBuild_InjectsGitShaAndTimestamp()
+        {
+            using var dir = new TempDir();
+            var manifest = Path.Combine(dir.Path, "plugin.json");
+            await File.WriteAllTextAsync(manifest, JsonSerializer.Serialize(new { id = "test", version = "1.0.0" }));
+
+            // Invoking InjectPluginBuildMetadata also runs ValidatePackageClosure (AfterTargets);
+            // the dir holds only plugin.json so the closure gate passes (no forbidden DLLs).
+            var (code, stdout, stderr) = await RunMsBuildAsync(
+                "InjectPluginBuildMetadata",
+                $"{dir.Path}{Path.DirectorySeparatorChar}",
+                "-p:PluginManifestFileName=plugin.json");
+
+            Assert.True(code == 0, $"Expected exit 0 but got {code}.\n{stdout}\n{stderr}");
+
+            using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(manifest));
+            Assert.True(doc.RootElement.TryGetProperty("gitSha", out var sha) && !string.IsNullOrWhiteSpace(sha.GetString()),
+                $"plugin.json was not given a gitSha — the inline-command sh-expansion bug has regressed.\n{stdout}\n{stderr}");
+            Assert.True(doc.RootElement.TryGetProperty("buildTimestamp", out var ts) && !string.IsNullOrWhiteSpace(ts.GetString()),
+                $"plugin.json was not given a buildTimestamp.\n{stdout}\n{stderr}");
+        }
+
+        [Fact]
+        public async Task Targets_ValidateClosure_ViaMsBuild_PassesForCleanDir()
+        {
+            using var dir = new TempDir();
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "Test.Plugin.dll"), "x");
+
+            var (code, stdout, stderr) = await RunMsBuildAsync(
+                "ValidatePackageClosure",
+                $"{dir.Path}{Path.DirectorySeparatorChar}");
+
+            Assert.True(code == 0, $"Expected exit 0 for a clean dir but got {code}.\n{stdout}\n{stderr}");
+        }
+
+        [Fact]
+        public async Task Targets_ValidateClosure_ViaMsBuild_FailsForForbiddenDll()
+        {
+            using var dir = new TempDir();
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "Test.Plugin.dll"), "x");
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "FluentValidation.dll"), "x");
+
+            var (code, stdout, stderr) = await RunMsBuildAsync(
+                "ValidatePackageClosure",
+                $"{dir.Path}{Path.DirectorySeparatorChar}");
+
+            Assert.True(code != 0, $"Expected non-zero exit when a forbidden DLL is present but got {code}.\n{stdout}\n{stderr}");
+            Assert.Contains("FORBIDDEN", stdout + stderr, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static async Task<(int code, string stdout, string stderr)> RunMsBuildAsync(string target, string targetDir, params string[] extraProps)
+        {
+            var targetsFile = Path.Combine(RepoRoot, "build", "PluginPackaging.targets");
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = RepoRoot
+            };
+            psi.ArgumentList.Add("msbuild");
+            psi.ArgumentList.Add(targetsFile);
+            psi.ArgumentList.Add($"-t:{target}");
+            psi.ArgumentList.Add("-p:PluginPackagingDisable=false");
+            psi.ArgumentList.Add($"-p:TargetDir={targetDir}");
+            psi.ArgumentList.Add("-p:AssemblyName=Test");
+            foreach (var p in extraProps) psi.ArgumentList.Add(p);
+            psi.ArgumentList.Add("-nologo");
+            psi.ArgumentList.Add("-v:minimal");
+
+            using var p2 = new Process { StartInfo = psi };
+            var sbOut = new StringBuilder();
+            var sbErr = new StringBuilder();
+            p2.OutputDataReceived += (s, e) => { if (e.Data != null) sbOut.AppendLine(e.Data); };
+            p2.ErrorDataReceived += (s, e) => { if (e.Data != null) sbErr.AppendLine(e.Data); };
+            p2.Start();
+            p2.BeginOutputReadLine();
+            p2.BeginErrorReadLine();
+
+            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(120));
+            try { await p2.WaitForExitAsync(cts.Token); }
+            catch (OperationCanceledException) { try { p2.Kill(entireProcessTree: true); } catch { } return (-1, sbOut.ToString(), "msbuild timed out after 120s"); }
+
+            return (p2.ExitCode, sbOut.ToString(), sbErr.ToString());
+        }
+
+        private static async Task<(int code, string stdout, string stderr)> RunPwshAsync(string scriptRelative, string args)
+        {
+            var script = Path.Combine(RepoRoot, scriptRelative);
+            var psi = new ProcessStartInfo
+            {
+                FileName = "pwsh",
+                Arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{script}\" {args}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = RepoRoot
+            };
+            using var p = new Process { StartInfo = psi };
+            var sbOut = new StringBuilder();
+            var sbErr = new StringBuilder();
+            p.OutputDataReceived += (s, e) => { if (e.Data != null) sbOut.AppendLine(e.Data); };
+            p.ErrorDataReceived += (s, e) => { if (e.Data != null) sbErr.AppendLine(e.Data); };
+            p.Start();
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+
+            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(60));
+            try { await p.WaitForExitAsync(cts.Token); }
+            catch (OperationCanceledException) { try { p.Kill(entireProcessTree: true); } catch { } return (-1, sbOut.ToString(), "Process timed out after 60s"); }
+
+            return (p.ExitCode, sbOut.ToString(), sbErr.ToString());
+        }
+
+        private static string GetRepoRoot()
+        {
+            var dir = AppContext.BaseDirectory;
+            for (var i = 0; i < 6; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "build", "Test-PackageClosure.ps1"))) return dir;
+                var parent = Directory.GetParent(dir)?.FullName;
+                if (parent == null) break;
+                dir = parent;
+            }
+            throw new DirectoryNotFoundException("Could not locate repo root containing build/Test-PackageClosure.ps1");
+        }
+
+        private sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+            public TempDir() { Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "pts-" + Guid.NewGuid().ToString("N")); Directory.CreateDirectory(Path); }
+            public void Dispose() { try { Directory.Delete(Path, true); } catch { } }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`InjectPluginBuildMetadata` and `ValidatePackageClosure` in `build/PluginPackaging.targets` ran PowerShell via inline `pwsh -Command "...$var..."`. On Linux, MSBuild executes `Exec` commands through `/bin/sh`, which expands the PowerShell `$variable` sigils as **empty shell variables** before pwsh parses them:

- `$manifest | Add-Member` collapsed to ` | Add-Member` → `ParserError: An empty pipe element is not allowed` (build metadata silently never injected), and
- the closure check's `$spec` / `$found` / `$name` blanked out.

The `powershell` (Windows PowerShell) fallback then ran unconditionally and failed with `powershell: not found` on Linux. This is the root cause of the brainarr **Packaging Gates** Linux failures.

## Fix

- Extract both inline commands into `build/Inject-PluginBuildMetadata.ps1` and `build/Test-PackageClosure.ps1`, invoked via `pwsh -File` with paths passed as parameters. `-File` keeps the script's `$variables` inside the `.ps1` so `/bin/sh` never sees or expands them.
- Guard the Windows PowerShell fallbacks with `'$(OS)' == 'Windows_NT'` so they never run on Linux/macOS.
- Add `IgnoreExitCode` to the closure pwsh `Exec` so the capture-and-`<Error>` flow runs (clean message instead of raw MSB3073) and the Windows fallback can engage when pwsh is absent.
- Strip the trailing separator from `$(TargetDir)` before passing it as a quoted `-OutputDir` argument: on Windows a quoted `"C:\dir\"` makes the trailing `\"` an **escaped quote**, corrupting the path so the closure check silently finds nothing (a Windows regression caught by the new behavioral test).

## Tests

New `tests/PackagingTargetScriptTests.cs` runs in the main `dotnet test` lane (ubuntu + windows) — the lane the dead `scripts/tests/*.Tests.ps1` Pester files never ran in (they don't match the CI `Test-*.ps1` glob, and there is no `Invoke-Pester` anywhere):

- **script behavior** — inject adds/overwrites `gitSha`+`buildTimestamp` preserving other fields; closure passes clean, fails + names the offender;
- **content guards** — targets use `-File`, never inline `-Command "$var"`; every `powershell` fallback is `Windows_NT`-guarded;
- **behavioral via real `dotnet msbuild`** — both targets, including the forbidden-DLL rejection (this is what caught the trailing-backslash regression).

## Test plan

- [x] 9/9 new tests green locally on Windows
- [x] Both targets verified end-to-end via `dotnet msbuild` (inject + closure clean + closure forbidden→fail)
- [ ] Common CI green on **ubuntu-latest** (the real Linux validation)
- [ ] After merge: re-pin brainarr → re-run Packaging Gates to confirm end-to-end green

🤖 Generated with [Claude Code](https://claude.com/claude-code)