### PR TITLE
fix(pathguard): accept children when configured root has a trailing separator

### DIFF
--- a/src/HostBridge/PathTraversalGuard.cs
+++ b/src/HostBridge/PathTraversalGuard.cs
@@ -123,6 +123,14 @@ public static class PathTraversalGuard
     private static bool IsDescendant(string canonical, string root)
     {
         var rootCanonical = Path.GetFullPath(root);
+        // Path.GetFullPath PRESERVES a trailing separator, so a user-configured root like
+        // "/downloads/qobuz/" stays "/downloads/qobuz/". Without trimming it, the
+        // "rootCanonical + separator" prefix below becomes a DOUBLE separator
+        // ("/downloads/qobuz//") that no legitimate child starts with — which previously
+        // rejected every download path ("refusing to build output path ... resolves outside
+        // the configured DownloadPath"). Trim trailing separators so the descendant check is
+        // exact regardless of whether the configured root ends with a slash.
+        rootCanonical = rootCanonical.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         if (canonical.Equals(rootCanonical, OsAwareComparison))
         {
             return true;

--- a/tests/HostBridge/PathTraversalGuardTests.cs
+++ b/tests/HostBridge/PathTraversalGuardTests.cs
@@ -106,6 +106,31 @@ public class PathTraversalGuardTests
         Assert.True(PathTraversalGuard.IsPathWithinRoot(root, root));
     }
 
+    [Theory]
+    [InlineData("Radiohead", "A Moon Shaped Pool")]
+    [InlineData("Pink Floyd", "The Dark Side of the Moon")]
+    public void IsPathWithinRoot_RootHasTrailingSeparator_ChildStillWithin(string artist, string album)
+    {
+        // Regression: users routinely configure a DownloadPath WITH a trailing separator
+        // (e.g. "/downloads/qobuz/"). Path.GetFullPath PRESERVES the trailing separator, so the
+        // naive "rootCanonical + separator" StartsWith check produced a DOUBLE separator
+        // ("/downloads/qobuz//") and rejected every legitimate child — which blocked ALL
+        // tidalarr/qobuzarr downloads ("refusing to build output path ... resolves outside the
+        // configured DownloadPath"). The guard must normalize trailing separators on the root.
+        var root = RandomRoot() + Path.DirectorySeparatorChar; // trailing separator (user-configured)
+        var output = Path.Combine(root, artist, album);
+        Assert.True(PathTraversalGuard.IsPathWithinRoot(output, root));
+    }
+
+    [Fact]
+    public void IsPathWithinRoot_RootHasTrailingSeparator_EqualsRoot_ReturnsTrue()
+    {
+        // The bare root must still count as within a trailing-separator-configured root.
+        var bare = RandomRoot();
+        var rootWithSeparator = bare + Path.DirectorySeparatorChar;
+        Assert.True(PathTraversalGuard.IsPathWithinRoot(bare, rootWithSeparator));
+    }
+
     [Fact]
     public void IsPathWithinRoot_AlternateRoot_AcceptsBothPaths()
     {

--- a/tests/HostBridge/PathTraversalGuardTests.cs
+++ b/tests/HostBridge/PathTraversalGuardTests.cs
@@ -132,6 +132,28 @@ public class PathTraversalGuardTests
     }
 
     [Fact]
+    public void IsPathWithinRoot_RootHasMultipleTrailingSeparators_ChildStillWithin()
+    {
+        // Defensive: a doubled trailing separator must also normalize (TrimEnd removes all).
+        var bare = RandomRoot();
+        var root = bare + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar;
+        var output = Path.Combine(bare, "Artist", "Album");
+        Assert.True(PathTraversalGuard.IsPathWithinRoot(output, root));
+    }
+
+    [Fact]
+    public void IsPathWithinRoot_FilesystemRoot_ContainsAbsoluteChildren_AndDoesNotThrow()
+    {
+        // Edge case the trim makes load-bearing (reviewer F1.2): a root that is the filesystem
+        // root canonicalizes to a separator (e.g. "/" or "C:\"), which TrimEnd reduces to "" / "C:".
+        // Absolute children must still be considered within-root and the guard must not throw.
+        // Use the temp dir's own root so the drive matches on Windows.
+        var fsRoot = Path.GetPathRoot(Path.GetFullPath(Path.GetTempPath()))!; // "/" on Unix, "C:\" on Windows
+        var child = Path.Combine(Path.GetTempPath(), "ptg-bareroot-" + Guid.NewGuid().ToString("N"));
+        Assert.True(PathTraversalGuard.IsPathWithinRoot(child, fsRoot));
+    }
+
+    [Fact]
     public void IsPathWithinRoot_AlternateRoot_AcceptsBothPaths()
     {
         // ProbeOnly fallback pattern: blank configured root → fall back to %TEMP%/<plugin>.


### PR DESCRIPTION
## Problem
`PathTraversalGuard.IsPathWithinRoot` rejected **every** legitimate download path when the user configured a DownloadPath **with a trailing separator** (e.g. `/downloads/qobuz/`).

`Path.GetFullPath` PRESERVES a trailing separator, so `IsDescendant`'s `rootCanonical + separator` prefix became a **double** separator (`/downloads/qobuz//`) that no real child path starts with. Result: tidalarr **and** qobuzarr both threw and **all downloads failed**:

```
System.InvalidOperationException: Qobuzarr: refusing to build output path
'/downloads/qobuz/Radiohead/A Moon Shaped Pool' — resolves outside the configured
DownloadPath '/downloads/qobuz/'.
```
(reproduced live in a Dockerized Lidarr with both plugins installed).

## Fix
Trim trailing directory separators from the canonicalized root before the descendant comparison, so the check is exact whether or not the configured root ends with a slash.

## Tests (TDD)
Added `IsPathWithinRoot_RootHasTrailingSeparator_ChildStillWithin` (2 cases) + `…_EqualsRoot_ReturnsTrue` — **red before the fix**, green after. Full suite 29/29; the sibling-prefix (`/foo/musicEvil`) and unsanitized-`..` protections are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)