### PR TITLE
feat(packaging-gates): make canonical-abstractions sidecar opt-in

### DIFF
--- a/.github/workflows/packaging-gates.yml
+++ b/.github/workflows/packaging-gates.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: true
+      require-canonical-abstractions:
+        description: "Inject + SHA-verify the canonical Lidarr.Plugin.Abstractions.dll as a sidecar in the package. Set false for plugins that internalize Abstractions via ILRepack (their package ships no Abstractions sidecar, matching their expected-contents.txt)."
+        required: false
+        type: boolean
+        default: true
       plugin-load-gate:
         description: "Load plugin package via Abstractions PluginLoader and create components (Abstractions-based plugins only)"
         required: false
@@ -187,14 +192,22 @@ jobs:
 
           Import-Module (Resolve-Path -LiteralPath $pluginPack) -Force
 
-          $zipPath = (New-PluginPackage `
-            -Csproj $csproj `
-            -Manifest $manifest `
-            -Framework $framework `
-            -Configuration $configuration `
-            -RequireCanonicalAbstractions `
-            -ResolveEntryPoints `
-            -AdditionalKeepAssemblies $additionalKeep | Select-Object -Last 1)
+          # Canonical Abstractions sidecar is opt-in: plugins that internalize
+          # Abstractions via ILRepack (e.g. tidalarr/qobuzarr) pass
+          # require-canonical-abstractions=false so the package ships no sidecar,
+          # matching what their release.yml produces and their expected-contents.txt.
+          $packArgs = @{
+            Csproj = $csproj
+            Manifest = $manifest
+            Framework = $framework
+            Configuration = $configuration
+            ResolveEntryPoints = $true
+            AdditionalKeepAssemblies = $additionalKeep
+          }
+          if ('${{ inputs.require-canonical-abstractions }}' -eq 'true') {
+            $packArgs['RequireCanonicalAbstractions'] = $true
+          }
+          $zipPath = (New-PluginPackage @packArgs | Select-Object -Last 1)
 
           if (-not $zipPath) { throw "New-PluginPackage returned an empty path." }
           if (-not (Test-Path -LiteralPath $zipPath)) { throw "Package not found at: $zipPath" }
@@ -269,6 +282,7 @@ jobs:
           }
 
       - name: Canonical Abstractions gate
+        if: ${{ inputs.require-canonical-abstractions }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Problem
The reusable `packaging-gates.yml` hard-codes `-RequireCanonicalAbstractions` in its `New-PluginPackage` call, forcing **every** caller to ship `Lidarr.Plugin.Abstractions.dll` as a SHA-verified sidecar.

Plugins that **internalize** Abstractions via ILRepack (tidalarr, qobuzarr) ship no sidecar — their real release zips contain just the merged plugin DLL + `plugin.json`, and their `expected-contents.txt` **forbids** the sidecar. So the contents-manifest gate fails:

```
::error::Found FORBIDDEN: lidarr.plugin.abstractions.dll
Contents manifest gate failed: 0 missing, 1 forbidden.
```

i.e. the gate validates a package the plugin never actually ships. (brainarr avoids this only because it pins the older `@workflows/v1`, which predates the `-RequireCanonicalAbstractions` addition.)

## Fix
Add a `require-canonical-abstractions` input (**default `true`**, so sidecar plugins are unaffected). When `false`:
- `New-PluginPackage` is invoked **without** `-RequireCanonicalAbstractions` (no sidecar injection), via a splat.
- The **Canonical Abstractions gate** step is skipped (`if: ${{ inputs.require-canonical-abstractions }}`).

The gate then validates the internalized package the plugin actually releases, and `expected-contents.txt` (which forbids the sidecar) is the single source of truth.

Callers that internalize set `require-canonical-abstractions: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)