### PR TITLE
fix(cli): resolve quarantined CLI-framework bugs #318 (Int32 coercion) + #319 (MemoryQueue ids)

### DIFF
--- a/src/CLI/Services/FileStateService.cs
+++ b/src/CLI/Services/FileStateService.cs
@@ -75,7 +75,7 @@ namespace Lidarr.Plugin.Common.CLI.Services
 
         public Task<T> GetAsync<T>(string key)
         {
-            if (_state.TryGetValue(key, out var value) && value is T typedValue)
+            if (_state.TryGetValue(key, out var value) && TryCoerce<T>(value, out var typedValue))
             {
                 return Task.FromResult(typedValue);
             }
@@ -86,11 +86,55 @@ namespace Lidarr.Plugin.Common.CLI.Services
 
         public Task<T?> TryGetAsync<T>(string key)
         {
-            if (_state.TryGetValue(key, out var value) && value is T typedValue)
+            if (_state.TryGetValue(key, out var value) && TryCoerce<T>(value, out var typedValue))
             {
                 return Task.FromResult<T?>(typedValue);
             }
             return Task.FromResult<T?>(default);
+        }
+
+        /// <summary>
+        /// Coerces a stored value to the requested target type <typeparamref name="T"/>.
+        /// JSON deserialization boxes numbers as Int64/Double, so a value originally stored as
+        /// (e.g.) Int32 returns as a boxed Int64 after a save/load round-trip. This honors the
+        /// caller's requested type by converting compatible primitives, preserving type fidelity
+        /// for plugin settings (quality level, limits, etc.).
+        /// </summary>
+        private static bool TryCoerce<T>(object? value, out T result)
+        {
+            if (value is T typedValue)
+            {
+                result = typedValue;
+                return true;
+            }
+
+            if (value == null)
+            {
+                result = default!;
+                return false;
+            }
+
+            try
+            {
+                var targetType = typeof(T);
+                var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+                // Only attempt conversion between convertible (primitive/IConvertible) types.
+                // This restores Int32/Int64/Double/Decimal/etc. faithfully without forcing
+                // unrelated reference-type mismatches to succeed.
+                if (value is IConvertible && typeof(IConvertible).IsAssignableFrom(underlyingType))
+                {
+                    result = (T)Convert.ChangeType(value, underlyingType);
+                    return true;
+                }
+            }
+            catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
+            {
+                // Not convertible to the requested type; fall through to failure.
+            }
+
+            result = default!;
+            return false;
         }
 
         public Task<bool> ExistsAsync(string key)

--- a/tests/FileStateServiceTests.cs
+++ b/tests/FileStateServiceTests.cs
@@ -260,7 +260,6 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
-        [Trait("State", "Quarantined")]  // Quarantined 2026-02-05: Pre-existing Int32 type coercion failure on all platforms - Issue #318
         public async Task LoadAsync_MultipleTypes_RestoresAll()
         {
             var data = new Dictionary<string, object>
@@ -636,7 +635,6 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
-        [Trait("State", "Quarantined")]  // Quarantined 2026-02-05: Pre-existing Int32 type coercion failure on all platforms - Issue #318
         public async Task SaveLoad_RoundTrip_Integer_PreservesValue()
         {
             var service = CreateService();

--- a/tests/MemoryQueueServiceTests.cs
+++ b/tests/MemoryQueueServiceTests.cs
@@ -742,7 +742,6 @@ namespace Lidarr.Plugin.Common.Tests
         #region Thread Safety Tests
 
         [Fact]
-        [Trait("State", "Quarantined")] // Quarantined 2026-02-05: Bug - ids HashSet never populated, assertion always fails - Issue #319
         public async Task EnqueueAsync_ConcurrentEnqueues_AllItemsAdded()
         {
             // Arrange
@@ -756,6 +755,11 @@ namespace Lidarr.Plugin.Common.Tests
             ).ToArray();
 
             var results = await Task.WhenAll(tasks);
+
+            foreach (var id in results)
+            {
+                ids.Add(id);
+            }
 
             // Assert
             Assert.Equal(threadCount, results.Length);


### PR DESCRIPTION
Fixes the two tracked, quarantined logic bugs in the opt-in CLI framework so it's a clean adoption target (CLI consolidation Step 0 — 'no tech debt' before plugins migrate onto it).

**#318 — Int32 type coercion (real correctness bug).** `FileStateService.LoadAsync` deserializes into `Dictionary<string,object>`, so Newtonsoft boxes JSON numbers as `Int64`/`Double`; `GetAsync<int>`'s `value is T` check then failed for a boxed `long` → `KeyNotFoundException`. An int setting (quality level, limit) would change type on save/load round-trip. Fix: a narrow `TryCoerce<T>` at the typed-access boundary — tries the exact cast first (unchanged behavior), else converts only when both sides are `IConvertible` (handles `Nullable<T>`), catching only `InvalidCast/Format/Overflow` so genuine mismatches still fail. Routed `GetAsync<T>` + `TryGetAsync<T>` through it.

**#319 — MemoryQueue ids (test bug).** Production `EnqueueAsync` correctly assigns a unique GUID per item. The test declared an `ids` HashSet but never populated it, so `Assert.Equal(threadCount, ids.Count)` was always `50 != 0`. Fix completes the test's intent (`foreach (var id in results) ids.Add(id)`) — the assertion now genuinely proves all concurrent enqueues produced unique ids. Assertion unchanged (not weakened).

Removed `[Trait("State","Quarantined")]` from all three now-passing tests. Independently verified: 3/3 fixed tests green; agent regression 139/139 (State!=Quarantined). Out of scope: the flaky LiveDashboard timing tests stay quarantined (separate work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)