### PR TITLE
feat(telemetry): consolidate download logging into Common (artist/album/track/format/quality) + parity guard

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -138,7 +138,9 @@
     "normalisation",
     "normalises",
     "recognise",
-    "syscall"
+    "syscall",
+    "Lrclib",
+    "LRCLIB"
   ],
   "ignorePaths": [
     "**/bin",

--- a/docs/ECOSYSTEM_PARITY_MATRIX.md
+++ b/docs/ECOSYSTEM_PARITY_MATRIX.md
@@ -126,6 +126,19 @@ This document is the single source of truth for "does every plugin follow the sa
 
 ---
 
+## 10. Download telemetry logging (telemetry-consolidation session, 2026-05-29)
+
+| # | Axis | applemusicarr | tidalarr | qobuzarr | brainarr |
+|---|------|:-:|:-:|:-:|:-:|
+| 36 | Canonical `IDownloadTelemetrySink` (Common `LoggingDownloadTelemetrySink` via `AddDownloadTelemetry`) | N/A — no Common download-telemetry path (developer-token flow; not on `SimpleDownloadOrchestrator`) | ✗ → **pending #556**: registers a bespoke `TidalDownloadTelemetrySink` that hand-rolls an IDs-only NLog format duplicating `DownloadTelemetryService`. Migrates to `AddDownloadTelemetry()` + deletes the sink after Common PR #556 lands + re-pin | ✗ → **pending #556**: logs ad-hoc (`Downloaded: {title} ({MB})`), no Common telemetry. Adopts the orchestrator sink after #556 + re-pin | N/A — import-list plugin, no download client |
+| 37 | Rich per-track log fields (artist/album/track/format/quality/size/path) | N/A | ✗ → **pending #556** | ✗ → **pending #556** | N/A |
+
+**Executable guard**: `EcosystemParityTestBase.Check_UsesCommonDownloadTelemetrySink` (behavior contract #7) fails any plugin assembly that declares a local `IDownloadTelemetrySink` instead of registering Common's `LoggingDownloadTelemetrySink`. Auto-enforces for tidal/qobuz once they re-pin and opt into `RunBehaviorContractChecks` via `PluginAssembly`. A genuinely custom telemetry backend opts out by overriding the check with a rationale.
+
+**Common foundation (PR #556)**: `DownloadTelemetry` enriched with nullable identity/quality fields + `From(StreamingTrack, StreamingAlbum, StreamingQuality, …)` factory; `DownloadTelemetryService` renders the rich human line + adds `artist`/`track_title`/`album_title`/`format` to the `[LPC_TELEMETRY]` marker (additive; `success` stays last); `SimpleDownloadOrchestrator` (the single producer) enriches centrally; `LoggingDownloadTelemetrySink` + `AddDownloadTelemetry()` give one-line opt-in so the log format lives in exactly one file.
+
+---
+
 ## Wave 21 (this session) commits
 
 | Repo | Commit | What it does |

--- a/src/Extensions/DownloadTelemetryServiceCollectionExtensions.cs
+++ b/src/Extensions/DownloadTelemetryServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+using Lidarr.Plugin.Common.Services.Download;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Lidarr.Plugin.Common.Extensions
+{
+    /// <summary>
+    /// DI helpers for opting into the shared download-telemetry logging path.
+    /// </summary>
+    public static class DownloadTelemetryServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers the canonical download-telemetry services so a plugin gets ecosystem-standard
+        /// per-track logging without writing its own sink: the shared
+        /// <see cref="DownloadTelemetryService"/> (rich line + <c>[LPC_TELEMETRY]</c> marker) and the
+        /// <see cref="LoggingDownloadTelemetrySink"/> that the download orchestrator drives. Both use
+        /// TryAdd, so a plugin can still override either with a custom implementation if it has a
+        /// genuine reason (and document that as intentionally divergent).
+        /// </summary>
+        public static IServiceCollection AddDownloadTelemetry(this IServiceCollection services)
+        {
+            services.TryAddSingleton<IDownloadTelemetryService, DownloadTelemetryService>();
+            // Explicit factory rather than open-type registration: LoggingDownloadTelemetrySink has
+            // two single-arg constructors, which would make the DI container's constructor selection
+            // ambiguous. The factory pins the IDownloadTelemetryService-based one.
+            services.TryAddSingleton<IDownloadTelemetrySink>(sp =>
+                new LoggingDownloadTelemetrySink(sp.GetRequiredService<IDownloadTelemetryService>()));
+            return services;
+        }
+    }
+}

--- a/src/Services/Download/DownloadTelemetry.cs
+++ b/src/Services/Download/DownloadTelemetry.cs
@@ -1,7 +1,15 @@
 using System;
+using Lidarr.Plugin.Abstractions.Models;
 
 namespace Lidarr.Plugin.Common.Services.Download
 {
+    /// <summary>
+    /// Canonical per-track download telemetry record shared by all plugins. The leading fields are
+    /// the original transfer facts; the trailing nullable fields carry the user-valuable identity
+    /// and quality info (artist/album/track/format/quality/path) so the logged line reads
+    /// "Miles Davis - So What [FLAC HiRes] ... -> /path" instead of "track=123 album=456". The
+    /// enrichment fields default to null, preserving the original positional construction.
+    /// </summary>
     public sealed record DownloadTelemetry(
         string ServiceName,
         string? AlbumId,
@@ -12,6 +20,59 @@ namespace Lidarr.Plugin.Common.Services.Download
         double BytesPerSecond,
         int RetryCount,
         int TooManyRequestsCount,
-        string? ErrorMessage);
+        string? ErrorMessage,
+        string? Artist = null,
+        string? AlbumTitle = null,
+        string? TrackTitle = null,
+        string? Format = null,
+        string? QualityTier = null,
+        int? BitrateKbps = null,
+        int? SampleRateHz = null,
+        int? BitDepth = null,
+        TimeSpan? TrackDuration = null,
+        string? OutputPath = null)
+    {
+        /// <summary>
+        /// Builds an enriched telemetry record from Common's streaming models. Plugins supply only
+        /// the service-specific <see cref="StreamingTrack"/>/<see cref="StreamingAlbum"/>/
+        /// <see cref="StreamingQuality"/> they already construct plus the transfer facts; the
+        /// identity/quality fields are mapped here so every plugin logs the same shape.
+        /// </summary>
+        public static DownloadTelemetry From(
+            string serviceName,
+            bool success,
+            StreamingTrack? track,
+            StreamingAlbum? album,
+            StreamingQuality? quality,
+            long bytesWritten,
+            TimeSpan elapsed,
+            string? outputPath = null,
+            int retryCount = 0,
+            int tooManyRequestsCount = 0,
+            string? errorMessage = null)
+        {
+            var bytesPerSecond = elapsed.TotalSeconds > 0 ? bytesWritten / elapsed.TotalSeconds : 0d;
+            return new DownloadTelemetry(
+                ServiceName: serviceName,
+                AlbumId: album?.Id,
+                TrackId: track?.Id ?? string.Empty,
+                Success: success,
+                BytesWritten: bytesWritten,
+                Elapsed: elapsed,
+                BytesPerSecond: bytesPerSecond,
+                RetryCount: retryCount,
+                TooManyRequestsCount: tooManyRequestsCount,
+                ErrorMessage: errorMessage,
+                Artist: string.IsNullOrWhiteSpace(track?.Artist?.Name) ? null : track!.Artist.Name,
+                AlbumTitle: album?.Title ?? track?.Album?.Title,
+                TrackTitle: string.IsNullOrWhiteSpace(track?.Title) ? null : track!.Title,
+                Format: string.IsNullOrWhiteSpace(quality?.Format) ? null : quality!.Format,
+                QualityTier: quality?.GetTier().ToString(),
+                BitrateKbps: quality?.Bitrate,
+                SampleRateHz: quality?.SampleRate,
+                BitDepth: quality?.BitDepth,
+                TrackDuration: track?.Duration,
+                OutputPath: outputPath);
+        }
+    }
 }
-

--- a/src/Services/Download/DownloadTelemetryService.cs
+++ b/src/Services/Download/DownloadTelemetryService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Lidarr.Plugin.Common.Services.Download
@@ -24,6 +25,13 @@ namespace Lidarr.Plugin.Common.Services.Download
     /// <para>
     /// The structured marker format is documented in <c>docs/TELEMETRY_DI_CONTRACT.md</c>.
     /// E2E tests should prefer the structured marker over regex-based log matching.
+    /// </para>
+    /// <para>
+    /// When the telemetry record carries the optional identity/quality enrichment fields
+    /// (see <see cref="DownloadTelemetry.From"/>), the human line reads
+    /// "Download completed: Artist - Track [FLAC HiRes 96kHz/24bit] 38.1MB in 4.00s (...) -> /path"
+    /// instead of the IDs-only form, and the marker gains artist/track_title/album_title/format keys.
+    /// Records constructed positionally (without enrichment) keep emitting the original IDs-only line.
     /// </para>
     /// </remarks>
     public class DownloadTelemetryService : IDownloadTelemetryService
@@ -57,42 +65,97 @@ namespace Lidarr.Plugin.Common.Services.Download
             {
                 var seconds = Math.Max(0.001, telemetry.Elapsed.TotalSeconds);
                 var kbPerSecond = (telemetry.BytesPerSecond / 1024.0);
+                var sizeMb = telemetry.BytesWritten / 1048576.0;
 
-                // Emit structured JSON marker for deterministic E2E detection
-                // This is the primary signal - E2E tests should look for this first
-                // Format: [LPC_TELEMETRY] {"event":"telemetry_emitted","service":"...","success":true/false}
-                var structuredMarker = $"{StructuredMarkerPrefix} {{\"event\":\"telemetry_emitted\",\"service\":\"{EscapeJson(telemetry.ServiceName)}\",\"track\":\"{EscapeJson(telemetry.TrackId)}\",\"success\":{(telemetry.Success ? "true" : "false")}}}";
+                // Emit structured JSON marker for deterministic E2E detection.
+                // This is the primary signal - E2E tests should look for this first.
+                // The identity keys (artist/track_title/album_title/format) are additive: they are
+                // always present (empty when the record was built without enrichment) and "success"
+                // stays last so existing suffix matchers keep working.
+                var structuredMarker = $"{StructuredMarkerPrefix} {{\"event\":\"telemetry_emitted\",\"service\":\"{EscapeJson(telemetry.ServiceName)}\",\"track\":\"{EscapeJson(telemetry.TrackId)}\",\"artist\":\"{EscapeJson(telemetry.Artist)}\",\"track_title\":\"{EscapeJson(telemetry.TrackTitle)}\",\"album_title\":\"{EscapeJson(telemetry.AlbumTitle)}\",\"format\":\"{EscapeJson(telemetry.Format)}\",\"success\":{(telemetry.Success ? "true" : "false")}}}";
                 _logger.LogDebug("{StructuredMarker}", structuredMarker);
 
-                // Emit human-readable log for debugging (existing behavior)
+                var hasIdentity = !string.IsNullOrEmpty(telemetry.TrackTitle);
+
                 if (telemetry.Success)
                 {
-                    _logger.LogInformation(
-                        "Download completed: track={TrackId} album={AlbumId} bytes={BytesWritten} elapsed={ElapsedSeconds:F2}s rate={Rate:F1}KB/s retries={RetryCount} 429s={TooManyRequestsCount}",
-                        telemetry.TrackId,
-                        telemetry.AlbumId ?? "",
-                        telemetry.BytesWritten,
-                        seconds,
-                        kbPerSecond,
-                        telemetry.RetryCount,
-                        telemetry.TooManyRequestsCount);
+                    if (hasIdentity)
+                    {
+                        _logger.LogInformation(
+                            "Download completed: {Artist} - {TrackTitle} [{Quality}] {SizeMB:F1}MB in {ElapsedSeconds:F2}s ({Rate:F1} KB/s) -> {OutputPath} retries={RetryCount} 429s={TooManyRequestsCount}",
+                            telemetry.Artist ?? "",
+                            telemetry.TrackTitle,
+                            FormatQuality(telemetry),
+                            sizeMb,
+                            seconds,
+                            kbPerSecond,
+                            telemetry.OutputPath ?? "",
+                            telemetry.RetryCount,
+                            telemetry.TooManyRequestsCount);
+                    }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "Download completed: track={TrackId} album={AlbumId} bytes={BytesWritten} elapsed={ElapsedSeconds:F2}s rate={Rate:F1}KB/s retries={RetryCount} 429s={TooManyRequestsCount}",
+                            telemetry.TrackId,
+                            telemetry.AlbumId ?? "",
+                            telemetry.BytesWritten,
+                            seconds,
+                            kbPerSecond,
+                            telemetry.RetryCount,
+                            telemetry.TooManyRequestsCount);
+                    }
                 }
                 else
                 {
-                    _logger.LogWarning(
-                        "Download failed: track={TrackId} album={AlbumId} elapsed={ElapsedSeconds:F2}s retries={RetryCount} 429s={TooManyRequestsCount} error={ErrorMessage}",
-                        telemetry.TrackId,
-                        telemetry.AlbumId ?? "",
-                        seconds,
-                        telemetry.RetryCount,
-                        telemetry.TooManyRequestsCount,
-                        telemetry.ErrorMessage ?? "");
+                    if (hasIdentity)
+                    {
+                        _logger.LogWarning(
+                            "Download failed: {Artist} - {TrackTitle} [{Quality}] after {ElapsedSeconds:F2}s retries={RetryCount} 429s={TooManyRequestsCount} error={ErrorMessage}",
+                            telemetry.Artist ?? "",
+                            telemetry.TrackTitle,
+                            FormatQuality(telemetry),
+                            seconds,
+                            telemetry.RetryCount,
+                            telemetry.TooManyRequestsCount,
+                            telemetry.ErrorMessage ?? "");
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "Download failed: track={TrackId} album={AlbumId} elapsed={ElapsedSeconds:F2}s retries={RetryCount} 429s={TooManyRequestsCount} error={ErrorMessage}",
+                            telemetry.TrackId,
+                            telemetry.AlbumId ?? "",
+                            seconds,
+                            telemetry.RetryCount,
+                            telemetry.TooManyRequestsCount,
+                            telemetry.ErrorMessage ?? "");
+                    }
                 }
             }
             catch
             {
                 // best-effort; never break downloads for telemetry
             }
+        }
+
+        /// <summary>
+        /// Builds a compact, human-friendly quality descriptor (e.g. "FLAC HiRes 1411kbps 96kHz/24bit"),
+        /// omitting any field the plugin did not supply. Used only for the human log line.
+        /// </summary>
+        private static string FormatQuality(DownloadTelemetry t)
+        {
+            var parts = new List<string>(4);
+            if (!string.IsNullOrEmpty(t.Format)) parts.Add(t.Format!);
+            if (!string.IsNullOrEmpty(t.QualityTier)) parts.Add(t.QualityTier!);
+            if (t.BitrateKbps is > 0) parts.Add($"{t.BitrateKbps}kbps");
+            if (t.SampleRateHz is > 0)
+            {
+                var sampleRate = $"{t.SampleRateHz.Value / 1000.0:0.#}kHz";
+                if (t.BitDepth is > 0) sampleRate += $"/{t.BitDepth}bit";
+                parts.Add(sampleRate);
+            }
+            return string.Join(" ", parts);
         }
 
         /// <summary>

--- a/src/Services/Download/LoggingDownloadTelemetrySink.cs
+++ b/src/Services/Download/LoggingDownloadTelemetrySink.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Lidarr.Plugin.Common.Services.Download
+{
+    /// <summary>
+    /// The canonical <see cref="IDownloadTelemetrySink"/>: it renders every completed/failed track
+    /// through the shared <see cref="IDownloadTelemetryService"/> (rich human line + the stable
+    /// <c>[LPC_TELEMETRY]</c> marker). Plugins register this instead of hand-rolling a sink, so
+    /// download logging is identical across the ecosystem and a format change touches exactly one
+    /// file (<see cref="DownloadTelemetryService"/>). Best-effort: the underlying service never throws.
+    /// </summary>
+    public sealed class LoggingDownloadTelemetrySink : IDownloadTelemetrySink
+    {
+        private readonly IDownloadTelemetryService _service;
+
+        /// <summary>Creates a sink that delegates to the supplied telemetry service.</summary>
+        public LoggingDownloadTelemetrySink(IDownloadTelemetryService service)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+        }
+
+        /// <summary>
+        /// Convenience constructor for plugins that don't register an <see cref="IDownloadTelemetryService"/>
+        /// in DI: wraps a fresh <see cref="DownloadTelemetryService"/> over the given logger.
+        /// </summary>
+        public LoggingDownloadTelemetrySink(ILogger<DownloadTelemetryService>? logger = null)
+            : this(new DownloadTelemetryService(logger))
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnTrackCompleted(DownloadTelemetry telemetry) => _service.LogDownloadTelemetry(telemetry);
+    }
+}

--- a/src/Services/Download/SimpleDownloadOrchestrator.cs
+++ b/src/Services/Download/SimpleDownloadOrchestrator.cs
@@ -304,18 +304,18 @@ namespace Lidarr.Plugin.Common.Services.Download
                 }
 
                 stopwatch.Stop();
-                EmitTrackTelemetry(albumId, trackId, result, stopwatch.Elapsed, counters);
+                EmitTrackTelemetry(albumId, track, quality, trackId, result, stopwatch.Elapsed, counters);
                 return result;
             }
             catch (OperationCanceledException)
             {
                 stopwatch.Stop();
-                EmitTrackTelemetry(albumId, trackId, new TrackDownloadResult { TrackId = trackId, Success = false, ErrorMessage = "Canceled" }, stopwatch.Elapsed, counters);
+                EmitTrackTelemetry(albumId, track, quality, trackId, new TrackDownloadResult { TrackId = trackId, Success = false, ErrorMessage = "Canceled" }, stopwatch.Elapsed, counters);
                 throw;
             }
         }
 
-        private void EmitTrackTelemetry(string? albumId, string trackId, TrackDownloadResult result, TimeSpan elapsed, DownloadTelemetryCounters counters)
+        private void EmitTrackTelemetry(string? albumId, StreamingTrack? track, StreamingQuality? quality, string trackId, TrackDownloadResult result, TimeSpan elapsed, DownloadTelemetryCounters counters)
         {
             if (_telemetrySink == null)
             {
@@ -323,23 +323,27 @@ namespace Lidarr.Plugin.Common.Services.Download
             }
 
             var bytesWritten = Math.Max(0, result.FileSize);
-            var bytesPerSecond = elapsed.TotalSeconds > 0
-                ? bytesWritten / elapsed.TotalSeconds
-                : 0.0;
 
             try
             {
-                _telemetrySink.OnTrackCompleted(new DownloadTelemetry(
-                    ServiceName,
-                    albumId,
-                    trackId,
-                    result.Success,
-                    bytesWritten,
-                    elapsed,
-                    bytesPerSecond,
-                    counters.RetryCount,
-                    counters.TooManyRequestsCount,
-                    result.ErrorMessage));
+                // Enrich centrally from the track/quality the orchestrator already holds, so every
+                // plugin's sink receives artist/album/track/format/quality identically. The explicit
+                // albumId/trackId arguments stay authoritative (the model's Id may be unset or differ
+                // from the requested id), so they are re-applied over From()'s derived values.
+                var telemetry = DownloadTelemetry.From(
+                    serviceName: ServiceName,
+                    success: result.Success,
+                    track: track,
+                    album: track?.Album,
+                    quality: result.ActualQuality ?? quality,
+                    bytesWritten: bytesWritten,
+                    elapsed: elapsed,
+                    outputPath: result.FilePath,
+                    retryCount: counters.RetryCount,
+                    tooManyRequestsCount: counters.TooManyRequestsCount,
+                    errorMessage: result.ErrorMessage) with { AlbumId = albumId, TrackId = trackId };
+
+                _telemetrySink.OnTrackCompleted(telemetry);
             }
             catch (Exception ex)
             {

--- a/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
@@ -539,6 +539,59 @@ public abstract partial class EcosystemParityTestBase
 
     #endregion
 
+    #region Check_UsesCommonDownloadTelemetrySink
+
+    /// <summary>
+    /// Plugins must consume common's canonical download-telemetry sink
+    /// (<c>LoggingDownloadTelemetrySink</c>, registered via <c>AddDownloadTelemetry()</c>) instead
+    /// of hand-rolling an <c>IDownloadTelemetrySink</c>. A plugin-local implementation re-creates
+    /// the per-track log format that lives in <c>DownloadTelemetryService</c>, re-introducing the
+    /// cross-plugin logging divergence this contract exists to prevent. A genuinely custom sink
+    /// (e.g. one that forwards telemetry to an external metrics backend instead of logging) is a
+    /// legitimate divergence — document it by overriding this check to return
+    /// <see cref="ComplianceResult.Success"/> with a rationale.
+    /// </summary>
+    public virtual ComplianceResult Check_UsesCommonDownloadTelemetrySink()
+    {
+        var assembly = PluginAssembly;
+        if (assembly == null) return Skipped();
+
+        const string ifaceFullName = "Lidarr.Plugin.Common.Services.Download.IDownloadTelemetrySink";
+        const string commonSinkFullName = "Lidarr.Plugin.Common.Services.Download.LoggingDownloadTelemetrySink";
+
+        var offenders = new List<string>();
+        foreach (var type in SafeGetTypes(assembly))
+        {
+            if (type == null) continue;
+            try { if (type.IsInterface || type.IsAbstract) continue; }
+            catch { continue; }
+
+            Type[] ifaces;
+            try { ifaces = type.GetInterfaces(); }
+            catch { continue; }
+            if (!ifaces.Any(i => i.FullName == ifaceFullName)) continue;
+
+            // common's own types (incl. ILRepack-internalized LoggingDownloadTelemetrySink) are fine.
+            string ns;
+            try { ns = type.Namespace ?? string.Empty; }
+            catch { continue; }
+            if (IsCommonProductionNamespace(ns)) continue;
+
+            // Belt-and-suspenders: allow the canonical sink by full name even if its namespace
+            // classification ever changes.
+            var fullName = type.FullName ?? type.Name;
+            if (fullName == commonSinkFullName) continue;
+
+            offenders.Add(fullName);
+        }
+        return offenders.Count == 0
+            ? ComplianceResult.Success
+            : ComplianceResult.Failure(
+                $"Plugin-local IDownloadTelemetrySink implementations are forbidden — register common's via AddDownloadTelemetry() / LoggingDownloadTelemetrySink (or override this check to document a custom telemetry backend): {string.Join(", ", offenders)}");
+    }
+
+    #endregion
+
     #region Aggregator
 
     /// <summary>
@@ -557,6 +610,7 @@ public abstract partial class EcosystemParityTestBase
             [nameof(Check_UsesCommonPluginConfigRoots)] = Check_UsesCommonPluginConfigRoots(),
             [nameof(Check_UsesCommonLyricsEnricher)] = Check_UsesCommonLyricsEnricher(),
             [nameof(Check_UsesCommonDiagnosticTypes)] = Check_UsesCommonDiagnosticTypes(),
+            [nameof(Check_UsesCommonDownloadTelemetrySink)] = Check_UsesCommonDownloadTelemetrySink(),
         };
 
         var passed = results.Values.Count(r => r.Passed);

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -9,6 +9,7 @@ using Lidarr.Plugin.Abstractions.Results;
 using Lidarr.Plugin.Common.Interfaces;
 using Lidarr.Plugin.Common.Services.Authentication;
 using Lidarr.Plugin.Common.Services.Caching;
+using Lidarr.Plugin.Common.Services.Download;
 using Lidarr.Plugin.Common.Services.Registration;
 using Lidarr.Plugin.Common.TestKit.Compliance;
 using Xunit;
@@ -66,6 +67,7 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         public ComplianceResult RunConfigRoots() => Check_UsesCommonPluginConfigRoots();
         public ComplianceResult RunLyricsEnricher() => Check_UsesCommonLyricsEnricher();
         public ComplianceResult RunDiagnosticTypes() => Check_UsesCommonDiagnosticTypes();
+        public ComplianceResult RunDownloadTelemetrySink() => Check_UsesCommonDownloadTelemetrySink();
     }
 
     /// <summary>A plugin-local re-declaration of the lyrics enricher (forbidden — must use common's).</summary>
@@ -105,6 +107,12 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
 
     /// <summary>Plugin-local config-path helper (forbidden).</summary>
     private sealed class MyServiceConfigPathDefaults { }
+
+    /// <summary>A fake plugin-local IDownloadTelemetrySink (forbidden — hand-rolls the log format).</summary>
+    private sealed class RogueTelemetrySink : IDownloadTelemetrySink
+    {
+        public void OnTrackCompleted(DownloadTelemetry telemetry) { }
+    }
 
     /// <summary>Subclass of StreamingPluginModule for bridge-defaults check.</summary>
     private abstract class FakeModule : StreamingPluginModule { }
@@ -491,6 +499,41 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         Assert.True(h.RunDiagnosticTypes().Passed);
     }
 
+    // --- Check_UsesCommonDownloadTelemetrySink ---
+
+    [Fact]
+    public void TelemetrySink_NoAssembly_ReturnsSkipped()
+    {
+        var h = new Harness(_tempRepo) { AssemblyValue = null };
+        Assert.True(h.RunDownloadTelemetrySink().Passed);
+    }
+
+    [Fact]
+    public void TelemetrySink_PluginLocalImpl_Fails()
+    {
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(RogueTelemetrySink) },
+        };
+        var r = h.RunDownloadTelemetrySink();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("RogueTelemetrySink"));
+    }
+
+    [Fact]
+    public void TelemetrySink_CommonSink_Passes()
+    {
+        // common's own LoggingDownloadTelemetrySink lives under Lidarr.Plugin.Common.* so it is
+        // accepted (this also covers the ILRepack-internalized case).
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(LoggingDownloadTelemetrySink) },
+        };
+        Assert.True(h.RunDownloadTelemetrySink().Passed);
+    }
+
     // --- Aggregator ---
 
     [Fact]
@@ -498,8 +541,8 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
     {
         var h = new Harness(_tempRepo) { AssemblyValue = null };
         var report = h.RunBehaviorContractChecks();
-        Assert.Equal(8, report.TotalCount);
-        // No assembly => all 8 skipped (Pass).
+        Assert.Equal(9, report.TotalCount);
+        // No assembly => all 9 skipped (Pass).
         Assert.True(report.AllPassed);
     }
 }

--- a/tests/DownloadTelemetryEnrichmentTests.cs
+++ b/tests/DownloadTelemetryEnrichmentTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Lidarr.Plugin.Abstractions.Models;
+using Lidarr.Plugin.Common.Services.Download;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// Contract for the enriched download telemetry — the single source of truth that replaces
+    /// qobuz's duplicated emoji logging and tidal's IDs-only line. The record now carries the
+    /// user-valuable fields (artist/album/track/format/quality/size/path), a From(...) factory
+    /// maps them off Common's StreamingTrack/StreamingQuality models, and the service emits one
+    /// rich human line + the stable [LPC_TELEMETRY] marker.
+    /// </summary>
+    public class DownloadTelemetryEnrichmentTests
+    {
+        private sealed class CapturingLogger<T> : ILogger<T>
+        {
+            public List<string> Messages { get; } = new();
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                => Messages.Add(formatter(state, exception));
+
+            private sealed class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
+        }
+
+        private static StreamingTrack SampleTrack() => new()
+        {
+            Title = "So What",
+            Artist = new StreamingArtist { Name = "Miles Davis" },
+            Album = new StreamingAlbum { Title = "Kind of Blue" },
+            Duration = TimeSpan.FromSeconds(545),
+        };
+
+        private static StreamingQuality SampleQuality() => new()
+        {
+            Format = "FLAC",
+            Bitrate = 1411,
+            SampleRate = 96000,
+            BitDepth = 24,
+        };
+
+        [Fact]
+        public void From_maps_track_album_quality_onto_record()
+        {
+            var t = SampleTrack();
+            var q = SampleQuality();
+
+            var rec = DownloadTelemetry.From(
+                serviceName: "Qobuz", success: true, track: t, album: t.Album, quality: q,
+                bytesWritten: 40_000_000, elapsed: TimeSpan.FromSeconds(4), outputPath: "/music/x.flac",
+                retryCount: 1, tooManyRequestsCount: 0);
+
+            Assert.Equal("Qobuz", rec.ServiceName);
+            Assert.True(rec.Success);
+            Assert.Equal("Miles Davis", rec.Artist);
+            Assert.Equal("Kind of Blue", rec.AlbumTitle);
+            Assert.Equal("So What", rec.TrackTitle);
+            Assert.Equal("FLAC", rec.Format);
+            Assert.Equal(StreamingQualityTier.HiRes.ToString(), rec.QualityTier);
+            Assert.Equal(1411, rec.BitrateKbps);
+            Assert.Equal(96000, rec.SampleRateHz);
+            Assert.Equal(24, rec.BitDepth);
+            Assert.Equal("/music/x.flac", rec.OutputPath);
+            Assert.Equal(40_000_000, rec.BytesWritten);
+            Assert.Equal(1, rec.RetryCount);
+        }
+
+        [Fact]
+        public void LogDownloadTelemetry_emits_rich_human_line_when_fields_present()
+        {
+            var logger = new CapturingLogger<DownloadTelemetryService>();
+            var svc = new DownloadTelemetryService(logger);
+
+            var rec = DownloadTelemetry.From(
+                "Qobuz", true, SampleTrack(), SampleTrack().Album, SampleQuality(),
+                40_000_000, TimeSpan.FromSeconds(4), "/music/Kind of Blue/01 So What.flac");
+
+            svc.LogDownloadTelemetry(rec);
+
+            var joined = string.Join("\n", logger.Messages);
+            Assert.Contains("Miles Davis", joined);
+            Assert.Contains("So What", joined);
+            Assert.Contains("FLAC", joined);
+        }
+
+        [Fact]
+        public void LogDownloadTelemetry_marker_includes_identity_fields()
+        {
+            var logger = new CapturingLogger<DownloadTelemetryService>();
+            var svc = new DownloadTelemetryService(logger);
+
+            var rec = DownloadTelemetry.From(
+                "Tidal", true, SampleTrack(), SampleTrack().Album, SampleQuality(),
+                1000, TimeSpan.FromSeconds(1), "/x.flac");
+
+            svc.LogDownloadTelemetry(rec);
+
+            var marker = logger.Messages.Find(m => m.Contains(DownloadTelemetryService.StructuredMarkerPrefix));
+            Assert.NotNull(marker);
+            Assert.Contains("\"artist\":\"Miles Davis\"", marker);
+            Assert.Contains("\"track_title\":\"So What\"", marker);
+            Assert.Contains("\"format\":\"FLAC\"", marker);
+        }
+
+        [Fact]
+        public void LogDownloadTelemetry_still_works_for_legacy_id_only_record()
+        {
+            var logger = new CapturingLogger<DownloadTelemetryService>();
+            var svc = new DownloadTelemetryService(logger);
+
+            // Back-compat: the original positional shape (no enrichment fields) must still log.
+            var rec = new DownloadTelemetry("Apple", "alb1", "trk1", true, 2048, TimeSpan.FromSeconds(2), 1024, 0, 0, null);
+
+            svc.LogDownloadTelemetry(rec);
+
+            Assert.Contains(logger.Messages, m => m.Contains("trk1"));
+        }
+    }
+}

--- a/tests/DownloadTelemetryEnrichmentTests.cs
+++ b/tests/DownloadTelemetryEnrichmentTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Lidarr.Plugin.Abstractions.Models;
+using Lidarr.Plugin.Common.Extensions;
 using Lidarr.Plugin.Common.Services.Download;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -118,6 +120,48 @@ namespace Lidarr.Plugin.Common.Tests
             svc.LogDownloadTelemetry(rec);
 
             Assert.Contains(logger.Messages, m => m.Contains("trk1"));
+        }
+
+        private sealed class CapturingService : IDownloadTelemetryService
+        {
+            public List<DownloadTelemetry> Items { get; } = new();
+            public void LogDownloadTelemetry(DownloadTelemetry telemetry) => Items.Add(telemetry);
+        }
+
+        [Fact]
+        public void LoggingSink_delegates_to_telemetry_service()
+        {
+            // The canonical sink renders via the shared service rather than hand-rolling a format,
+            // so a plugin that registers it gets identical logging with zero per-plugin code.
+            var service = new CapturingService();
+            var sink = new LoggingDownloadTelemetrySink(service);
+
+            var rec = DownloadTelemetry.From("Qobuz", true, SampleTrack(), SampleTrack().Album, SampleQuality(), 1000, TimeSpan.FromSeconds(1));
+            sink.OnTrackCompleted(rec);
+
+            Assert.Same(rec, Assert.Single(service.Items));
+        }
+
+        [Fact]
+        public void LoggingSink_logger_ctor_renders_rich_line()
+        {
+            var logger = new CapturingLogger<DownloadTelemetryService>();
+            var sink = new LoggingDownloadTelemetrySink(logger);
+
+            sink.OnTrackCompleted(DownloadTelemetry.From("Qobuz", true, SampleTrack(), SampleTrack().Album, SampleQuality(), 1000, TimeSpan.FromSeconds(1), "/x.flac"));
+
+            Assert.Contains(logger.Messages, m => m.Contains("Miles Davis") && m.Contains("So What"));
+        }
+
+        [Fact]
+        public void AddDownloadTelemetry_registers_service_and_logging_sink()
+        {
+            var services = new ServiceCollection();
+            services.AddDownloadTelemetry();
+            using var provider = services.BuildServiceProvider();
+
+            Assert.IsType<DownloadTelemetryService>(provider.GetRequiredService<IDownloadTelemetryService>());
+            Assert.IsType<LoggingDownloadTelemetrySink>(provider.GetRequiredService<IDownloadTelemetrySink>());
         }
     }
 }

--- a/tests/SimpleDownloadOrchestratorTelemetryTests.cs
+++ b/tests/SimpleDownloadOrchestratorTelemetryTests.cs
@@ -103,6 +103,64 @@ namespace Lidarr.Plugin.Common.Tests
             }
         }
 
+        [Fact]
+        public async Task Should_emit_enriched_track_telemetry_with_identity_and_quality()
+        {
+            // The orchestrator is the single producer of download telemetry. It must enrich the
+            // emitted record from the StreamingTrack/StreamingQuality it already has in scope, so
+            // every plugin's sink receives artist/album/track/format/quality without re-deriving them.
+            var sink = new CapturingTelemetrySink();
+            using var httpClient = new HttpClient(new OkBytesHandler(bytes: 4096));
+
+            var outputDir = Path.Combine(Path.GetTempPath(), $"orch_telemetry_rich_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(outputDir);
+            var outputPath = Path.Combine(outputDir, "track");
+
+            try
+            {
+                var orchestrator = new SimpleDownloadOrchestrator(
+                    serviceName: "Test",
+                    httpClient: httpClient,
+                    getAlbumAsync: _ => Task.FromResult(new StreamingAlbum { Id = "alb1", Title = "Kind of Blue" }),
+                    getTrackAsync: id => Task.FromResult(new StreamingTrack
+                    {
+                        Id = id,
+                        Title = "So What",
+                        TrackNumber = 1,
+                        Artist = new StreamingArtist { Name = "Miles Davis" },
+                        Album = new StreamingAlbum { Id = "alb1", Title = "Kind of Blue" },
+                        Duration = TimeSpan.FromSeconds(545),
+                    }),
+                    getAlbumTrackIdsAsync: _ => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>()),
+                    getStreamAsync: (_, _) => Task.FromResult<(string Url, string Extension)>(("https://unit.test/stream", "flac")),
+                    maxConcurrentTracks: 1,
+                    streamProvider: null,
+                    metadataApplier: new NoopMetadataApplier(),
+                    logger: null,
+                    postProcessor: null,
+                    telemetrySink: sink);
+
+                var quality = new StreamingQuality { Format = "FLAC", Bitrate = 1411, SampleRate = 96000, BitDepth = 24 };
+                var result = await orchestrator.DownloadTrackAsync("track1", outputPath, quality, CancellationToken.None);
+
+                Assert.True(result.Success);
+
+                var telemetry = Assert.Single(sink.Items);
+                Assert.Equal("track1", telemetry.TrackId);     // authoritative id preserved (not track.Id from model)
+                Assert.Equal("Miles Davis", telemetry.Artist);
+                Assert.Equal("So What", telemetry.TrackTitle);
+                Assert.Equal("Kind of Blue", telemetry.AlbumTitle);
+                Assert.Equal("FLAC", telemetry.Format);
+                Assert.Equal(StreamingQualityTier.HiRes.ToString(), telemetry.QualityTier);
+                Assert.Equal(96000, telemetry.SampleRateHz);
+                Assert.False(string.IsNullOrEmpty(telemetry.OutputPath));
+            }
+            finally
+            {
+                try { Directory.Delete(outputDir, recursive: true); } catch { }
+            }
+        }
+
         internal sealed class CapturingTelemetrySink : IDownloadTelemetrySink
         {
             private readonly object _lock = new();


### PR DESCRIPTION
## Why

Logging axis of the cross-plugin consolidation program. Per-track download logging had diverged: **qobuz** logs ad-hoc (`Downloaded: {title} ({MB})`), **tidal** hand-rolls an IDs-only NLog format in `TidalDownloadTelemetrySink` that duplicates what Common's own `DownloadTelemetryService` already renders. Users couldn't see the valuable facts (artist / album / track / format / quality / size / path) consistently, and a format fix would have to touch every plugin.

This makes Common's `DownloadTelemetry` the single source of truth and makes the parity executable.

## What

1. **Enrich `DownloadTelemetry`** — append nullable fields (`Artist/AlbumTitle/TrackTitle/Format/QualityTier/BitrateKbps/SampleRateHz/BitDepth/TrackDuration/OutputPath`) with `= null` defaults (positional construction stays source-compatible). Add `DownloadTelemetry.From(track, album, quality, ...)` mapping off Common's `StreamingTrack`/`StreamingQuality`.

2. **Rich rendering** — `DownloadTelemetryService` now logs `Artist - Track [FLAC HiRes 96kHz/24bit] 38.1MB in 4.00s (...) -> /path` when enrichment is present (IDs-only line preserved for legacy records). The `[LPC_TELEMETRY]` marker gains `artist/track_title/album_title/format` keys (additive; `success` stays last so existing E2E suffix matchers keep working).

3. **Single producer enriches** — `SimpleDownloadOrchestrator.EmitTrackTelemetry` builds the record via `From(...)` from the `StreamingTrack`/`StreamingQuality` already in scope, re-applying the authoritative `albumId`/`trackId` via `with`. Every plugin sink now receives rich telemetry without re-deriving anything.

4. **Canonical sink** — new `LoggingDownloadTelemetrySink` delegates to `DownloadTelemetryService`, and `AddDownloadTelemetry()` registers service + sink for one-line opt-in. The log format now lives in exactly one file ecosystem-wide.

5. **Executable parity guard** — `EcosystemParityTestBase.Check_UsesCommonDownloadTelemetrySink` (7th behavior check) fails any plugin that declares its own `IDownloadTelemetrySink` instead of registering Common's; custom backends opt out by overriding the check.

## Follow-ups (separate PRs, after this lands + re-pin)
- **tidalarr**: replace `TidalDownloadTelemetrySink` registration with `AddDownloadTelemetry()` and delete the bespoke sink (guard then passes).
- **qobuzarr**: adopt the orchestrator telemetry path / register the sink so its downloads emit the rich line.

## Testing
- Test-first throughout (RED→GREEN): 4 record/service tests, 1 orchestrator-enrichment test, 3 sink/DI tests, 3 parity-guard tests.
- 30 telemetry tests + 27 parity-extension tests green locally.
- CI-equivalent build (`-warnaserror`, analyzers off) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)