### PR TITLE
fix(ci): pin bash for nightly matrix job (windows pwsh misparsed --flags)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,13 @@ jobs:
           - os: ubuntu-latest
             dotnet-version: '9.0.x'
 
+    # Steps below use bash line-continuations; windows-latest defaults to pwsh
+    # (where a line-leading `--flag` parses as the `--` decrement operator), so
+    # pin bash for every OS in this matrix job.
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
**Root cause:** the nightly matrix runs on `[ubuntu-latest, windows-latest]`, but the "Run tests" step uses bash `\` line-continuations. windows-latest defaults to **pwsh**, where a line-leading `--configuration` is parsed as the `--` decrement operator -> `Missing expression after unary operator '--'` ParserError. The windows nightly leg failed every night (the "Nightly Summary" failure was a downstream consequence).

**Fix:** pin `shell: bash` at the job level so every OS in the matrix uses the shell the steps are written for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)