### PR TITLE
feat(parity): host-coupled dependency-version guard (DirectoryPackagesProps_HostVersionsMatchCanonical)

### DIFF
--- a/testkit/Compliance/EcosystemParityTestBase.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.cs
@@ -178,6 +178,46 @@ public abstract partial class EcosystemParityTestBase : IDisposable
         return ComplianceResult.Success;
     }
 
+    /// <summary>
+    /// Host-coupled dependency versions must match the Lidarr host's shipped assemblies (the version
+    /// table in each plugin's CLAUDE.md). A merged plugin DLL that references a version the host
+    /// doesn't ship causes AssemblyLoadContext / load failures in multi-plugin co-existence — the
+    /// class of bug behind the historical "ALC lifecycle" red herring. This is the deterministic,
+    /// host-DLL-free counterpart to plugin-local HostVersionCouplingTests (which reads ext/Lidarr DLLs
+    /// and is Docker-flaky). A package is only checked when the plugin references it (absence is fine).
+    /// </summary>
+    public virtual ComplianceResult DirectoryPackagesProps_HostVersionsMatchCanonical()
+    {
+        if (!FileExists("Directory.Packages.props"))
+            return ComplianceResult.Failure("Directory.Packages.props not found");
+
+        var canonical = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Microsoft.Extensions.DependencyInjection"] = "8.0.1",
+            ["Microsoft.Extensions.Logging"] = "8.0.1",
+            ["Microsoft.Extensions.Logging.Abstractions"] = "8.0.3",
+            ["Microsoft.Extensions.Http"] = "8.0.1",
+            ["FluentValidation"] = "9.5.4",
+            ["NLog"] = "5.4.0",
+        };
+
+        var doc = LoadXml("Directory.Packages.props");
+        var offenders = new List<string>();
+        foreach (var pv in doc.Descendants().Where(e => e.Name.LocalName == "PackageVersion"))
+        {
+            var id = (string?)pv.Attribute("Include");
+            if (id == null || !canonical.TryGetValue(id, out var expected)) continue;
+            var actual = (string?)pv.Attribute("Version");
+            if (!string.Equals(actual, expected, StringComparison.Ordinal))
+                offenders.Add($"{id} = {actual ?? "<none>"} (host-coupled; must be {expected})");
+        }
+
+        return offenders.Count == 0
+            ? ComplianceResult.Success
+            : ComplianceResult.Failure(
+                $"Host-coupled dependency versions must match the Lidarr host (multi-plugin ALC safety): {string.Join("; ", offenders)}");
+    }
+
     #endregion
 
     #region plugin.json Tests

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -711,6 +711,35 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         Assert.Contains(r.Errors, e => e.Contains("Common helpers in use"));
     }
 
+    // --- DirectoryPackagesProps_HostVersionsMatchCanonical ---
+
+    [Fact]
+    public void HostVersions_MatchingCanonical_Passes()
+    {
+        File.WriteAllText(Path.Combine(_tempRepo, "Directory.Packages.props"),
+            "<Project><ItemGroup>"
+            + "<PackageVersion Include=\"NLog\" Version=\"5.4.0\" />"
+            + "<PackageVersion Include=\"FluentValidation\" Version=\"9.5.4\" />"
+            + "<PackageVersion Include=\"Microsoft.Extensions.Http\" Version=\"8.0.1\" />"
+            + "<PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" />" // not host-coupled — ignored
+            + "</ItemGroup></Project>");
+        var h = new Harness(_tempRepo);
+        Assert.True(h.DirectoryPackagesProps_HostVersionsMatchCanonical().Passed);
+    }
+
+    [Fact]
+    public void HostVersions_MismatchedHostCoupled_Fails()
+    {
+        File.WriteAllText(Path.Combine(_tempRepo, "Directory.Packages.props"),
+            "<Project><ItemGroup>"
+            + "<PackageVersion Include=\"NLog\" Version=\"6.0.3\" />" // host-coupled drift (host ships 5.x)
+            + "</ItemGroup></Project>");
+        var h = new Harness(_tempRepo);
+        var r = h.DirectoryPackagesProps_HostVersionsMatchCanonical();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("NLog") && e.Contains("5.4.0"));
+    }
+
     // --- Aggregator ---
 
     [Fact]


### PR DESCRIPTION
Turns the cross-plugin host-pinned version table (in each plugin's CLAUDE.md) into a deterministic `EcosystemParityTestBase` guard. A merged plugin DLL referencing a version the Lidarr host doesn''t ship causes ALC/load failures in multi-plugin co-existence — this fails CI instead of waiting for an audit.

Checks `Directory.Packages.props` for the host-coupled packages (DI/Logging/Logging.Abstractions/Http 8.0.x, FluentValidation 9.5.4, NLog 5.4.0), only where referenced. Deterministic (no host-DLL dependency, unlike the Docker-flaky plugin-local `HostVersionCouplingTests`). 2 unit tests green. Characterized: all 3 streaming plugins already match; brainarr diverges (NLog 6.0.3) — reconciled separately when its parallel work settles.

Next: re-pin tidal/qobuz/apple to this SHA (one common SHA across all 3) + wire the guard into their parity suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)