### PR TITLE
fix: 4 defect-hunt findings (redirect loop, semaphore dispose race, cache tmp collision, mutex thread-affinity)

### DIFF
--- a/src/Services/Authentication/FileTokenStore.cs
+++ b/src/Services/Authentication/FileTokenStore.cs
@@ -237,50 +237,14 @@ namespace Lidarr.Plugin.Common.Services.Authentication
 
         private static IDisposable AcquireCrossProcessLock(string name, CancellationToken cancellationToken)
         {
-            if (OperatingSystem.IsWindows())
-            {
-                return new NamedMutexScope(name, cancellationToken);
-            }
-            else
-            {
-                return new FileLockScope(name, cancellationToken);
-            }
-        }
-
-        private sealed class NamedMutexScope : IDisposable
-        {
-            private readonly Mutex _mutex;
-            public NamedMutexScope(string name, CancellationToken cancellationToken)
-            {
-                _mutex = new Mutex(false, name);
-                bool acquired = false;
-                try
-                {
-                    // Allow a more generous cross-process wait to reduce
-                    // rare false negatives on busy Windows CI runners.
-                    acquired = _mutex.WaitOne(TimeSpan.FromSeconds(120));
-                }
-                catch (AbandonedMutexException)
-                {
-                    acquired = true; // Consider abandoned as acquired to proceed
-                }
-                if (!acquired)
-                {
-                    throw new TimeoutException($"Failed to acquire cross-process token store mutex '{name}'.");
-                }
-                if (cancellationToken.CanBeCanceled)
-                {
-                    cancellationToken.Register(() =>
-                    {
-                        try { _mutex.ReleaseMutex(); } catch { }
-                    });
-                }
-            }
-            public void Dispose()
-            {
-                try { _mutex.ReleaseMutex(); } catch { }
-                _mutex.Dispose();
-            }
+            // Use a FileStream-based lock on ALL platforms. A named Win32 Mutex has thread
+            // affinity (ReleaseMutex must run on the acquiring thread), but this lock is held
+            // across `await`s whose continuations may resume on a different thread — and the
+            // cancellation callback always runs off-thread — so the Mutex release would fail
+            // (it was silently swallowed), leaving the lock held until a 120s timeout/abandon.
+            // FileLockScope (exclusive FileStream, FileShare.None) has no thread affinity and is
+            // safe to release from any thread, while still coordinating across processes.
+            return new FileLockScope(name, cancellationToken);
         }
 
         private sealed class FileLockScope : IDisposable

--- a/src/Services/Caching/FileStreamingResponseCache.cs
+++ b/src/Services/Caching/FileStreamingResponseCache.cs
@@ -22,7 +22,6 @@ namespace Lidarr.Plugin.Common.Services.Caching
         private readonly string _root;
         private readonly TimeSpan _defaultDuration;
         private readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web) { WriteIndented = false };
-        private readonly SemaphoreSlim _gate = new(1, 1);
         private readonly int _maxEntries;
         private readonly long _maxBytes;
         private readonly ILogger _logger;
@@ -107,15 +106,16 @@ namespace Lidarr.Plugin.Common.Services.Caching
                 ExpireAt = DateTimeOffset.UtcNow.Add(duration)
             };
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            var tmp = path + ".tmp";
+            // Unique temp name per write so concurrent Set() calls for the same key don't collide on a
+            // shared "<path>.tmp", then atomically replace the destination (no delete-then-move race).
+            var tmp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
             try
             {
                 using (var fs = File.Create(tmp))
                 {
                     JsonSerializer.Serialize(fs, entry, _json);
                 }
-                if (File.Exists(path)) File.Delete(path);
-                File.Move(tmp, path);
+                File.Move(tmp, path, overwrite: true);
                 EnforceLimits();
             }
             catch (IOException ex)

--- a/src/Services/Performance/AdaptiveConcurrencyManager.cs
+++ b/src/Services/Performance/AdaptiveConcurrencyManager.cs
@@ -317,22 +317,18 @@ namespace Lidarr.Plugin.Common.Services.Performance
                 _consecutiveSuccesses = 0;
                 _consecutiveFailures = 0;
 
-                // Update the shared semaphore with new limit
-                var oldSemaphore = _sharedSemaphore;
+                // Update the shared semaphore with the new limit. New callers pick up the new
+                // semaphore; callers already in-flight keep using the previous one and drain
+                // against the limit they were admitted under.
+                //
+                // The previous semaphore is intentionally NOT disposed here. In-flight callers
+                // still hold a reference to it (e.g. ExecuteWithConcurrencyAsync's finally
+                // Release(), or anything from GetConcurrencySemaphore()), and disposing it out
+                // from under them threw ObjectDisposedException on their Release()/WaitAsync().
+                // A SemaphoreSlim whose AvailableWaitHandle is never accessed (the case here)
+                // holds no unmanaged resource, so the GC reclaims it once the last in-flight
+                // caller releases it — no handle leak, no cross-epoch disposal race.
                 _sharedSemaphore = new SemaphoreSlim(newConcurrency, newConcurrency);
-
-                // Dispose old semaphore in a background task to avoid blocking
-                Task.Run(() =>
-                {
-                    try
-                    {
-                        oldSemaphore?.Dispose();
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug("Error disposing old semaphore during concurrency adjustment: {0}", ex.Message);
-                    }
-                });
 
                 _logger.LogInformation("Concurrency adjusted: {0} → {1} (decision: {2}, avg latency: {3:F1}ms, success rate: {4:P1})",
                     oldConcurrency, newConcurrency, decision, AverageLatency, SuccessRate);

--- a/src/Utilities/HttpClientExtensions.cs
+++ b/src/Utilities/HttpClientExtensions.cs
@@ -360,6 +360,8 @@ namespace Lidarr.Plugin.Common.Utilities
             var effectiveToken = timeoutCts?.Token ?? cancellationToken;
             var deadline = DateTime.UtcNow + retryBudget.Value;
             var attempt = 0;
+            var redirectCount = 0;
+            const int maxRedirects = 10;
             // Resolve relative URIs against HttpClient.BaseAddress when present
             Uri? currentUri = request.RequestUri;
             if (currentUri != null && !currentUri.IsAbsoluteUri)
@@ -475,6 +477,17 @@ namespace Lidarr.Plugin.Common.Utilities
                                 var loc = response.Headers.Location;
                                 var targetUri = loc.IsAbsoluteUri ? loc : new Uri(attemptRequest.RequestUri!, loc);
 
+                                // Bound redirect-following: cap the hop count and honor the retry-budget deadline
+                                // so a redirect cycle (A->B->A, or a self-redirect) cannot loop forever. The
+                                // deadline check below the retryable path is skipped by the redirect `continue`,
+                                // so it must also be enforced here.
+                                redirectCount++;
+                                if (redirectCount > maxRedirects || DateTime.UtcNow >= deadline)
+                                {
+                                    try { httpActivity?.SetTag("resilience.redirects.exhausted", redirectCount); } catch (Exception swallowEx) { SwallowToTrace(swallowEx); }
+                                    return response;
+                                }
+
                                 // If the redirect crosses hosts, release current gates and reacquire for the new host
                                 var newHost = targetUri.Host;
                                 var crossingHosts = !string.Equals(newHost, host, StringComparison.OrdinalIgnoreCase);
@@ -533,6 +546,17 @@ namespace Lidarr.Plugin.Common.Utilities
                             {
                                 var loc = response.Headers.Location;
                                 var targetUri = loc.IsAbsoluteUri ? loc : new Uri(attemptRequest.RequestUri!, loc);
+
+                                // Bound redirect-following: cap the hop count and honor the retry-budget deadline
+                                // so a redirect cycle (A->B->A, or a self-redirect) cannot loop forever. The
+                                // deadline check below the retryable path is skipped by the redirect `continue`,
+                                // so it must also be enforced here.
+                                redirectCount++;
+                                if (redirectCount > maxRedirects || DateTime.UtcNow >= deadline)
+                                {
+                                    try { httpActivity?.SetTag("resilience.redirects.exhausted", redirectCount); } catch (Exception swallowEx) { SwallowToTrace(swallowEx); }
+                                    return response;
+                                }
 
                                 // If the redirect crosses hosts, release current gates and reacquire for the new host
                                 var newHost = targetUri.Host;

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -177,27 +177,6 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.4, )",
-        "resolved": "13.0.4",
-        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
-      },
-      "Spectre.Console": {
-        "type": "Direct",
-        "requested": "[0.55.2, )",
-        "resolved": "0.55.2",
-        "contentHash": "yc0g12YJpmZHofGJLTQX02/uqfzJ6XHRx6pe9rANNjleQptXMHPxD9KI2/DWkXiJWddc+4oizEdGox15c89hhw==",
-        "dependencies": {
-          "Spectre.Console.Ansi": "0.55.2"
-        }
-      },
-      "System.CommandLine": {
-        "type": "Direct",
-        "requested": "[2.0.0-beta4.22272.1, )",
-        "resolved": "2.0.0-beta4.22272.1",
-        "contentHash": "1uqED/q2H0kKoLJ4+hI2iPSBSEdTuhfCYADeJrAqERmiGQ2NNacYKRNEQ+gFbU4glgVyK8rxI+ZOe1onEtr/Pg=="
-      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -429,11 +408,6 @@
         "type": "Transitive",
         "resolved": "1.1.1",
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
-      },
-      "Spectre.Console.Ansi": {
-        "type": "Transitive",
-        "resolved": "0.55.2",
-        "contentHash": "tN3KEJQQZwLW9HJnG5YTSAxfBwxsmg1wVuGvhGG2rM+pbl+NGaHU8pDcNofPlOXlgpkbpBMxI5t9o9qPfy3sHQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",

--- a/tests/AdaptiveConcurrencyManagerTests.cs
+++ b/tests/AdaptiveConcurrencyManagerTests.cs
@@ -126,6 +126,40 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
+        public void ApplyAdjustment_DoesNotDisposeInFlightSemaphore()
+        {
+            // Regression: a concurrency adjustment swapped _sharedSemaphore and disposed the old
+            // instance in a background task, so in-flight callers holding the old reference hit
+            // ObjectDisposedException on their Release()/WaitAsync(). The swapped-out semaphore
+            // must remain usable until its last in-flight holder is done.
+            var manager = CreateManager(
+                minConcurrency: 1, maxConcurrency: 8,
+                targetLatency: 100, maxLatency: 5000,
+                adjustmentInterval: TimeSpan.Zero);
+
+            // Grow concurrency so a subsequent decrease has room to actually swap the semaphore.
+            for (int i = 0; i < 30; i++) manager.RecordOperation(TimeSpan.FromMilliseconds(20), true);
+
+            var oldSem = manager.GetConcurrencySemaphore();
+
+            // Drive decreases until the shared semaphore is swapped (capped to avoid a hang).
+            var swapped = false;
+            for (int i = 0; i < 50 && !swapped; i++)
+            {
+                manager.RecordOperation(TimeSpan.FromMilliseconds(9000), true); // well above maxLatency
+                swapped = !ReferenceEquals(manager.GetConcurrencySemaphore(), oldSem);
+            }
+            Assert.True(swapped, "expected a concurrency adjustment to swap the shared semaphore");
+
+            // Give any background disposal a chance to run (pre-fix this disposed oldSem).
+            Thread.Sleep(250);
+
+            // The swapped-out semaphore must still be usable (no ObjectDisposedException).
+            var ex = Record.Exception(() => { if (oldSem.Wait(0)) oldSem.Release(); });
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public void RecordOperation_DecreasesConcurrencyOnHighLatency()
         {
             // Arrange

--- a/tests/AtomicFileTokenStoreTests.cs
+++ b/tests/AtomicFileTokenStoreTests.cs
@@ -51,6 +51,42 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
+        public async Task RapidSequentialSaves_ReleaseLockEachTime_NoStallOrThrow()
+        {
+            // Regression: the Windows cross-process lock was a thread-affine Mutex whose
+            // ReleaseMutex ran on an await-continuation / cancellation thread and failed
+            // (silently swallowed), leaving the lock held so later saves stalled (~120s) or
+            // relied on abandoned-mutex recovery. A thread-agnostic FileStream lock releases
+            // cleanly from any thread, so back-to-back saves stay fast.
+            var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n")));
+            try
+            {
+                var file = Path.Combine(dir.FullName, "tokens.json");
+                var store = CreateFileStore(file);
+
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                for (int i = 0; i < 25; i++)
+                {
+                    var env = new TokenEnvelope<SessionDto>(new SessionDto { AccessToken = $"tok{i}", RefreshToken = $"ref{i}" }, DateTime.UtcNow.AddMinutes(10));
+                    await store.SaveAsync(env);
+                }
+                sw.Stop();
+
+                // A release-on-wrong-thread failure would leave the lock held and stall the next
+                // acquire; 25 prompt saves must finish well under the lock's acquire timeout.
+                Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30), $"25 sequential saves took {sw.Elapsed} — cross-process lock likely not released between saves");
+
+                var loaded = await store.LoadAsync();
+                Assert.NotNull(loaded);
+                Assert.Equal("tok24", loaded!.Session.AccessToken);
+            }
+            finally
+            {
+                try { Directory.Delete(dir.FullName, true); } catch { }
+            }
+        }
+
+        [Fact]
         public async Task Ignores_Stale_Temp_File()
         {
             var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n")));

--- a/tests/FileStreamingResponseCacheTests.cs
+++ b/tests/FileStreamingResponseCacheTests.cs
@@ -117,6 +117,39 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
+        public async Task Set_ConcurrentWritesSameKey_ProduceValidEntry_NoCorruption()
+        {
+            // Regression: concurrent Set() for the same key collided on a shared "<path>.tmp"
+            // and a non-atomic delete-then-move, silently dropping/corrupting writes. With a
+            // unique temp name + atomic overwrite move, concurrent writers converge to one valid entry.
+            var endpoint = "/api/concurrent";
+            var parameters = new Dictionary<string, string> { { "k", "v" } };
+            const int writers = 40;
+
+            var tasks = Enumerable.Range(0, writers).Select(i => Task.Run(() =>
+            {
+                var resp = new CachedHttpResponse
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    ContentType = "application/json",
+                    Body = Encoding.UTF8.GetBytes($"{{\"n\":{i}}}"),
+                    StoredAt = DateTimeOffset.UtcNow
+                };
+                _cache.Set(endpoint, parameters, resp);
+            })).ToArray();
+
+            await Task.WhenAll(tasks);
+
+            // Must hold exactly one valid, fully-deserialized entry (not corrupt or missing).
+            var result = _cache.Get<CachedHttpResponse>(endpoint, parameters);
+            Assert.NotNull(result);
+            Assert.Equal(HttpStatusCode.OK, result!.StatusCode);
+            Assert.NotNull(result.Body);
+            var body = Encoding.UTF8.GetString(result.Body);
+            Assert.Matches(@"^\{""n"":\d+\}$", body); // a complete, uncorrupted body from some writer
+        }
+
+        [Fact]
         public void Get_ReturnsNullForInvalidType()
         {
             // Arrange

--- a/tests/HttpClientExtensionsTests.cs
+++ b/tests/HttpClientExtensionsTests.cs
@@ -226,6 +226,48 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
+        public async Task ExecuteWithResilienceAsync_CapsRedirectChain_DoesNotLoopForever()
+        {
+            // Regression: a redirect cycle previously looped forever — the redirect `continue`
+            // path never checked the retry-budget deadline and there was no hop cap.
+            var host = $"redir-{Guid.NewGuid():N}.example";
+            var calls = 0;
+            var handler = new StubHandler(req =>
+            {
+                var n = System.Threading.Interlocked.Increment(ref calls);
+                if (n > 50)
+                {
+                    // Safety valve so a regression fails fast instead of hanging the test host.
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+                }
+                var resp = new HttpResponseMessage(HttpStatusCode.PermanentRedirect); // 308 preserves method
+                resp.Headers.Location = new Uri($"https://{host}/r{n}");
+                return Task.FromResult(resp);
+            });
+            using var client = new HttpClient(handler);
+
+            using var result = await client.ExecuteWithResilienceAsync(
+                new HttpRequestMessage(HttpMethod.Get, $"https://{host}/start"),
+                maxRetries: 0,
+                retryBudget: TimeSpan.FromSeconds(30),
+                maxConcurrencyPerHost: 1,
+                perRequestTimeout: null,
+                cancellationToken: CancellationToken.None);
+
+            try
+            {
+                // The chain must be bounded (~maxRedirects + 1), not run to the safety valve.
+                Assert.True(calls <= 12, $"redirect chain was not capped: {calls} requests were made");
+                // After the hop budget is exhausted, the last redirect response is returned (not the 500 valve).
+                Assert.Equal(HttpStatusCode.PermanentRedirect, result.StatusCode);
+            }
+            finally
+            {
+                ClearHostGate(host);
+            }
+        }
+
+        [Fact]
         public async Task ExecuteWithResilienceAsync_ThrowsTimeoutExceptionWhenPerRequestTimeoutExceeded()
         {
             var handler = new StubHandler(async (req, ct) =>


### PR DESCRIPTION
Fixes the 4 Common findings from the adversarial defect hunt (each verified; TDD regression test added).

| Sev | File | Bug | Fix |
|----|------|-----|-----|
| HIGH | `HttpClientExtensions.cs` | 3xx redirects followed with no hop cap; redirect `continue` skips the retry-budget deadline → **infinite loop** on a redirect cycle | `maxRedirects`(10) cap + deadline guard in both 307/308 and 301/302 branches |
| HIGH | `AdaptiveConcurrencyManager.cs` | `ApplyAdjustment` disposes the swapped-out `_sharedSemaphore` while in-flight callers hold it → `ObjectDisposedException` | stop disposing the old semaphore (no unmanaged handle; GC reclaims once drained) |
| MED | `FileStreamingResponseCache.cs` | concurrent `Set()` same key collide on shared `<path>.tmp` + non-atomic delete-then-move | unique temp name + atomic overwrite move; removed dead `_gate` field |
| MED | `FileTokenStore.cs` | Windows cross-process lock = thread-affine `Mutex`; `ReleaseMutex` off-thread (await continuation / cancellation cb) fails silently → lock held | use thread-agnostic `FileLockScope` on all platforms; removed `NamedMutexScope` |

Local: HttpClientExtensions 75, AdaptiveConcurrencyManager 39, FileStreamingResponseCache+AtomicFileTokenStore 40 — all green. CI runs the full suite on ubuntu+windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)