### PR TITLE
feat(lyrics): shared ILyricsEnricher/LyricsEnricher + INativeLyricsSource (consolidation pilot)

### DIFF
--- a/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -23,3 +23,12 @@ Lidarr.Plugin.Common.Services.Performance.NamedServiceRateLimiter.WaitIfNeededAs
 Lidarr.Plugin.Common.Services.Performance.NamedServiceRateLimiter.WaitIfNeededAsync(string! service, string! endpoint, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<bool>!
 Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.ShouldShortCircuit() -> bool
 Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.RecordExceptionOutcome(System.Exception! ex, System.Func<System.Exception!, Lidarr.Plugin.Abstractions.Contracts.AuthFailure?>! classify) -> void
+Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher
+Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher.TryEnrichAsync(string! audioFilePath, string! artistName, string! trackName, string! albumName, int durationSeconds, bool allowLrclibFallback, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task!
+Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource
+Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource.TryGetSyncedLyricsAsync(string! artistName, string! trackName, string! albumName, int durationSeconds, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<string?>!
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.Dispose() -> void
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource, Lidarr.Plugin.Common.Services.Lyrics.LrclibClient! lrclibClient, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.TryEnrichAsync(string! audioFilePath, string! artistName, string! trackName, string! albumName, int durationSeconds, bool allowLrclibFallback, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task!

--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -52,3 +52,12 @@ static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.BuildHostFirs
 static Lidarr.Plugin.Common.Services.Http.RateLimitHeaderUtilities.BuildHostFirstSegmentKey(System.Uri? uri, string! unknownKey = "unknown") -> string!
 Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.ShouldShortCircuit() -> bool
 Lidarr.Plugin.Common.Services.Bridge.AuthFailureGate.RecordExceptionOutcome(System.Exception! ex, System.Func<System.Exception!, Lidarr.Plugin.Abstractions.Contracts.AuthFailure?>! classify) -> void
+Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher
+Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher.TryEnrichAsync(string! audioFilePath, string! artistName, string! trackName, string! albumName, int durationSeconds, bool allowLrclibFallback, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task!
+Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource
+Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource.TryGetSyncedLyricsAsync(string! artistName, string! trackName, string! albumName, int durationSeconds, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<string?>!
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.Dispose() -> void
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource, Lidarr.Plugin.Common.Services.Lyrics.LrclibClient! lrclibClient, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.TryEnrichAsync(string! audioFilePath, string! artistName, string! trackName, string! albumName, int durationSeconds, bool allowLrclibFallback, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task!

--- a/src/Services/Lyrics/ILyricsEnricher.cs
+++ b/src/Services/Lyrics/ILyricsEnricher.cs
@@ -18,7 +18,7 @@ namespace Lidarr.Plugin.Common.Services.Lyrics
 
     /// <summary>
     /// Shared synced-lyrics enrichment used by every plugin. Tries the optional native source first,
-    /// then — when <paramref name="allowLrclibFallback"/> is set — the LRCLIB public API, and writes
+    /// then — when <c>allowLrclibFallback</c> is set — the LRCLIB public API, and writes
     /// the resulting <c>.lrc</c> next to the audio file. Best-effort: it never throws (other than
     /// cancellation) and never writes a file when no lyrics are found, so a lyrics miss can never
     /// fail a download.

--- a/src/Services/Lyrics/ILyricsEnricher.cs
+++ b/src/Services/Lyrics/ILyricsEnricher.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lidarr.Plugin.Common.Services.Lyrics
+{
+    /// <summary>
+    /// A streaming service's own synced-lyrics source (e.g. Tidal's lyrics endpoint or Apple Music's
+    /// SDK lyrics). Implemented per-plugin; the shared <see cref="ILyricsEnricher"/> tries it before
+    /// the LRCLIB fallback. Return <c>null</c> when the service has no synced lyrics for the track.
+    /// This is the only lyrics code that should remain plugin-local — the fetch-and-write
+    /// orchestration lives once in Common.
+    /// </summary>
+    public interface INativeLyricsSource
+    {
+        Task<string?> TryGetSyncedLyricsAsync(string artistName, string trackName, string albumName, int durationSeconds, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Shared synced-lyrics enrichment used by every plugin. Tries the optional native source first,
+    /// then — when <paramref name="allowLrclibFallback"/> is set — the LRCLIB public API, and writes
+    /// the resulting <c>.lrc</c> next to the audio file. Best-effort: it never throws (other than
+    /// cancellation) and never writes a file when no lyrics are found, so a lyrics miss can never
+    /// fail a download.
+    /// </summary>
+    public interface ILyricsEnricher : IDisposable
+    {
+        Task TryEnrichAsync(string audioFilePath, string artistName, string trackName, string albumName, int durationSeconds, bool allowLrclibFallback, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Services/Lyrics/LyricsEnricher.cs
+++ b/src/Services/Lyrics/LyricsEnricher.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Lidarr.Plugin.Common.Services.Lyrics
+{
+    /// <summary>
+    /// Canonical synced-lyrics enricher shared across plugins (replaces the duplicated per-plugin
+    /// copies). Orchestration only: native-source-first, LRCLIB fallback (gated by the caller),
+    /// write the <c>.lrc</c> next to the audio. Service-specific fetching belongs in an
+    /// <see cref="INativeLyricsSource"/>; the per-feature gating (e.g. SaveSyncedLyrics / UseLRCLIB)
+    /// stays in the plugin that owns the settings UI and is expressed via the call arguments.
+    /// </summary>
+    public sealed class LyricsEnricher : ILyricsEnricher
+    {
+        private readonly INativeLyricsSource? _nativeSource;
+        private readonly LrclibClient _lrclib;
+        private readonly bool _ownsLrclib;
+        private readonly ILogger? _logger;
+
+        /// <summary>
+        /// Creates an enricher with an internally-owned <see cref="LrclibClient"/> (disposed with
+        /// this instance). Convenient for DI registration; long-lived consumers should register this
+        /// as a singleton so the LRCLIB HttpClient is reused.
+        /// </summary>
+        public LyricsEnricher(INativeLyricsSource? nativeSource = null, ILogger? logger = null)
+            : this(nativeSource, new LrclibClient(), ownsLrclib: true, logger)
+        {
+        }
+
+        /// <summary>
+        /// Creates an enricher over a caller-owned <see cref="LrclibClient"/> (not disposed here).
+        /// Use when the LRCLIB client should share the consumer's HttpClient/handler chain, or for tests.
+        /// </summary>
+        public LyricsEnricher(INativeLyricsSource? nativeSource, LrclibClient lrclibClient, ILogger? logger = null)
+            : this(nativeSource, lrclibClient ?? throw new ArgumentNullException(nameof(lrclibClient)), ownsLrclib: false, logger)
+        {
+        }
+
+        private LyricsEnricher(INativeLyricsSource? nativeSource, LrclibClient lrclibClient, bool ownsLrclib, ILogger? logger)
+        {
+            _nativeSource = nativeSource;
+            _lrclib = lrclibClient;
+            _ownsLrclib = ownsLrclib;
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async Task TryEnrichAsync(string audioFilePath, string artistName, string trackName, string albumName, int durationSeconds, bool allowLrclibFallback, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(artistName) || string.IsNullOrWhiteSpace(trackName))
+            {
+                return;
+            }
+
+            var album = albumName ?? string.Empty;
+            var duration = Math.Max(0, durationSeconds);
+
+            try
+            {
+                string? lyrics = null;
+
+                if (_nativeSource is not null)
+                {
+                    lyrics = await _nativeSource.TryGetSyncedLyricsAsync(artistName, trackName, album, duration, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (string.IsNullOrWhiteSpace(lyrics) && allowLrclibFallback)
+                {
+                    lyrics = await _lrclib.TryFetchSyncedLyricsAsync(artistName, trackName, album, duration, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (string.IsNullOrWhiteSpace(lyrics))
+                {
+                    return;
+                }
+
+                var lrcPath = Path.ChangeExtension(audioFilePath, ".lrc");
+                await File.WriteAllTextAsync(lrcPath, lyrics, cancellationToken).ConfigureAwait(false);
+                _logger?.LogDebug("Saved synced lyrics: {File}", Path.GetFileName(lrcPath));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "Lyrics enrichment failed for {Artist} - {Track} (non-fatal)", artistName, trackName);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_ownsLrclib)
+            {
+                _lrclib.Dispose();
+            }
+        }
+    }
+}

--- a/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
@@ -437,6 +437,60 @@ public abstract partial class EcosystemParityTestBase
 
     #endregion
 
+    #region Check_UsesCommonLyricsEnricher
+
+    /// <summary>
+    /// Synced-lyrics enrichment is consolidated in common
+    /// (<c>Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher</c> / <c>LyricsEnricher</c>).
+    /// A plugin must not define its own <c>ILyricsEnricher</c>/<c>LyricsEnricher</c> (the
+    /// historical qobuz/tidal duplication) nor fork the orchestration by implementing common's
+    /// interface in plugin-local code — it consumes common's type directly. Service-specific
+    /// fetches belong behind common's <c>INativeLyricsSource</c>, not a re-declared enricher.
+    /// </summary>
+    public virtual ComplianceResult Check_UsesCommonLyricsEnricher()
+    {
+        var assembly = PluginAssembly;
+        if (assembly == null) return Skipped();
+
+        const string commonInterfaceFullName = "Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher";
+        var offenders = new List<string>();
+        foreach (var type in SafeGetTypes(assembly))
+        {
+            if (type == null) continue;
+            string ns, name;
+            try { ns = type.Namespace ?? string.Empty; name = type.Name ?? string.Empty; }
+            catch { continue; }
+
+            // Common's own types (incl. ILRepack-internalized) are the canonical implementation.
+            if (IsCommonProductionNamespace(ns)) continue;
+
+            // (a) A plugin-local re-declaration of the lyrics-enricher shape (the historical fork).
+            if (name == "ILyricsEnricher" || name == "LyricsEnricher")
+            {
+                offenders.Add(type.FullName ?? name);
+                continue;
+            }
+
+            // (b) A plugin-local fork that implements common's shared interface directly.
+            try
+            {
+                if (type.IsInterface || type.IsAbstract) continue;
+                if (type.GetInterfaces().Any(i => i.FullName == commonInterfaceFullName))
+                {
+                    offenders.Add(type.FullName ?? name);
+                }
+            }
+            catch { /* unresolved interfaces — skip safely */ }
+        }
+
+        return offenders.Count == 0
+            ? ComplianceResult.Success
+            : ComplianceResult.Failure(
+                $"Plugin defines its own lyrics enricher — consolidate on Lidarr.Plugin.Common.Services.Lyrics.ILyricsEnricher/LyricsEnricher (put service-specific fetches behind INativeLyricsSource): {string.Join(", ", offenders)}");
+    }
+
+    #endregion
+
     #region Aggregator
 
     /// <summary>
@@ -453,6 +507,7 @@ public abstract partial class EcosystemParityTestBase
             [nameof(Check_PluginManifest_Capabilities_HaveBackingTypes)] = Check_PluginManifest_Capabilities_HaveBackingTypes(),
             [nameof(Check_NoFluentValidation_ErrorsApi_Drift)] = Check_NoFluentValidation_ErrorsApi_Drift(),
             [nameof(Check_UsesCommonPluginConfigRoots)] = Check_UsesCommonPluginConfigRoots(),
+            [nameof(Check_UsesCommonLyricsEnricher)] = Check_UsesCommonLyricsEnricher(),
         };
 
         var passed = results.Values.Count(r => r.Passed);

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -64,6 +64,13 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         public ComplianceResult RunCapabilities() => Check_PluginManifest_Capabilities_HaveBackingTypes();
         public ComplianceResult RunValidationDrift() => Check_NoFluentValidation_ErrorsApi_Drift();
         public ComplianceResult RunConfigRoots() => Check_UsesCommonPluginConfigRoots();
+        public ComplianceResult RunLyricsEnricher() => Check_UsesCommonLyricsEnricher();
+    }
+
+    /// <summary>A plugin-local re-declaration of the lyrics enricher (forbidden — must use common's).</summary>
+    private static class RogueLyrics
+    {
+        public interface ILyricsEnricher { }
     }
 
     // --- Fixture types ---
@@ -405,6 +412,43 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         Assert.True(h.RunConfigRoots().Passed);
     }
 
+    // --- Check_UsesCommonLyricsEnricher ---
+
+    [Fact]
+    public void LyricsEnricher_NoAssembly_ReturnsSkipped()
+    {
+        var h = new Harness(_tempRepo) { AssemblyValue = null };
+        Assert.True(h.RunLyricsEnricher().Passed);
+    }
+
+    [Fact]
+    public void LyricsEnricher_PluginLocalRedeclaration_Fails()
+    {
+        // A plugin-local type named ILyricsEnricher/LyricsEnricher (the historical qobuz/tidal
+        // duplication) must be flagged — lyrics is consolidated in common.
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(RogueLyrics.ILyricsEnricher) },
+        };
+        var r = h.RunLyricsEnricher();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("ILyricsEnricher"));
+    }
+
+    [Fact]
+    public void LyricsEnricher_CommonType_Passes()
+    {
+        // Common's own enricher (here referenced directly; in production it's ILRepack-internalized
+        // but keeps its Lidarr.Plugin.Common.* namespace) is the canonical implementation.
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher) },
+        };
+        Assert.True(h.RunLyricsEnricher().Passed);
+    }
+
     // --- Aggregator ---
 
     [Fact]
@@ -412,8 +456,8 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
     {
         var h = new Harness(_tempRepo) { AssemblyValue = null };
         var report = h.RunBehaviorContractChecks();
-        Assert.Equal(6, report.TotalCount);
-        // No assembly => all 6 skipped (Pass).
+        Assert.Equal(7, report.TotalCount);
+        // No assembly => all 7 skipped (Pass).
         Assert.True(report.AllPassed);
     }
 }

--- a/tests/Lyrics/LyricsEnricherTests.cs
+++ b/tests/Lyrics/LyricsEnricherTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Services.Lyrics;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Lyrics
+{
+    /// <summary>
+    /// Contract suite for the consolidated lyrics enricher (source of truth for tidal + qobuz).
+    /// Canonical behavior: a native source is tried first; LRCLIB is a fallback gated by
+    /// <c>allowLrclibFallback</c>; the found LRC is written next to the audio file; everything is
+    /// best-effort (a lyrics failure never throws and never writes a partial file).
+    /// </summary>
+    public class LyricsEnricherTests
+    {
+        private sealed class StubNativeSource : INativeLyricsSource
+        {
+            private readonly string? _result;
+            public int Calls { get; private set; }
+            public StubNativeSource(string? result) => _result = result;
+            public Task<string?> TryGetSyncedLyricsAsync(string artistName, string trackName, string albumName, int durationSeconds, CancellationToken ct = default)
+            {
+                Calls++;
+                return Task.FromResult(_result);
+            }
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpResponseMessage> _factory;
+            public int Calls { get; private set; }
+            public StubHandler(Func<HttpResponseMessage> factory) => _factory = factory;
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Calls++;
+                return Task.FromResult(_factory());
+            }
+        }
+
+        private static HttpResponseMessage LrclibHit(string synced)
+            => new(HttpStatusCode.OK) { Content = new StringContent($"{{\"syncedLyrics\":\"{synced}\"}}") };
+
+        private static HttpResponseMessage LrclibMiss() => new(HttpStatusCode.NotFound);
+
+        private static LyricsEnricher Enricher(INativeLyricsSource? native, StubHandler handler)
+            => new(native, new LrclibClient(new HttpClient(handler)));
+
+        private sealed class TempDir : IDisposable
+        {
+            public string Dir { get; }
+            public TempDir() { Dir = Path.Combine(Path.GetTempPath(), "lyr-" + Guid.NewGuid().ToString("N")); Directory.CreateDirectory(Dir); }
+            public string Audio() { var p = Path.Combine(Dir, "song.flac"); File.WriteAllText(p, "x"); return p; }
+            public static string Lrc(string audio) => Path.ChangeExtension(audio, ".lrc");
+            public void Dispose() { try { Directory.Delete(Dir, true); } catch { } }
+        }
+
+        [Fact]
+        public async Task Prefers_native_source_and_skips_lrclib_on_native_hit()
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var native = new StubNativeSource("[00:00.00]native");
+            var handler = new StubHandler(() => LrclibHit("[00:00.00]lrclib"));
+            using var sut = Enricher(native, handler);
+
+            await sut.TryEnrichAsync(audio, "Artist", "Track", "Album", 100, allowLrclibFallback: true);
+
+            Assert.Equal(1, native.Calls);
+            Assert.Equal(0, handler.Calls);
+            Assert.Contains("native", await File.ReadAllTextAsync(TempDir.Lrc(audio)));
+        }
+
+        [Fact]
+        public async Task Falls_back_to_lrclib_when_native_empty_and_allowed()
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var native = new StubNativeSource(null);
+            var handler = new StubHandler(() => LrclibHit("[00:00.00]lrclib"));
+            using var sut = Enricher(native, handler);
+
+            await sut.TryEnrichAsync(audio, "Artist", "Track", "Album", 100, allowLrclibFallback: true);
+
+            Assert.Equal(1, handler.Calls);
+            Assert.Contains("lrclib", await File.ReadAllTextAsync(TempDir.Lrc(audio)));
+        }
+
+        [Fact]
+        public async Task Does_not_consult_lrclib_when_fallback_disabled()
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var native = new StubNativeSource(null);
+            var handler = new StubHandler(() => LrclibHit("[00:00.00]lrclib"));
+            using var sut = Enricher(native, handler);
+
+            await sut.TryEnrichAsync(audio, "Artist", "Track", "Album", 100, allowLrclibFallback: false);
+
+            Assert.Equal(0, handler.Calls);
+            Assert.False(File.Exists(TempDir.Lrc(audio)));
+        }
+
+        [Fact]
+        public async Task Uses_lrclib_when_no_native_source_supplied()
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var handler = new StubHandler(() => LrclibHit("[00:00.00]only-lrclib"));
+            using var sut = Enricher(null, handler);
+
+            await sut.TryEnrichAsync(audio, "Artist", "Track", "Album", 100, allowLrclibFallback: true);
+
+            Assert.Contains("only-lrclib", await File.ReadAllTextAsync(TempDir.Lrc(audio)));
+        }
+
+        [Fact]
+        public async Task Writes_nothing_when_no_lyrics_found()
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var handler = new StubHandler(LrclibMiss);
+            using var sut = Enricher(null, handler);
+
+            await sut.TryEnrichAsync(audio, "Artist", "Track", "Album", 100, allowLrclibFallback: true);
+
+            Assert.False(File.Exists(TempDir.Lrc(audio)));
+        }
+
+        [Theory]
+        [InlineData("", "Track")]
+        [InlineData("Artist", "")]
+        [InlineData("   ", "Track")]
+        public async Task Skips_when_artist_or_track_missing(string artist, string track)
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var handler = new StubHandler(() => LrclibHit("x"));
+            using var sut = Enricher(null, handler);
+
+            await sut.TryEnrichAsync(audio, artist, track, "Album", 100, allowLrclibFallback: true);
+
+            Assert.Equal(0, handler.Calls);
+            Assert.False(File.Exists(TempDir.Lrc(audio)));
+        }
+
+        [Fact]
+        public async Task Is_best_effort_when_source_throws()
+        {
+            using var tmp = new TempDir();
+            var audio = tmp.Audio();
+            var native = new StubNativeSource(null);
+            var handler = new StubHandler(() => throw new HttpRequestException("boom"));
+            using var sut = Enricher(native, handler);
+
+            var ex = await Record.ExceptionAsync(() =>
+                sut.TryEnrichAsync(audio, "Artist", "Track", "Album", 100, allowLrclibFallback: true));
+
+            Assert.Null(ex);
+            Assert.False(File.Exists(TempDir.Lrc(audio)));
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds the shared, single-source-of-truth synced-lyrics enrichment to Common — the consolidation **pilot** for eliminating cross-plugin divergence. tidal and qobuz each currently carry a near-identical local `LyricsEnricher` + `ILyricsEnricher` (both wrapping Common's `LrclibClient`), and they've already diverged (tidal gates on `SaveSyncedLyrics && UseLRCLIB`; qobuz's is unwired/ungated).

## API (in `Lidarr.Plugin.Common.Services.Lyrics`)
- **`INativeLyricsSource`** — the *only* piece that stays plugin-local: a service's own synced-lyrics fetch (Tidal endpoint, Apple SDK…). Returns `null` when absent.
- **`ILyricsEnricher` / `LyricsEnricher`** — orchestration: native-source-first → LRCLIB fallback (gated by `allowLrclibFallback`) → write `.lrc` next to the audio. Best-effort: never throws (except cancellation), never writes a partial file.

## Canonical gating contract (ecosystem-wide)
`SaveSyncedLyrics` decides whether to enrich at all (plugin-side); a native source is always tried; `UseLRCLIB` toggles the LRCLIB fallback (`allowLrclibFallback`). Per-feature settings stay in the plugin that owns the UI.

## Tests
9-case contract suite (native-first, fallback gating, no-native, miss, missing artist/track, best-effort-on-throw) via an HttpClient-fake-handler `LrclibClient` + stub native source — coverage neither plugin's copy ever had. Public API recorded for net8.0 + net6.0.

## Follow-ups (stacked, pin to this SHA)
- Migrate tidal (delete dup, supersedes #299) and qobuz (delete dup, adopt canonical gating) to this enricher; re-pin submodule + `ext-common-sha.txt`.
- Add a parity guard test: no plugin defines its own `ILyricsEnricher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)