### PR TITLE
AuthFailureGate consumer helpers + rate-limiter lane fix

### DIFF
--- a/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -21,3 +21,5 @@ Lidarr.Plugin.Common.Services.Performance.NamedServiceRateLimiter.RecordResponse
 Lidarr.Plugin.Common.Services.Performance.NamedServiceRateLimiter.RecordResponse(string! service, string! endpoint, System.Net.Http.HttpResponseMessage! response) -> void
 Lidarr.Plugin.Common.Services.Performance.NamedServiceRateLimiter.WaitIfNeededAsync(string! endpoint, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<bool>!
 Lidarr.Plugin.Common.Services.Performance.NamedServiceRateLimiter.WaitIfNeededAsync(string! service, string! endpoint, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<bool>!
+Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.ShouldShortCircuit() -> bool
+Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.RecordExceptionOutcome(System.Exception! ex, System.Func<System.Exception!, Lidarr.Plugin.Abstractions.Contracts.AuthFailure?>! classify) -> void

--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -50,3 +50,5 @@ static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.ResolveRetryA
 static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.ResolveRetryAfter(System.Net.Http.HttpResponseMessage? response) -> System.TimeSpan
 static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.BuildHostFirstSegmentKey(System.Net.Http.HttpRequestMessage! request, string! unknownKey = "unknown") -> string!
 static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.BuildHostFirstSegmentKey(System.Uri? uri, string! unknownKey = "unknown") -> string!
+Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.ShouldShortCircuit() -> bool
+Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.RecordExceptionOutcome(System.Exception! ex, System.Func<System.Exception!, Lidarr.Plugin.Abstractions.Contracts.AuthFailure?>! classify) -> void

--- a/src/Services/Bridge/AuthFailureGate.cs
+++ b/src/Services/Bridge/AuthFailureGate.cs
@@ -115,6 +115,64 @@ public sealed class AuthFailureGate
         => Handler.HandleSuccessAsync(cancellationToken);
 
     /// <summary>
+    /// Consumer-side convenience for bridge entry points (indexer / download-client
+    /// <c>Search</c>, <c>Download</c>, <c>Test</c>). Returns true when auth is latched
+    /// bad AND no probe slot is currently available — i.e. the caller should
+    /// short-circuit (return empty / fail fast) without touching the network. This is
+    /// the qobuzarr-incident amplification fix: when Lidarr's search loop drives the
+    /// plugin at full rate, refuse to forward every call upstream until the user
+    /// re-credentials.
+    /// <para>
+    /// Equivalent to <c>!IsHealthy &amp;&amp; !TryAcquireProbeSlot()</c>. NOTE: like
+    /// <see cref="TryAcquireProbeSlot"/>, this CONSUMES the per-interval probe slot as a
+    /// side effect when latched, so call it at most once per entry-point invocation.
+    /// </para>
+    /// Lifted from the byte-identical <c>IsAuthShortCircuited</c> helpers that
+    /// applemusicarr / tidalarr / qobuzarr each re-implemented at their bridge entry
+    /// points.
+    /// </summary>
+    public bool ShouldShortCircuit()
+    {
+        if (IsHealthy) return false;
+        return !TryAcquireProbeSlot();
+    }
+
+    /// <summary>
+    /// Consumer-side convenience: classify <paramref name="ex"/> via the supplied
+    /// <paramref name="classify"/> delegate and, when it maps to an auth failure,
+    /// record it on the gate so the gate latches. <paramref name="classify"/> returns
+    /// <c>null</c> when the exception is NOT an auth failure (no latch) — this is the
+    /// only service-specific part each plugin supplies (401/403, plus e.g. apple's
+    /// "user token" <see cref="InvalidOperationException"/>).
+    /// <para>
+    /// <strong>Why this lives in Common:</strong> every bridge entry point was
+    /// duplicating the <c>Task.Run(() =&gt; Handler.HandleFailureAsync(failure).AsTask())
+    /// .GetAwaiter().GetResult()</c> hop. That sync-over-async pattern (Category A) is a
+    /// deadlock trap — a direct <c>.GetAwaiter().GetResult()</c> on the handler's
+    /// <see cref="ValueTask"/> can deadlock under Lidarr's single-threaded host
+    /// <see cref="SynchronizationContext"/> because the async continuation is posted
+    /// back to the blocked context. Encapsulating it once means the error-prone line
+    /// has a single tested home.
+    /// </para>
+    /// </summary>
+    /// <param name="ex">The exception observed at the bridge entry point.</param>
+    /// <param name="classify">
+    /// Maps an exception to an <see cref="AuthFailure"/> (latch) or <c>null</c> (ignore).
+    /// </param>
+    public void RecordExceptionOutcome(Exception ex, Func<Exception, AuthFailure?> classify)
+    {
+        if (ex is null) throw new ArgumentNullException(nameof(ex));
+        if (classify is null) throw new ArgumentNullException(nameof(classify));
+
+        AuthFailure? failure = classify(ex);
+        if (failure is null) return;
+
+        // SYNC-OVER-ASYNC (Category A): hop to the thread-pool before blocking on the
+        // ValueTask so we don't deadlock the host's single-threaded SynchronizationContext.
+        Task.Run(() => Handler.HandleFailureAsync(failure).AsTask()).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
     /// True when the underlying handler is in a state that allows requests to
     /// proceed without restriction (Authenticated or Unknown AND no in-flight
     /// failure streak). With <c>failureThreshold &gt; 1</c>, the K-1 failures

--- a/src/Services/Performance/UniversalAdaptiveRateLimiter.cs
+++ b/src/Services/Performance/UniversalAdaptiveRateLimiter.cs
@@ -288,27 +288,42 @@ namespace Lidarr.Plugin.Common.Services.Performance
                 ConsecutiveErrors = 0
             });
 
+            TimeSpan delay;
             await _semaphore.WaitAsync(cancellationToken);
             try
             {
                 var now = DateTime.UtcNow;
-                var timeSinceLastRequest = now - limit.LastRequest;
                 var minInterval = TimeSpan.FromMilliseconds(60000.0 / limit.RequestsPerMinute);
 
-                if (timeSinceLastRequest < minInterval)
-                {
-                    var delay = minInterval - timeSinceLastRequest;
-                    await Task.Delay(delay, cancellationToken);
-                }
+                // Reserve the next pacing slot under the lock, then wait for it OUTSIDE the lock.
+                // Previously the per-SERVICE semaphore was held across `await Task.Delay`, which
+                // serialized every endpoint's requests into a single lane and paid each pacing
+                // delay sequentially (a 1000-item burst degraded to one-at-a-time across the whole
+                // service). By claiming LastRequest = the reserved slot here, concurrent callers —
+                // same or different endpoint — each get a monotonically-spaced slot and wait in
+                // parallel: per-endpoint pacing is preserved, cross-endpoint throughput is not
+                // throttled to one request at a time. The only work under the lock is the O(1) slot
+                // computation; no I/O. (LastRequest is read/written only here, so retargeting it
+                // to "next reserved slot" has no other observers.)
+                var nextSlot = (limit.LastRequest == DateTime.MinValue || (now - limit.LastRequest) >= minInterval)
+                    ? now
+                    : limit.LastRequest + minInterval;
+                delay = nextSlot - now;
+                if (delay < TimeSpan.Zero)
+                    delay = TimeSpan.Zero;
 
-                limit.LastRequest = DateTime.UtcNow;
+                limit.LastRequest = nextSlot;
                 limit.TotalRequests++;
-                return true;
             }
             finally
             {
                 _semaphore.Release();
             }
+
+            if (delay > TimeSpan.Zero)
+                await Task.Delay(delay, cancellationToken);
+
+            return true;
         }
 
         public void RecordResponse(string endpoint, HttpResponseMessage response)

--- a/tests/Bridge/AuthFailureGateConsumerHelpersTests.cs
+++ b/tests/Bridge/AuthFailureGateConsumerHelpersTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading.Tasks;
+
+using Lidarr.Plugin.Abstractions.Contracts;
+using Lidarr.Plugin.Common.Services.Bridge;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Bridge;
+
+/// <summary>
+/// Tests for the consumer-side convenience helpers <see cref="AuthFailureGate.ShouldShortCircuit"/>
+/// and <see cref="AuthFailureGate.RecordExceptionOutcome"/> — lifted from the byte-identical
+/// IsAuthShortCircuited / RecordAuthOutcomeFromException helpers that applemusicarr, tidalarr
+/// and qobuzarr each duplicated at their bridge entry points.
+/// </summary>
+public sealed class AuthFailureGateConsumerHelpersTests
+{
+    private static AuthFailureGate NewGate(out FakeClock clock, TimeSpan? probeInterval = null)
+    {
+        clock = new FakeClock(new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero));
+        var handler = new DefaultAuthFailureHandler(NullLogger<DefaultAuthFailureHandler>.Instance);
+        return new AuthFailureGate(handler, clock, probeInterval ?? TimeSpan.FromSeconds(60),
+            NullLogger<AuthFailureGate>.Instance);
+    }
+
+    [Fact]
+    public void ShouldShortCircuit_WhenHealthy_ReturnsFalse()
+    {
+        var gate = NewGate(out _);
+        Assert.False(gate.ShouldShortCircuit()); // Unknown/healthy never short-circuits
+    }
+
+    [Fact]
+    public async Task ShouldShortCircuit_WhenLatched_AllowsOneProbeThenShortCircuits()
+    {
+        var gate = NewGate(out _, probeInterval: TimeSpan.FromSeconds(60));
+        await gate.Handler.HandleFailureAsync(new AuthFailure { ErrorCode = "401", Message = "bad token" });
+
+        // First call after latch consumes the single per-interval probe slot → allow it through.
+        Assert.False(gate.ShouldShortCircuit());
+        // No slot left within the interval → short-circuit subsequent calls.
+        Assert.True(gate.ShouldShortCircuit());
+        Assert.True(gate.ShouldShortCircuit());
+    }
+
+    [Fact]
+    public async Task ShouldShortCircuit_WhenLatched_RefreshesProbeAfterInterval()
+    {
+        var gate = NewGate(out var clock, probeInterval: TimeSpan.FromSeconds(60));
+        await gate.Handler.HandleFailureAsync(new AuthFailure { Message = "fail" });
+
+        Assert.False(gate.ShouldShortCircuit()); // probe 1
+        Assert.True(gate.ShouldShortCircuit());  // rate-limited
+        clock.Advance(TimeSpan.FromSeconds(61));
+        Assert.False(gate.ShouldShortCircuit()); // probe 2 after interval elapses
+    }
+
+    [Fact]
+    public void RecordExceptionOutcome_WhenClassifyReturnsNull_DoesNotLatch()
+    {
+        var gate = NewGate(out _);
+        gate.RecordExceptionOutcome(new InvalidOperationException("not an auth problem"), _ => null);
+
+        Assert.True(gate.IsHealthy);
+        gate.EnsureCanProceed(); // must not throw
+    }
+
+    [Fact]
+    public void RecordExceptionOutcome_WhenClassifyReturnsFailure_Latches()
+    {
+        var gate = NewGate(out _);
+        var ex = new System.Net.Http.HttpRequestException("unauthorized", null, System.Net.HttpStatusCode.Unauthorized);
+
+        gate.RecordExceptionOutcome(ex, e => new AuthFailure
+        {
+            ErrorCode = (e as System.Net.Http.HttpRequestException)?.StatusCode?.ToString(),
+            Message = e.Message,
+        });
+
+        Assert.False(gate.IsHealthy);
+        var thrown = Assert.Throws<AuthGatedException>(() => gate.EnsureCanProceed());
+        Assert.Equal("Unauthorized", thrown.ErrorCode);
+    }
+
+    [Fact]
+    public void RecordExceptionOutcome_NullException_Throws()
+    {
+        var gate = NewGate(out _);
+        Assert.Throws<ArgumentNullException>(() => gate.RecordExceptionOutcome(null!, _ => null));
+    }
+
+    [Fact]
+    public void RecordExceptionOutcome_NullClassify_Throws()
+    {
+        var gate = NewGate(out _);
+        Assert.Throws<ArgumentNullException>(() => gate.RecordExceptionOutcome(new Exception(), null!));
+    }
+
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeClock(DateTimeOffset start) => _now = start;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
Two Common improvements consumed by the streaming plugins:
- feat(bridge): AuthFailureGate.ShouldShortCircuit() + RecordExceptionOutcome() — lifts the byte-identical consumer-helper trio (incl. the Category-A sync-over-async hop) out of 6 duplicated bridge entry points across apple/tidal/qobuz. PublicAPI registered; 7 new tests.
- perf(ratelimit): ServiceRateLimiter reserves the pacing slot under the lock then waits OUTSIDE it — stops serializing a whole service through one lane while preserving per-endpoint pacing.

Validated locally: 76 AuthFailureGate + rate-limiter tests green on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)