### PR TITLE
fix(cli): align Spectre.Console 0.55.2 + headless-safe LiveDashboard

### DIFF
--- a/src/CLI/Services/LiveDashboard.cs
+++ b/src/CLI/Services/LiveDashboard.cs
@@ -180,9 +180,15 @@ namespace Lidarr.Plugin.Common.CLI.Services
                     .BorderColor(Color.Grey)
             );
 
-            // Render to console
-            AnsiConsole.Clear();
-            AnsiConsole.Write(layout);
+            // Render to console. Clear via the injected UI (testable + headless-safe). The rich
+            // Spectre layout is written to the real console only when attached to an interactive
+            // terminal — in redirected/headless environments (CI, `dotnet test`) the legacy
+            // console backend has no valid handle and AnsiConsole throws IOException.
+            _ui.Clear();
+            if (!System.Console.IsOutputRedirected)
+            {
+                AnsiConsole.Write(layout);
+            }
         }
     }
 }

--- a/src/Lidarr.Plugin.Common.csproj
+++ b/src/Lidarr.Plugin.Common.csproj
@@ -138,7 +138,7 @@
   <ItemGroup Condition="'$(IncludeCLIFramework)' == 'true'">
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" PrivateAssets="All" />
-    <PackageReference Include="Spectre.Console" Version="0.50.0" PrivateAssets="All" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" PrivateAssets="All" />
   </ItemGroup>
   <!-- Audio Processing Dependency removed from core to avoid private feed.
        Plugin authors who need TagLib should reference a public package (e.g., TagLibSharp from nuget.org) directly in their plugin. -->

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -177,6 +177,27 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "Spectre.Console": {
+        "type": "Direct",
+        "requested": "[0.55.2, )",
+        "resolved": "0.55.2",
+        "contentHash": "yc0g12YJpmZHofGJLTQX02/uqfzJ6XHRx6pe9rANNjleQptXMHPxD9KI2/DWkXiJWddc+4oizEdGox15c89hhw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.2"
+        }
+      },
+      "System.CommandLine": {
+        "type": "Direct",
+        "requested": "[2.0.0-beta4.22272.1, )",
+        "resolved": "2.0.0-beta4.22272.1",
+        "contentHash": "1uqED/q2H0kKoLJ4+hI2iPSBSEdTuhfCYADeJrAqERmiGQ2NNacYKRNEQ+gFbU4glgVyK8rxI+ZOe1onEtr/Pg=="
+      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -408,6 +429,11 @@
         "type": "Transitive",
         "resolved": "1.1.1",
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.2",
+        "contentHash": "tN3KEJQQZwLW9HJnG5YTSAxfBwxsmg1wVuGvhGG2rM+pbl+NGaHU8pDcNofPlOXlgpkbpBMxI5t9o9qPfy3sHQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -609,8 +609,8 @@
           "NSubstitute": "[5.3.0, )",
           "Xunit.SkippableFact": "[1.5.23, )",
           "xunit.assert": "[2.9.2, )",
-          "xunit.extensibility.core": "[2.9.2, )",
-          "xunit.extensibility.execution": "[2.9.2, )"
+          "xunit.extensibility.core": "[2.9.3, )",
+          "xunit.extensibility.execution": "[2.9.3, )"
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes the `LiveDashboardTests` failures that have been making Common CI red on `main` (and blocking downstream PRs). Root cause: dependabot bumped the **test** project's Spectre.Console 0.54→0.55.2 (#476) while **src** stayed at **0.50.0**:

1. `MissingMethodException: Spectre.Console.Markup..ctor(String, Style)` — the CLI code compiled against 0.50.0 referenced a ctor signature 0.55.2 removed. Fixed by aligning `src` Spectre.Console to **0.55.2**.
2. After aligning, `AnsiConsole.Clear()` throws `IOException` ("handle is invalid") in 0.55.2 under headless/redirected output (CI, `dotnet test`): `LiveDashboard` rendered via the **global** `AnsiConsole` instead of the injected `IConsoleUI`. Fixed by routing the per-refresh clear through `_ui` (testable + headless-safe; also restores the `ClearCallCount` the tests assert) and guarding the rich Spectre layout write to interactive terminals only.

## Validation
- Build succeeds with `IncludeCLIFramework=true`.
- Full CLI test suite passes locally (LiveDashboard, ConfigCommand, JsonConfigService, MemoryQueue, FileState, CLIServicesTryGet) — exit 0.

This is the dependabot-introduced regression flagged during the parity work; landing it unblocks the reusable Docker E2E workflow PR (#536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)