### PR TITLE
test(parity): harden host-version guard (fail-loud on non-literal pins + lock intent)

### DIFF
--- a/testkit/Compliance/EcosystemParityTestBase.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.cs
@@ -185,6 +185,15 @@ public abstract partial class EcosystemParityTestBase : IDisposable
     /// class of bug behind the historical "ALC lifecycle" red herring. This is the deterministic,
     /// host-DLL-free counterpart to plugin-local HostVersionCouplingTests (which reads ext/Lidarr DLLs
     /// and is Docker-flaky). A package is only checked when the plugin references it (absence is fine).
+    ///
+    /// Two complementary layers, not duplicates: this is the DECLARED-PINS layer (what
+    /// Directory.Packages.props says), HostVersionCouplingTests is the RESOLVED-VERSION layer (what the
+    /// merged DLL actually binds, vs the real host DLL). They intentionally differ on FluentValidation:
+    /// Common internalizes FV (PrivateAssets=all) so its identity need not cross the host ALC boundary
+    /// (only NLog does — that's all HostVersionCouplingTests asserts against the host DLL). FV is pinned
+    /// here purely for cross-plugin PARITY (every plugin on the identical 9.5.4, whose AssemblyVersion
+    /// 9.0.0.0 also happens to match the host). So a present-but-non-canonical pin is a parity defect
+    /// even where it isn't strictly an ALC hazard.
     /// </summary>
     public virtual ComplianceResult DirectoryPackagesProps_HostVersionsMatchCanonical()
     {
@@ -207,7 +216,15 @@ public abstract partial class EcosystemParityTestBase : IDisposable
         {
             var id = (string?)pv.Attribute("Include");
             if (id == null || !canonical.TryGetValue(id, out var expected)) continue;
-            var actual = (string?)pv.Attribute("Version");
+            var actual = ((string?)pv.Attribute("Version"))?.Trim();
+            if (actual != null && actual.Contains("$("))
+            {
+                // An MSBuild expression (e.g. Version="$(NLogVersion)") can't be statically
+                // verified and defeats the greppable-literal-pin philosophy. Fail loud rather
+                // than silently miscompare the raw "$(...)" string.
+                offenders.Add($"{id} = {actual} (host-coupled; must be the literal {expected} — MSBuild expressions can't be statically verified for parity)");
+                continue;
+            }
             if (!string.Equals(actual, expected, StringComparison.Ordinal))
                 offenders.Add($"{id} = {actual ?? "<none>"} (host-coupled; must be {expected})");
         }

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -740,6 +740,56 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         Assert.Contains(r.Errors, e => e.Contains("NLog") && e.Contains("5.4.0"));
     }
 
+    [Fact]
+    public void HostVersions_AllSixCanonicalPackagesPresent_Passes()
+    {
+        // Characterization: proves all six canonical keys are wired correctly (a typo in any
+        // dictionary key would let a wrong version slip through for that package).
+        File.WriteAllText(Path.Combine(_tempRepo, "Directory.Packages.props"),
+            "<Project><ItemGroup>"
+            + "<PackageVersion Include=\"Microsoft.Extensions.DependencyInjection\" Version=\"8.0.1\" />"
+            + "<PackageVersion Include=\"Microsoft.Extensions.Logging\" Version=\"8.0.1\" />"
+            + "<PackageVersion Include=\"Microsoft.Extensions.Logging.Abstractions\" Version=\"8.0.3\" />"
+            + "<PackageVersion Include=\"Microsoft.Extensions.Http\" Version=\"8.0.1\" />"
+            + "<PackageVersion Include=\"FluentValidation\" Version=\"9.5.4\" />"
+            + "<PackageVersion Include=\"NLog\" Version=\"5.4.0\" />"
+            + "</ItemGroup></Project>");
+        var h = new Harness(_tempRepo);
+        var r = h.DirectoryPackagesProps_HostVersionsMatchCanonical();
+        Assert.True(r.Passed, string.Join("; ", r.Errors));
+    }
+
+    [Fact]
+    public void HostVersions_NoHostCoupledPackagesDeclared_Passes()
+    {
+        // "Absence is OK" is intentional: this guard is the DECLARED-PINS layer. A plugin that
+        // doesn't declare a host-coupled package (e.g. applemusicarr omits
+        // Microsoft.Extensions.DependencyInjection, which resolves transitively) is validated at
+        // the RESOLVED-VERSION layer by the per-plugin host-DLL-grounded HostVersionCouplingTests.
+        File.WriteAllText(Path.Combine(_tempRepo, "Directory.Packages.props"),
+            "<Project><ItemGroup>"
+            + "<PackageVersion Include=\"Newtonsoft.Json\" Version=\"13.0.3\" />"
+            + "</ItemGroup></Project>");
+        var h = new Harness(_tempRepo);
+        Assert.True(h.DirectoryPackagesProps_HostVersionsMatchCanonical().Passed);
+    }
+
+    [Fact]
+    public void HostVersions_NonLiteralVersionExpression_FailsLoud()
+    {
+        // A host-coupled package pinned to an MSBuild expression can't be statically verified for
+        // parity (and defeats the greppability the literal-pin philosophy depends on). The guard
+        // must fail with an actionable message, not silently miscompare the raw "$(...)" string.
+        File.WriteAllText(Path.Combine(_tempRepo, "Directory.Packages.props"),
+            "<Project><ItemGroup>"
+            + "<PackageVersion Include=\"NLog\" Version=\"$(NLogVersion)\" />"
+            + "</ItemGroup></Project>");
+        var h = new Harness(_tempRepo);
+        var r = h.DirectoryPackagesProps_HostVersionsMatchCanonical();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("NLog") && e.Contains("literal"));
+    }
+
     // --- Aggregator ---
 
     [Fact]


### PR DESCRIPTION
Acts on an adversarial CI/CD review of the host-version guard (#562).

- **Fail loud on non-literal pins**: `Version="$(NLogVersion)"` now fails with an actionable `must be the literal X` message instead of silently miscomparing the raw `$(...)` string. Version attribute is trimmed defensively.
- **Lock design intent** (characterization tests): all-six-canonical-present passes (catches a future typo in any dictionary key); no-host-coupled-declared passes (codifies *absence is OK* — this is the DECLARED-PINS layer; the per-plugin host-DLL `HostVersionCouplingTests` is the RESOLVED-VERSION layer).
- **Reconcile FluentValidation framing**: FV is internalized (`PrivateAssets=all`) so its identity need not cross the host ALC boundary (only NLog does); FV is pinned here for cross-plugin **parity**. The doc comment now spells out the two-layer model so this guard and `HostVersionCouplingTests` no longer read as conflicting.

53/53 `EcosystemParityTestBaseExtensionTests` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)