### PR TITLE
fix(ci): notify-failure reusable — secrets context invalid in step if

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -40,6 +40,12 @@ jobs:
     if: >
       github.event_name == 'workflow_call' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
+    # Map webhooks to env at the job level. The `secrets` context is NOT available in a
+    # step `if:` (only env/github/inputs/vars/…), so the per-step gates below check `env.*`.
+    # Fall back to repo/org variables so a webhook configured as a variable also works.
+    env:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK || vars.DISCORD_WEBHOOK }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK || vars.SLACK_WEBHOOK }}
 
     steps:
       - name: Prepare notification data
@@ -58,9 +64,7 @@ jobs:
           fi
 
       - name: Send Discord notification
-        if: ${{ secrets.DISCORD_WEBHOOK != '' }}
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        if: ${{ env.DISCORD_WEBHOOK != '' }}
         run: |
           curl -H "Content-Type: application/json" \
             -d '{
@@ -79,9 +83,7 @@ jobs:
             "$DISCORD_WEBHOOK"
 
       - name: Send Slack notification
-        if: ${{ secrets.SLACK_WEBHOOK != '' }}
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        if: ${{ env.SLACK_WEBHOOK != '' }}
         run: |
           curl -X POST -H "Content-Type: application/json" \
             -d '{
@@ -113,7 +115,7 @@ jobs:
             "$SLACK_WEBHOOK"
 
       - name: Log notification (fallback if no webhook configured)
-        if: ${{ secrets.DISCORD_WEBHOOK == '' && secrets.SLACK_WEBHOOK == '' }}
+        if: ${{ env.DISCORD_WEBHOOK == '' && env.SLACK_WEBHOOK == '' }}
         run: |
           echo "::warning::No notification webhook configured (DISCORD_WEBHOOK or SLACK_WEBHOOK)"
           echo ""


### PR DESCRIPTION
## Summary

The reusable `notify-failure.yml` gated its Discord/Slack/log steps with `if: ${{ secrets.DISCORD_WEBHOOK != '' }}`. The **`secrets` context is not available in a step `if:`** (only env/github/inputs/vars/…) — actionlint flags 4 occurrences and the conditions are invalid at runtime. It never surfaced because the workflow only fires on failure and no webhook is currently configured.

## Fix
- Map the webhooks to **job-level `env`** once, with a `vars.*` fallback so a webhook configured as a repo/org **variable** also works (parity with the plugins' original inline `secrets.X || vars.X`).
- Gate the steps on `env.*` instead of `secrets.*`.
- Drop the now-redundant step-level `env` blocks so the curl steps inherit the job-level env (keeps the vars fallback in the actual request).

## Why now
Prerequisite for converging the 4 plugins' duplicated `notify-failure.yml` onto this reusable — converging onto the broken version would replace working no-ops with a broken workflow.

## Validation
- `actionlint` clean (was 4 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)