### PR TITLE
fix(parity): FileClassNameParity recognizes top-level type matching filename (qobuz/apple HealthDiagnostics FP)

### DIFF
--- a/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
@@ -685,8 +685,19 @@ public abstract partial class EcosystemParityTestBase
             var matches = typeDecl.Matches(text);
             if (matches.Count != 1) continue; // 0 = no public type; >1 = grouping file (allowed)
             var typeName = matches[0].Groups[1].Value;
-            if (!string.Equals(typeName, fileName, StringComparison.Ordinal))
-                offenders.Add($"{Path.GetRelativePath(RepoRootPath, file)} (file '{fileName}' != type '{typeName}')");
+            if (string.Equals(typeName, fileName, StringComparison.Ordinal)) continue;
+
+            // The single PUBLIC type's name differs from the file name — but if the file's TOP-LEVEL
+            // type (any accessibility) is itself named after the file, the file IS correctly named and
+            // the public type is a nested helper (e.g. an `internal *HealthDiagnostics` whose only
+            // public member is a nested `Capabilities`). Only flag when no top-level type matches the
+            // file name. (^-anchored = top-level in the file-scoped-namespace style these repos use.)
+            var declaresFileNameTopLevelType = System.Text.RegularExpressions.Regex.IsMatch(
+                text,
+                $@"(?m)^(?:\[[^\]]*\]\s*)*(?:(?:public|internal|private|protected|file|sealed|abstract|static|partial|readonly|unsafe)\s+)*(?:class|interface|record|struct|enum)\s+{System.Text.RegularExpressions.Regex.Escape(fileName)}\b");
+            if (declaresFileNameTopLevelType) continue;
+
+            offenders.Add($"{Path.GetRelativePath(RepoRootPath, file)} (file '{fileName}' != type '{typeName}')");
         }
         return offenders.Count == 0
             ? ComplianceResult.Success

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -622,6 +622,19 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
     }
 
     [Fact]
+    public void FileClassParity_InternalPrimaryWithPublicNestedHelper_Passes()
+    {
+        // A file whose TOP-LEVEL type matches the file name (here `internal`) is correctly named even
+        // if its only PUBLIC type is a nested helper — the *HealthDiagnostics pattern (internal
+        // HealthDiagnostics + public nested Capabilities). Must NOT be flagged on the nested type.
+        var src = Path.Combine(_tempRepo, "src");
+        WriteSrcFile(src, "QobuzHealthDiagnostics.cs",
+            "namespace N;\ninternal static class QobuzHealthDiagnostics\n{\n    public static class Capabilities { }\n}");
+        var h = new Harness(_tempRepo) { SourceRootValue = src };
+        Assert.True(h.RunFileClassNameParity().Passed);
+    }
+
+    [Fact]
     public void FileClassParity_MultiTypeGroupingFile_Passes()
     {
         // DTO/exception-family grouping files declare >1 public type — allowed, not flagged.


### PR DESCRIPTION
`Check_FileClassNameParity` counted only PUBLIC type declarations, so a file whose top-level type is `internal` but which exposes a nested `public` helper got flagged on the nested type. Concretely, `qobuz`/`apple` `*HealthDiagnostics.cs` declare `internal static class *HealthDiagnostics` (correctly named after the file) + a nested `public static class Capabilities` → the guard misfired with `file '*HealthDiagnostics' != type 'Capabilities'`. tidal escaped only incidentally (it has 2 public nested types → multi-type skip).

Surfaced wiring the 12 guards into qobuz's parity suite (consolidation re-pin). Additive fix: when the single public type's name != filename, do **not** flag if the file declares a TOP-LEVEL type (any accessibility) named after the file. Real mis-named single-type files (no matching top-level type) still fail. Added `FileClassParity_InternalPrimaryWithPublicNestedHelper_Passes`; FileClassParity + count suite 10/10 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)