### PR TITLE
fix(diagnostics): redact secrets in logged HTTP response bodies (token leak via HTTP tap)

### DIFF
--- a/src/Services/Http/DiagnosticTapHandler.cs
+++ b/src/Services/Http/DiagnosticTapHandler.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -68,7 +69,7 @@ namespace Lidarr.Plugin.Common.Services.Http
                             var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
                             var toLog = bytes.Length > MaxLoggedBodyBytes ? bytes.AsSpan(0, MaxLoggedBodyBytes).ToArray() : bytes;
                             var encoding = TryGetEncoding(response.Content.Headers?.ContentType?.CharSet) ?? Encoding.UTF8;
-                            var snippet = SafeGetString(encoding, toLog);
+                            var snippet = RedactBodyForLog(SafeGetString(encoding, toLog));
                             _logger.LogDebug("http[{Id}] body: {Snippet}{Trunc}", id, snippet, bytes.Length > MaxLoggedBodyBytes ? " [truncated]" : string.Empty);
 
                             // Rebuild content so downstream can still read it.
@@ -184,6 +185,33 @@ namespace Lidarr.Plugin.Common.Services.Http
             || key.Contains("password", StringComparison.OrdinalIgnoreCase)
             || key.Contains("code", StringComparison.OrdinalIgnoreCase)
             || key.Contains("key", StringComparison.OrdinalIgnoreCase);
+
+        // Matches a JSON string key/value pair: "key":"value" (tolerating escaped chars and
+        // whitespace around the colon). Used to redact secret-bearing values from logged bodies.
+        private static readonly Regex JsonStringPairPattern = new Regex(
+            "\"(?<key>(?:\\\\.|[^\"\\\\])*)\"\\s*:\\s*\"(?<val>(?:\\\\.|[^\"\\\\])*)\"",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// Redacts the values of secret-bearing JSON string fields (access_token, refresh_token,
+        /// client_secret, api_key, code, password, …) from a textual body snippet before it is
+        /// logged. Reuses <see cref="IsSensitiveKey"/> so the body, header, and query-parameter
+        /// redaction policies stay in lockstep. Best-effort: only JSON string values are masked
+        /// (the only place credentials realistically appear in a logged body); everything else is
+        /// passed through unchanged.
+        /// </summary>
+        internal static string? RedactBodyForLog(string? body)
+        {
+            if (string.IsNullOrEmpty(body)) return body;
+
+            return JsonStringPairPattern.Replace(body, m =>
+            {
+                var key = m.Groups["key"].Value;
+                return IsSensitiveKey(key)
+                    ? $"\"{key}\":\"REDACTED\""
+                    : m.Value;
+            });
+        }
 
         private static bool IsTextual(HttpContentHeaders? headers)
         {

--- a/tests/Http/DiagnosticTapHandlerBodyRedactionTests.cs
+++ b/tests/Http/DiagnosticTapHandlerBodyRedactionTests.cs
@@ -1,0 +1,62 @@
+using Lidarr.Plugin.Common.Services.Http;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Http
+{
+    /// <summary>
+    /// The diagnostic HTTP tap (LIDARR_PLUGIN_HTTP_TAP) logs a snippet of textual/JSON response
+    /// bodies. OAuth/token endpoints return access_token / refresh_token / client_secret in the
+    /// body, so the snippet must be redacted before it reaches the log — headers and query params
+    /// already are.
+    /// </summary>
+    public class DiagnosticTapHandlerBodyRedactionTests
+    {
+        [Fact]
+        public void RedactBodyForLog_masks_oauth_token_values_in_json()
+        {
+            var body = "{\"access_token\":\"AT_eyJsecretpayloadsig\",\"refresh_token\":\"RT_supersecret123\",\"expires_in\":3600}";
+
+            var redacted = DiagnosticTapHandler.RedactBodyForLog(body);
+
+            Assert.DoesNotContain("AT_eyJsecretpayloadsig", redacted);
+            Assert.DoesNotContain("RT_supersecret123", redacted);
+            Assert.Contains("REDACTED", redacted);
+            Assert.Contains("expires_in", redacted); // non-secret key retained
+        }
+
+        [Fact]
+        public void RedactBodyForLog_masks_secret_apikey_code_password_keeps_plain_fields()
+        {
+            var body = "{\"client_secret\":\"SEKRET_VALUE\",\"api_key\":\"APIKEY_VALUE\",\"code\":\"AUTHCODE_VALUE\",\"password\":\"PASSWORD_VALUE\",\"name\":\"Real Name\"}";
+
+            var redacted = DiagnosticTapHandler.RedactBodyForLog(body);
+
+            Assert.DoesNotContain("SEKRET_VALUE", redacted);
+            Assert.DoesNotContain("APIKEY_VALUE", redacted);
+            Assert.DoesNotContain("AUTHCODE_VALUE", redacted);
+            Assert.DoesNotContain("PASSWORD_VALUE", redacted);
+            Assert.Contains("\"name\":\"Real Name\"", redacted); // non-secret field preserved
+        }
+
+        [Fact]
+        public void RedactBodyForLog_finds_nested_token()
+        {
+            var body = "{\"data\":{\"session\":{\"auth_token\":\"NESTED_SECRET\"}},\"ok\":true}";
+
+            var redacted = DiagnosticTapHandler.RedactBodyForLog(body);
+
+            Assert.DoesNotContain("NESTED_SECRET", redacted);
+            Assert.Contains("REDACTED", redacted);
+        }
+
+        [Fact]
+        public void RedactBodyForLog_passes_through_non_sensitive_and_null()
+        {
+            Assert.Null(DiagnosticTapHandler.RedactBodyForLog(null));
+            Assert.Equal(string.Empty, DiagnosticTapHandler.RedactBodyForLog(string.Empty));
+
+            var plain = "{\"items\":[1,2,3],\"status\":\"ok\"}";
+            Assert.Equal(plain, DiagnosticTapHandler.RedactBodyForLog(plain));
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`DiagnosticTapHandler` (the `LIDARR_PLUGIN_HTTP_TAP` wire-tap) carefully redacts request/response **headers** (`IsSensitiveHeader`) and **query parameters** (`IsSensitiveKey`), but then logs up to 2 KiB of the response **body** verbatim at Debug:
```csharp
var snippet = SafeGetString(encoding, toLog);
_logger.LogDebug("http[{Id}] body: {Snippet}{Trunc}", id, snippet, ...);
```
OAuth/token endpoints return `access_token` / `refresh_token` / `client_secret` in the JSON body, so enabling the "safe" diagnostic tap leaked live credentials into the log.

## Fix
`RedactBodyForLog` masks the values of secret-bearing JSON string fields before logging, **reusing the existing `IsSensitiveKey` predicate** so body / header / query-parameter redaction stay in lockstep (`token`, `secret`, `password`, `code`, `key` — including nested objects). Best-effort by design: only JSON string values are masked (the only place credentials realistically appear in a body); everything else passes through unchanged.

## Tests (TDD)
`DiagnosticTapHandlerBodyRedactionTests` assert `access_token`/`refresh_token`/`client_secret`/`api_key`/`code`/`password` values (incl. a nested `auth_token`) are masked while non-secret fields (`name`, `expires_in`, plain JSON) are preserved. 4/4 green.

Note: complements the header/query-param redaction widening on `fix/harden-campaign-common-med`; this targets the body and is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)