### PR TITLE
fix: harden 4 verified high-severity defects (cache, rate-limit, circuit breaker, OAuth)

### DIFF
--- a/src/Services/Authentication/OAuthStreamingAuthenticationService.cs
+++ b/src/Services/Authentication/OAuthStreamingAuthenticationService.cs
@@ -229,7 +229,13 @@ namespace Lidarr.Plugin.Common.Services.Authentication
             lock (_refreshLock)
             {
                 // Tier 1: late-arrival cache hit (the Windows-CI hot path).
-                if (_lastRefreshSessionOut != null && _lastRefreshTokenIn == refreshToken)
+                // Guard on !IsExpired: this cache is keyed only on the input refresh token, which
+                // for providers that do NOT rotate refresh tokens never changes — so without the
+                // expiry check it would serve the first refresh's (eventually-expired) session
+                // forever, permanently wedging auth. Serving only a still-valid session preserves
+                // the rotation-dedup (concurrent callers hit it while it's fresh) while forcing a
+                // real refresh once the access token expires.
+                if (_lastRefreshSessionOut != null && !_lastRefreshSessionOut.IsExpired && _lastRefreshTokenIn == refreshToken)
                 {
                     return _lastRefreshSessionOut;
                 }

--- a/src/Services/Caching/FileStreamingResponseCache.cs
+++ b/src/Services/Caching/FileStreamingResponseCache.cs
@@ -204,10 +204,15 @@ namespace Lidarr.Plugin.Common.Services.Caching
                     try { var fi = new FileInfo(file); files.Add(fi); total += fi.Length; } catch { }
                 }
                 if ((files.Count <= _maxEntries || _maxEntries <= 0) && (total <= _maxBytes || _maxBytes <= 0)) return;
+                // Track a DECREMENTING remaining count: `files` is a snapshot whose Count never
+                // changes, so testing files.Count in the break condition kept the entry-count
+                // conjunct permanently false whenever entries were the active constraint — deleting
+                // EVERY entry (wiping the whole cache) instead of trimming to the cap.
+                var remaining = files.Count;
                 foreach (var fi in files.OrderBy(f => f.LastWriteTimeUtc))
                 {
-                    try { total -= fi.Length; File.Delete(fi.FullName); } catch { }
-                    if ((files.Count <= _maxEntries || _maxEntries <= 0) && (total <= _maxBytes || _maxBytes <= 0)) break;
+                    try { File.Delete(fi.FullName); total -= fi.Length; remaining--; } catch { }
+                    if ((remaining <= _maxEntries || _maxEntries <= 0) && (total <= _maxBytes || _maxBytes <= 0)) break;
                 }
             }
             catch { }

--- a/src/Services/Http/AdaptiveRateLimitingHandler.cs
+++ b/src/Services/Http/AdaptiveRateLimitingHandler.cs
@@ -51,6 +51,11 @@ namespace Lidarr.Plugin.Common.Services.Http
         ///   (e.g. "Tidal", "Qobuz"). Must not be null or whitespace.
         /// </param>
         /// <param name="logger">Optional logger; when null, 429 warnings are silenced.</param>
+        /// <param name="maxRetryAfterDelay">
+        ///   Ceiling for honouring a 429 <c>Retry-After</c>. A far-future Retry-After Date (or huge
+        ///   Delta) would otherwise exceed <see cref="System.Threading.Tasks.Task.Delay(System.TimeSpan, System.Threading.CancellationToken)"/>'s
+        ///   ~49.7-day limit and throw. Defaults to 5 minutes when null or negative.
+        /// </param>
         public AdaptiveRateLimitingHandler(
             IUniversalAdaptiveRateLimiter limiter,
             string serviceName,

--- a/src/Services/Http/AdaptiveRateLimitingHandler.cs
+++ b/src/Services/Http/AdaptiveRateLimitingHandler.cs
@@ -40,6 +40,7 @@ namespace Lidarr.Plugin.Common.Services.Http
         private readonly IUniversalAdaptiveRateLimiter _limiter;
         private readonly string _serviceName;
         private readonly ILogger? _logger;
+        private readonly TimeSpan _maxRetryAfterDelay;
 
         /// <summary>
         /// Initialises the handler.
@@ -53,13 +54,17 @@ namespace Lidarr.Plugin.Common.Services.Http
         public AdaptiveRateLimitingHandler(
             IUniversalAdaptiveRateLimiter limiter,
             string serviceName,
-            ILogger? logger = null)
+            ILogger? logger = null,
+            TimeSpan? maxRetryAfterDelay = null)
         {
             _limiter = limiter ?? throw new ArgumentNullException(nameof(limiter));
             if (string.IsNullOrWhiteSpace(serviceName))
                 throw new ArgumentException("Service name must not be null or whitespace.", nameof(serviceName));
             _serviceName = serviceName;
             _logger = logger;
+            // Ceiling for honouring a 429 Retry-After. A far-future Retry-After Date (or huge Delta)
+            // would otherwise exceed Task.Delay's ~49.7-day limit and throw ArgumentOutOfRangeException.
+            _maxRetryAfterDelay = maxRetryAfterDelay is { } m && m >= TimeSpan.Zero ? m : TimeSpan.FromMinutes(5);
         }
 
         /// <inheritdoc />
@@ -93,6 +98,11 @@ namespace Lidarr.Plugin.Common.Services.Http
                 && response.Headers.RetryAfter is { } retryAfter)
             {
                 TimeSpan delay = ResolveRetryAfter(retryAfter);
+                // Clamp: a far-future Retry-After Date (or an enormous Delta) yields a delay beyond
+                // Task.Delay's ~49.7-day limit, which throws ArgumentOutOfRangeException — and that
+                // escapes the OperationCanceledException-only catch below, turning a 429 into a hard
+                // request failure. Cap at a sane ceiling; blocking the call longer is never useful.
+                if (delay > _maxRetryAfterDelay) delay = _maxRetryAfterDelay;
                 if (delay > TimeSpan.Zero)
                 {
                     _logger?.LogWarning(

--- a/src/Services/Resilience/AdvancedCircuitBreaker.cs
+++ b/src/Services/Resilience/AdvancedCircuitBreaker.cs
@@ -375,6 +375,10 @@ namespace Lidarr.Plugin.Common.Services.Resilience
             {
                 _consecutiveFailures = 0;
                 _halfOpenSuccessCount = 0;
+                // Start the failure-rate window fresh after recovery. Without this, stale failures
+                // recorded before the breaker opened remain in _operationResults and can immediately
+                // re-trip the breaker the moment it closes (flapping).
+                _operationResults.Clear();
             }
 
             return new CircuitBreakerEventArgs(Name, previousState, newState, reason);

--- a/tests/AdaptiveRateLimitingHandlerTests.cs
+++ b/tests/AdaptiveRateLimitingHandlerTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Services.Http;
+using Lidarr.Plugin.Common.Services.Performance;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    public class AdaptiveRateLimitingHandlerTests
+    {
+        /// <summary>
+        /// Regression (harden campaign): a 429 carrying a far-future Retry-After Date produced a
+        /// delay beyond Task.Delay's ~49.7-day limit, throwing ArgumentOutOfRangeException that
+        /// escaped the OperationCanceledException-only catch — turning a benign 429 into a hard
+        /// request failure. The delay is now clamped; SendAsync must return the 429, not throw.
+        /// </summary>
+        [Fact]
+        public async Task SendAsync_429_FarFutureRetryAfterDate_DoesNotThrow_ReturnsResponse()
+        {
+            var limiter = new Mock<IUniversalAdaptiveRateLimiter>();
+            limiter.Setup(l => l.WaitIfNeededAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(true);
+
+            var resp429 = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            resp429.Headers.RetryAfter = new RetryConditionHeaderValue(
+                new DateTimeOffset(9999, 12, 31, 23, 59, 59, TimeSpan.Zero)); // ~8000 years out
+
+            var inner = new Mock<HttpMessageHandler>();
+            inner.Protected()
+                 .Setup<Task<HttpResponseMessage>>(
+                     "SendAsync",
+                     ItExpr.IsAny<HttpRequestMessage>(),
+                     ItExpr.IsAny<CancellationToken>())
+                 .ReturnsAsync(resp429);
+
+            // maxRetryAfterDelay: Zero clamps the (far-future) honour-wait to 0 so the handler
+            // skips Task.Delay and returns immediately — keeping the test fast and deterministic.
+            using var handler = new AdaptiveRateLimitingHandler(
+                limiter.Object, "TestSvc", logger: null, maxRetryAfterDelay: TimeSpan.Zero)
+            {
+                InnerHandler = inner.Object
+            };
+            using var client = new HttpClient(handler);
+
+            var response = await client.SendAsync(
+                new HttpRequestMessage(HttpMethod.Get, "https://example.com/v1/x"), CancellationToken.None);
+
+            // Pre-fix the unclamped far-future delay threw ArgumentOutOfRangeException from Task.Delay.
+            Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        }
+    }
+}

--- a/tests/AdvancedCircuitBreakerTests.cs
+++ b/tests/AdvancedCircuitBreakerTests.cs
@@ -48,6 +48,41 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         /// <summary>
+        /// Regression (harden campaign): the failure-rate window (_operationResults) was cleared
+        /// only in Reset(), never on the Closed transition. After half-open recovery the stale
+        /// pre-open failures lingered, keeping FailureRate elevated so a single new failure could
+        /// immediately re-trip the breaker (flapping). Closing must start the window fresh.
+        /// </summary>
+        [Fact]
+        public void Closing_After_Recovery_Clears_FailureRate_Window()
+        {
+            var fakeTime = new FakeTimeProvider();
+            var options = new AdvancedCircuitBreakerOptions
+            {
+                ConsecutiveFailureThreshold = 3,
+                BreakDuration = TimeSpan.FromSeconds(30),
+                HalfOpenSuccessThreshold = 2
+            };
+            var cb = new AdvancedCircuitBreaker("test-window-clear", options, fakeTime);
+
+            cb.RecordFailure();
+            cb.RecordFailure();
+            cb.RecordFailure();
+            Assert.Equal(CircuitState.Open, cb.State);
+            Assert.True(cb.FailureRate > 0); // window holds the pre-open failures
+
+            fakeTime.Advance(TimeSpan.FromSeconds(31));
+            Assert.Equal(CircuitState.HalfOpen, cb.State);
+
+            cb.RecordSuccess();
+            cb.RecordSuccess();
+            Assert.Equal(CircuitState.Closed, cb.State);
+
+            // Window must be cleared on recovery — stale pre-open failures must not persist.
+            Assert.Equal(0.0, cb.FailureRate);
+        }
+
+        /// <summary>
         /// Test 2: Success resets consecutive failure count.
         /// After recording failures, a success should reset the counter.       
         /// </summary>

--- a/tests/FileStreamingResponseCacheTests.cs
+++ b/tests/FileStreamingResponseCacheTests.cs
@@ -811,6 +811,38 @@ namespace Lidarr.Plugin.Common.Tests
             }
         }
 
+        [Fact]
+        public void EnforceLimits_EntryCountOverflow_TrimsToCap_DoesNotWipeAll()
+        {
+            // Regression (harden campaign): the entry-count overflow path tested files.Count — a
+            // snapshot whose value never changes — in its break condition, so once entry-count was
+            // the active constraint it deleted EVERY entry (wiping the whole cache) instead of
+            // trimming to the cap. With max=5, writing 6 entries previously left 0; expect 5.
+            var folder = Path.Combine(Path.GetTempPath(), "cache-limits-wipe-" + Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable("ARR_RESP_CACHE_MAX_ENTRIES", "5");
+            try
+            {
+                var cache = new FileStreamingResponseCache(folder, TimeSpan.FromHours(1));
+                for (int i = 0; i < 6; i++)
+                {
+                    cache.Set($"/api/item-{i}", new Dictionary<string, string>(),
+                        new CachedHttpResponse { Body = Encoding.UTF8.GetBytes($"data-{i}") });
+                }
+
+                // Count is the robust proof: bug wiped everything (0 remain), fix trims to the cap.
+                // (Which specific entries survive isn't asserted — in a sub-millisecond write loop
+                // all files share a LastWriteTimeUtc, so the oldest-first ordering among ties is
+                // arbitrary; eviction order is exercised separately by EnforceLimits_RemovesOldestEntries.)
+                var jsonCount = Directory.GetFiles(folder, "*.json", SearchOption.AllDirectories).Length;
+                Assert.Equal(5, jsonCount);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ARR_RESP_CACHE_MAX_ENTRIES", null);
+                try { Directory.Delete(folder, recursive: true); } catch { }
+            }
+        }
+
         #endregion
 
         #region Parameter Ordering Tests

--- a/tests/OAuthStreamingAuthenticationServiceTests.cs
+++ b/tests/OAuthStreamingAuthenticationServiceTests.cs
@@ -159,6 +159,34 @@ namespace Lidarr.Plugin.Common.Tests
 
         #endregion
 
+        #region RefreshTokensAsync Late-Arrival Cache Regression
+
+        [Fact]
+        public async Task RefreshTokensAsync_NonRotatingToken_DoesNotServeExpiredCachedSession()
+        {
+            // Regression (harden campaign): the Tier-1 late-arrival cache is keyed only on the
+            // refresh-token value. For providers that do NOT rotate refresh tokens that key never
+            // changes, so without an expiry guard it served the first (eventually-expired) session
+            // forever — permanently wedging auth. A refresh after the cached session expires must
+            // hit the provider again.
+            var service = new TestOAuthService();
+            var input = new TestAuthSession { RefreshToken = "rt", AccessToken = "input", ExpiresAt = DateTime.UtcNow.AddHours(-1) };
+
+            // First refresh returns an already-expired session (cached as the late-arrival result).
+            service.SetRefreshResult("rt", new TestAuthSession { AccessToken = "v1", RefreshToken = "rt", ExpiresAt = DateTime.UtcNow.AddHours(-1) });
+            var first = await service.RefreshTokensAsync(input);
+            Assert.Equal("v1", first.AccessToken);
+
+            // The provider would now return a fresh token; the (non-rotating) refresh token is unchanged.
+            service.SetRefreshResult("rt", new TestAuthSession { AccessToken = "v2", RefreshToken = "rt", ExpiresAt = DateTime.UtcNow.AddHours(1) });
+            var second = await service.RefreshTokensAsync(input);
+
+            // Pre-fix the Tier-1 cache served the stale expired "v1"; post-fix a real refresh yields "v2".
+            Assert.Equal("v2", second.AccessToken);
+        }
+
+        #endregion
+
         #region InitiateOAuthFlowAsync Tests
 
         [Fact]


### PR DESCRIPTION
## Summary
First batch from the adversarial-harden campaign (converging multi-wave review, each finding skeptic-verified). Every finding here was **independently re-verified against the code** before fixing, and each has a regression test.

### 🔴 `FileStreamingResponseCache.EnforceLimits` wiped the entire cache
The eviction loop's break condition tested `files.Count` — a snapshot whose value never changes — so once the **entry-count** cap (not bytes) was the active constraint, the first conjunct stayed false forever and it deleted **every** entry instead of trimming to the cap. Default config (20000 entries / 256 MB): one overflow past 20000 small entries wiped the whole response cache. Now tracks a decrementing `remaining` count.

### 🔴 `AdaptiveRateLimitingHandler` crashed on a far-future `Retry-After`
A 429 with a `Retry-After` **Date** far in the future (or an enormous Delta) made `ResolveRetryAfter` return an unclamped delay > `Task.Delay`'s ~49.7-day limit → `ArgumentOutOfRangeException` that **escaped the `OperationCanceledException`-only catch**, turning a benign 429 into a hard request failure. Now clamps to a ceiling (new optional `maxRetryAfterDelay` ctor param, default 5 min).

### 🔴 `OAuthStreamingAuthenticationService` served an expired session forever (non-rotating tokens)
The Tier-1 late-arrival cache is keyed only on the refresh-token value. For providers that **don't rotate** refresh tokens, that key never changes, so it returned the first refresh's session forever — including after its access token expired — permanently wedging auth. Now guards the Tier-1 hit on `!IsExpired` (rotation single-flight dedup preserved).

### 🔴 `AdvancedCircuitBreaker` re-tripped immediately after recovery
The failure-rate window (`_operationResults`) was cleared only in `Reset()`, never on the Closed transition. After half-open recovery the stale pre-open failures lingered, so a single new failure could instantly re-open the breaker (flapping). Now clears the window on Close.

## Tests
Regression test per fix: entry-count trim-not-wipe; far-future Retry-After returns the 429; OAuth cache forces a real refresh once expired; failure-rate window cleared on recovery.

**Full suite: 3417 passed, 1 skip.** (Local run also shows `MultiPluginAlcTests`/`PackageClosure` failing — those load sibling plugins' `bin/` DLLs and are `[SkippableFact]`; they skip in CI where sibling plugins aren't pre-built. Unrelated to these changes.)