### PR TITLE
fix(local-ci): accept includedFrameworks in .NET 8 runtime guardrail

### DIFF
--- a/scripts/local-ci.ps1
+++ b/scripts/local-ci.ps1
@@ -304,6 +304,12 @@ if ($SkipExtract) {
         if (-not $runtimeVersion -and $rtOpts -and $rtOpts.PSObject.Properties['frameworks']) {
             $runtimeVersion = ($rtOpts.frameworks | Where-Object { $_.name -eq 'Microsoft.NETCore.App' }).version
         }
+        # Self-contained Lidarr images (e.g. ghcr.io/hotio/lidarr:pr-plugins-*) ship the
+        # runtime inside the app, so runtimeconfig carries `includedFrameworks` instead of
+        # a framework reference. Probe it last so framework-dependent layouts still win.
+        if (-not $runtimeVersion -and $rtOpts -and $rtOpts.PSObject.Properties['includedFrameworks']) {
+            $runtimeVersion = ($rtOpts.includedFrameworks | Where-Object { $_.name -eq 'Microsoft.NETCore.App' }).version
+        }
         if (-not $runtimeVersion -or -not $runtimeVersion.StartsWith('8.')) {
             throw ".NET 8 guardrail FAILED: runtime version is '$runtimeVersion' (expected 8.x)"
         }


### PR DESCRIPTION
## Problem
The EXTRACT-stage `.NET 8 guardrail` in `scripts/local-ci.ps1` read the host runtime version from `runtimeOptions.framework` (singular) or `runtimeOptions.frameworks` (plural), then asserted it starts with `8.`.

The canonical CI image `ghcr.io/hotio/lidarr:pr-plugins-3.1.2.4913` is **self-contained**, so its `Lidarr.runtimeconfig.json` carries `includedFrameworks` instead:

```json
"runtimeOptions": { "tfm": "net8.0", "includedFrameworks": [ { "name": "Microsoft.NETCore.App", "version": "8.0.12" }, ... ] }
```

Neither probe matched → version resolved to `''` → guardrail threw `".NET 8 guardrail FAILED: runtime version is '' (expected 8.x)"` on a perfectly valid .NET 8 host. This broke the **Docker E2E** build stage (`verify-local.ps1 -SkipTests`) across the plugin ecosystem (tidalarr/qobuzarr/brainarr).

## Fix
Add `includedFrameworks` as a final probe (framework-dependent layouts still take precedence). This mirrors the sibling bash guardrail `scripts/ci/assert-net8-runtime.sh`, which already greps for `"version": "8."` anywhere in the file and was therefore unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)