### PR TITLE
feat(ci): add reusable CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -1,0 +1,150 @@
+name: CodeQL (reusable)
+
+# Reusable CodeQL analysis for Lidarr plugins (manual build mode).
+#
+# C# CodeQL needs the project built so the extractor can observe compilation, and
+# plugins build against extracted Lidarr host assemblies — so this mirrors the plugin
+# build: init Common submodule, extract host assemblies, restore + build the solution
+# (un-merged: PluginPackagingDisable=true), then run the CodeQL analysis.
+#
+# A plugin adopts this by replacing its hand-rolled codeql.yml with a thin caller:
+#
+#   jobs:
+#     analyze:
+#       uses: RicherTunes/Lidarr.Plugin.Common/.github/workflows/codeql-reusable.yml@<sha>
+#       with:
+#         solution: Brainarr.sln
+#       secrets:
+#         submodules-token: ${{ secrets.SUBMODULES_TOKEN }}
+
+on:
+  workflow_call:
+    inputs:
+      solution:
+        description: 'Solution or project to restore/build for the CodeQL extractor.'
+        required: true
+        type: string
+      language:
+        description: 'CodeQL language.'
+        required: false
+        type: string
+        default: 'csharp'
+      extract-script:
+        description: 'Path to the host-assembly extraction script.'
+        required: false
+        type: string
+        default: 'scripts/extract-lidarr-assemblies.sh'
+      extract-mode:
+        description: 'Extraction mode passed to the script (minimal is enough for compile).'
+        required: false
+        type: string
+        default: 'minimal'
+      host-assemblies-path:
+        description: 'Output dir for extracted Lidarr host assemblies (becomes LIDARR_PATH).'
+        required: false
+        type: string
+        default: 'ext/Lidarr-docker/_output/net8.0'
+      build-props:
+        description: 'Extra MSBuild props for the build (kept un-merged for analysis).'
+        required: false
+        type: string
+        default: '-p:PluginPackagingDisable=true'
+      patch-taglib-nuget:
+        description: 'Patch the submodule NuGet.config to map TagLibSharp-Lidarr (plugin-specific).'
+        required: false
+        type: boolean
+        default: false
+      runs-on:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      timeout-minutes:
+        required: false
+        type: number
+        default: 45
+    secrets:
+      submodules-token:
+        description: 'PAT with read access to the private Common submodule (omit for forks).'
+        required: false
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (CodeQL)
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Init Common submodule
+        shell: bash
+        env:
+          SUBMODULES_TOKEN: ${{ secrets.submodules-token }}
+        run: |
+          if [ -n "${SUBMODULES_TOKEN}" ]; then echo "::add-mask::${SUBMODULES_TOKEN}"; fi
+          git submodule sync -- ext/Lidarr.Plugin.Common
+          if [ -n "${SUBMODULES_TOKEN}" ]; then
+            GIT_CONFIG_PARAMETERS="'url.https://x-access-token:${SUBMODULES_TOKEN}@github.com/.insteadOf=https://github.com/'" \
+              git submodule update --init --depth=1 -- ext/Lidarr.Plugin.Common
+          else
+            echo "::warning::submodules-token not provided (fork PR?) — attempting unauthenticated fetch"
+            git submodule update --init --depth=1 -- ext/Lidarr.Plugin.Common || {
+              echo "::error::Submodule init failed — likely a private repo without auth token"; exit 1; }
+          fi
+
+      - name: Patch submodule NuGet mapping (TagLibSharp-Lidarr)
+        if: ${{ inputs.patch-taglib-nuget }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          CFG="ext/Lidarr.Plugin.Common/NuGet.config"
+          if [ -f "$CFG" ]; then
+            grep -q 'TagLibSharp-Lidarr' "$CFG" || \
+              sed -i '/<packageSource key="lidarr-taglib">/a \      <package pattern="TagLibSharp-Lidarr*" />' "$CFG"
+            echo "Patched $CFG"
+          fi
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Initialize CodeQL (manual build)
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ inputs.language }}
+          build-mode: manual
+
+      - name: Extract Lidarr assemblies
+        shell: bash
+        run: timeout 12m bash "${{ inputs.extract-script }}" --mode "${{ inputs.extract-mode }}" --no-tar-fallback --output-dir "${{ inputs.host-assemblies-path }}"
+
+      - name: Verify assemblies and export LIDARR_PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "${{ inputs.host-assemblies-path }}/Lidarr.Core.dll" || { echo "Missing Lidarr.Core.dll in assemblies"; exit 1; }
+          echo "LIDARR_PATH=${{ github.workspace }}/${{ inputs.host-assemblies-path }}" >> "$GITHUB_ENV"
+
+      - name: Restore
+        shell: bash
+        run: timeout 10m dotnet restore "${{ inputs.solution }}"
+
+      - name: Build (un-merged, for analysis)
+        shell: bash
+        run: timeout 20m dotnet build "${{ inputs.solution }}" -c Release --no-restore -p:LidarrPath="${{ env.LIDARR_PATH }}" ${{ inputs.build-props }} -m:1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Second workflow convergence (after the reusable docker-e2e in #536): a reusable (`workflow_call`) CodeQL analysis so the 4 plugins stop maintaining divergent `codeql.yml` copies.

C# CodeQL needs a manual build, and plugins build against extracted Lidarr host assemblies — so the reusable mirrors the plugin build (submodule init → host-assembly extraction → restore → un-merged build) then runs CodeQL init/analyze. Parameterized via inputs (`solution`, `language`, `extract-script`/`extract-mode`, `host-assemblies-path`, `build-props`, `patch-taglib-nuget`) + `submodules-token` secret.

Named `codeql-reusable.yml` to avoid colliding with Common's own `codeql.yml` self-CI.

## Rollout
brainarr adopts first (follow-up PR, CI-validated since CodeQL runs on PRs); qobuzarr/tidalarr/applemusicarr adopt once billing is restored.

## Validation
- `actionlint` clean. Modeled directly on brainarr's working `codeql.yml` (codeql-action v4, manual build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)