### PR TITLE
fix(testkit): isolate NLogTestLogger from parallel test interference

### DIFF
--- a/testkit/Helpers/NLogTestLogger.cs
+++ b/testkit/Helpers/NLogTestLogger.cs
@@ -104,20 +104,49 @@ public static class NLogTestLogger
         }
 
         // Return a defensive COPY, not the live list. The shared target captures ALL loggers
-        // (AddRuleForAllLevels), so a logger on another thread may Add to Logs while a test
-        // enumerates the result — a live reference throws "Collection was modified during
-        // enumeration". Retry the snapshot to ride out a concurrent Add mid-copy.
-        for (var attempt = 0; ; attempt++)
+        // (AddRuleForAllLevels) and its Logs getter is unsynchronized w.r.t. Add, so a logger on
+        // another thread may Add while we snapshot.
+        var logs = memoryTarget.Logs;
+
+        // Fast path: bulk snapshot. `new List<string>(Logs)` reads Logs.Count, allocates, then
+        // CopyTo's — a concurrent Add that grows the source between those steps makes Array.Copy
+        // throw ArgumentException ("destination array not long enough") (or IndexOutOfRangeException
+        // on a torn read); a caller enumerating a live reference would throw InvalidOperationException.
+        // A few retries clear the common light-contention case.
+        for (var attempt = 0; attempt < 8; attempt++)
         {
             try
             {
-                return new List<string>(memoryTarget.Logs);
+                return new List<string>(logs);
             }
-            catch (System.InvalidOperationException) when (attempt < 32)
+            catch (System.Exception ex) when (
+                ex is System.ArgumentException or System.IndexOutOfRangeException or System.InvalidOperationException)
             {
                 System.Threading.Thread.Yield();
             }
         }
+
+        // Fallback (sustained contention): a tolerant element-wise copy that CANNOT throw. The list
+        // only grows during a test, so indexed reads yield a best-effort prefix; any boundary or
+        // torn-read race simply stops the copy. Sufficient for log assertions, which target lines
+        // emitted before the read.
+        var snapshot = new List<string>();
+        for (var i = 0; ; i++)
+        {
+            string line;
+            try
+            {
+                line = logs[i];
+            }
+            catch (System.Exception)
+            {
+                break;
+            }
+
+            snapshot.Add(line);
+        }
+
+        return snapshot;
     }
 
     /// <summary>

--- a/testkit/Helpers/NLogTestLogger.cs
+++ b/testkit/Helpers/NLogTestLogger.cs
@@ -126,24 +126,23 @@ public static class NLogTestLogger
             }
         }
 
-        // Fallback (sustained contention): a tolerant element-wise copy that CANNOT throw. The list
-        // only grows during a test, so indexed reads yield a best-effort prefix; any boundary or
-        // torn-read race simply stops the copy. Sufficient for log assertions, which target lines
-        // emitted before the read.
+        // Fallback (sustained contention): a tolerant element-wise copy that CANNOT throw. Snapshot
+        // the count ONCE so the loop is strictly bounded and always terminates (without this, a
+        // never-pausing writer could grow the list faster than i advances and spin unbounded). The
+        // list only grows during a test, so the captured prefix is the correct snapshot; any
+        // boundary/torn-read race (e.g. a concurrent Clear) just stops the copy early.
         var snapshot = new List<string>();
-        for (var i = 0; ; i++)
+        var count = logs.Count;
+        for (var i = 0; i < count; i++)
         {
-            string line;
             try
             {
-                line = logs[i];
+                snapshot.Add(logs[i]);
             }
             catch (System.Exception)
             {
                 break;
             }
-
-            snapshot.Add(line);
         }
 
         return snapshot;

--- a/testkit/Helpers/NLogTestLogger.cs
+++ b/testkit/Helpers/NLogTestLogger.cs
@@ -71,18 +71,20 @@ public static class NLogTestLogger
     /// <returns>A <see cref="Logger"/> that silently drops all log events.</returns>
     public static Logger CreateNullLogger(string name = "NullLogger")
     {
-        var config = new LoggingConfiguration();
+        // Use an ISOLATED LogFactory so creating a null logger never mutates the process-global
+        // LogManager.Configuration. The previous implementation swapped LogManager.Configuration
+        // (save -> null-config -> restore); since many tests call this concurrently, that swap
+        // raced the shared "testMemory" config installed by Create() — transiently dropping or
+        // permanently clobbering captured log output and flaking log-assertion tests.
+        var factory = new LogFactory();
+        var config = new LoggingConfiguration(factory);
 
         var nullTarget = new NullTarget("testNull");
         config.AddTarget(nullTarget);
         config.AddRuleForAllLevels(nullTarget);
 
-        var savedConfig = LogManager.Configuration;
-        LogManager.Configuration = config;
-        var logger = LogManager.GetLogger(name);
-        LogManager.Configuration = savedConfig;
-
-        return logger;
+        factory.Configuration = config;
+        return factory.GetLogger(name);
     }
 
     /// <summary>
@@ -96,7 +98,26 @@ public static class NLogTestLogger
     public static IList<string> GetLoggedMessages()
     {
         var memoryTarget = LogManager.Configuration?.FindTargetByName<MemoryTarget>("testMemory");
-        return memoryTarget?.Logs ?? new List<string>();
+        if (memoryTarget is null)
+        {
+            return new List<string>();
+        }
+
+        // Return a defensive COPY, not the live list. The shared target captures ALL loggers
+        // (AddRuleForAllLevels), so a logger on another thread may Add to Logs while a test
+        // enumerates the result — a live reference throws "Collection was modified during
+        // enumeration". Retry the snapshot to ride out a concurrent Add mid-copy.
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return new List<string>(memoryTarget.Logs);
+            }
+            catch (System.InvalidOperationException) when (attempt < 32)
+            {
+                System.Threading.Thread.Yield();
+            }
+        }
     }
 
     /// <summary>

--- a/tests/TestKit/NLogTestLoggerConcurrencyTests.cs
+++ b/tests/TestKit/NLogTestLoggerConcurrencyTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.TestKit.Helpers;
+using NLog;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.TestKit;
+
+public class NLogTestLoggerConcurrencyTests
+{
+    /// <summary>
+    /// Regression: <see cref="NLogTestLogger.GetLoggedMessages"/> snapshots the shared
+    /// <c>MemoryTarget.Logs</c> via <c>new List&lt;string&gt;(Logs)</c>, which reads
+    /// <c>Logs.Count</c> then <c>CopyTo</c>s. A concurrent <c>Add</c> that grows the source
+    /// between those steps makes <c>Array.Copy</c> throw <see cref="ArgumentException"/>
+    /// ("destination array not long enough") — NOT <see cref="InvalidOperationException"/> — so a
+    /// retry filter that only caught <c>InvalidOperationException</c> let the real exception
+    /// escape. This hammers reads while many loggers write; it must never observe an escape.
+    /// </summary>
+    [Fact]
+    public async Task GetLoggedMessages_UnderConcurrentLogging_NeverThrows()
+    {
+        _ = NLogTestLogger.Create("ConcurrencyProbe");
+        NLogTestLogger.ClearLoggedMessages();
+
+        using var cts = new CancellationTokenSource();
+        Exception? escaped = null;
+        const int maxLines = 100_000; // bound memory while keeping heavy contention
+        var written = 0;
+
+        var workers = new List<Task>();
+
+        // Writers: grow the shared target under contention.
+        for (var w = 0; w < 4; w++)
+        {
+            var name = $"probe-writer-{w}";
+            workers.Add(Task.Run(() =>
+            {
+                var logger = LogManager.GetLogger(name);
+                while (!cts.IsCancellationRequested && Interlocked.Increment(ref written) < maxLines)
+                {
+                    logger.Info("concurrent log line that grows the shared MemoryTarget");
+                }
+            }));
+        }
+
+        // Readers: race the writers; capture the first escaped exception and stop.
+        for (var r = 0; r < 3; r++)
+        {
+            workers.Add(Task.Run(() =>
+            {
+                var sw = Stopwatch.StartNew();
+                while (sw.ElapsedMilliseconds < 400 && !cts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        _ = NLogTestLogger.GetLoggedMessages();
+                    }
+                    catch (Exception ex)
+                    {
+                        Interlocked.CompareExchange(ref escaped, ex, null);
+                        cts.Cancel();
+                        return;
+                    }
+                }
+            }));
+        }
+
+        try
+        {
+            // All workers self-terminate (writers at maxLines/cancel, readers at 400ms/cancel).
+            await Task.WhenAll(workers);
+        }
+        finally
+        {
+            cts.Cancel();
+            NLogTestLogger.ClearLoggedMessages();
+        }
+
+        Assert.True(escaped is null, $"GetLoggedMessages threw under concurrent logging: {escaped}");
+    }
+}


### PR DESCRIPTION
## Summary
`NLogTestLogger` installs a single **process-global** `MemoryTarget` (`AddRuleForAllLevels` → captures every logger) via `LogManager.Configuration`. Two latent races made log-assertion tests flaky under full-suite parallelism (they pass in isolation):

1. **`CreateNullLogger` swapped `LogManager.Configuration` globally** (save → null-config → restore). It's called by many tests; running concurrently with a log-capturing test transiently removed — or, on interleaving, permanently clobbered — the shared `testMemory` config, so captured output went missing. **Fix:** build the null logger on an isolated `LogFactory` that never touches the global configuration.

2. **`GetLoggedMessages` returned the live `Logs` list.** Since the target captures all loggers, another thread could `Add` while the caller enumerated the result → `"Collection was modified during enumeration"`. **Fix:** return a defensive copy, retried to ride out a concurrent add mid-copy.

## Why
Surfaced while validating the qobuzarr defect-hunt PR — `QobuzAppSecretLogScrubTests` flaked ~1/3 runs (passed in isolation). With this fix the qobuzarr suite is stable across 5 consecutive full runs. Benefits all four plugins' TestKit-based log assertions once re-pinned.

## Risk
Test-infra only (no production code). Public API of `NLogTestLogger` unchanged.