### PR TITLE
fix(dedup): prevent ArgumentOutOfRangeException on punctuated names (AC/DC, P!nk)

### DIFF
--- a/src/Services/Deduplication/RequestDeduplicator.cs
+++ b/src/Services/Deduplication/RequestDeduplicator.cs
@@ -255,12 +255,15 @@ namespace Lidarr.Plugin.Common.Services.Deduplication
             if (string.IsNullOrWhiteSpace(component))
                 return "empty";
 
-            // Remove special characters and normalize case
-            return System.Text.RegularExpressions.Regex.Replace(
+            // Remove special characters and normalize case. Stripping non-word chars can shorten
+            // the string (e.g. "AC/DC" -> "acdc"), so the length cap must use the transformed
+            // string's length — bounding by the original component.Length threw
+            // ArgumentOutOfRangeException for punctuated names.
+            var normalized = System.Text.RegularExpressions.Regex.Replace(
                 component.ToLowerInvariant().Trim(),
                 @"[^\w\s]", "")
-                .Replace(" ", "_")
-                .Substring(0, Math.Min(component.Length, 50)); // Limit length
+                .Replace(" ", "_");
+            return normalized.Substring(0, Math.Min(normalized.Length, 50)); // Limit length
         }
 
         /// <summary>

--- a/tests/RequestDeduplicatorMoreCovTests.cs
+++ b/tests/RequestDeduplicatorMoreCovTests.cs
@@ -53,6 +53,49 @@ namespace Lidarr.Plugin.Common.Tests
             Assert.Equal("discography_empty", key);
         }
 
+        [Theory]
+        // Names whose length shrinks once non-word chars are stripped (or which become empty)
+        // crashed the old Substring(0, original.Length) bound with ArgumentOutOfRangeException.
+        [InlineData("AC/DC")]              // -> "acdc" (4) but bounded by original length 5
+        [InlineData("P!nk")]              // -> "pnk" (3) bounded by 4
+        [InlineData("Panic! at the Disco")]
+        [InlineData("***")]               // -> "" (0) bounded by 3 — non-whitespace so not short-circuited
+        [InlineData("!!!")]               // "Chk Chk Chk"
+        public void CreateSearchKey_DoesNotThrow_ForNamesShortenedByNormalization(string artist)
+        {
+            using var deduper = new RequestDeduplicator(NullLogger<RequestDeduplicator>.Instance);
+
+            var ex = Record.Exception(() => deduper.CreateSearchKey(artist, "Some Album!!"));
+
+            Assert.Null(ex);
+        }
+
+        [Theory]
+        [InlineData("AC/DC")]
+        [InlineData("***")]
+        public void CreateDiscographyKey_DoesNotThrow_ForNamesShortenedByNormalization(string artist)
+        {
+            using var deduper = new RequestDeduplicator(NullLogger<RequestDeduplicator>.Instance);
+
+            var ex = Record.Exception(() => deduper.CreateDiscographyKey(artist));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void CreateSearchKey_TruncatesLongComponents_To50Chars()
+        {
+            using var deduper = new RequestDeduplicator(NullLogger<RequestDeduplicator>.Instance);
+
+            // 80 word chars -> after normalization should be capped at 50 in the component.
+            var longName = new string('a', 80);
+            var key = deduper.CreateSearchKey(longName);
+
+            // Key shape is "search_artist_<normalized>"; the normalized component must be <= 50.
+            var component = key.Substring("search_artist_".Length);
+            Assert.True(component.Length <= 50, $"component length {component.Length} should be <= 50");
+        }
+
         [Fact]
         public async Task GetOrCreateAsync_PropagatesFactoryException_WhenFactoryThrows()
         {


### PR DESCRIPTION
## Problem
`RequestDeduplicator.NormalizeKeyComponent` strips non-word characters and then truncates with `Substring(0, Math.Min(component.Length, 50))` — using the **original** component length. When stripping shortens the string, the bound exceeds the result's length and throws `ArgumentOutOfRangeException`.

This crashes on common, punctuated artist/album names via the public `CreateSearchKey` / `CreateDiscographyKey` helpers:

| Input | After strip | Bound | Result |
|---|---|---|---|
| `AC/DC` | `acdc` (4) | `Substring(0, 5)` | **throws** |
| `P!nk` | `pnk` (3) | `Substring(0, 4)` | **throws** |
| `***` | `` (0) | `Substring(0, 3)` | **throws** |

(`***`/`!!!` are non-whitespace, so the `IsNullOrWhiteSpace` guard doesn't catch them.)

## Fix
Cap by the **transformed** string's own length. Adds `Theory` coverage for names shortened/emptied by normalization, plus a >50-char truncation guard.

## Verification
`RequestDeduplicator` tests: 24/24 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)