### PR TITLE
feat(download): canonical AlbumCompletionPolicy + parity guard (incomplete album => Failed)

### DIFF
--- a/src/Services/Download/AlbumCompletionPolicy.cs
+++ b/src/Services/Download/AlbumCompletionPolicy.cs
@@ -1,0 +1,53 @@
+namespace Lidarr.Plugin.Common.Services.Download
+{
+    /// <summary>
+    /// Canonical, side-effect-free album-completion rule shared by all streaming plugins.
+    /// </summary>
+    public static class AlbumCompletionPolicy
+    {
+        /// <summary>Default minimum success rate applied only to a COMPLETE album.</summary>
+        public const double DefaultMinimumSuccessRate = 0.8;
+
+        /// <summary>
+        /// Determines whether an album download should be reported to the host as successful.
+        /// </summary>
+        /// <remarks>
+        /// An album is successful ONLY when every track ended up on disk
+        /// (<paramref name="successfulTracks"/> == <paramref name="totalTracks"/>). Any deficit —
+        /// a failed track OR a sample/preview-skipped one — leaves the album incomplete, and
+        /// Lidarr's <c>NoMissingOrUnmatchedTracksSpecification</c> permanently rejects an incomplete
+        /// release ("Has missing tracks"), so reporting it Completed silently wastes the good files.
+        /// Reporting failure instead lets Lidarr blocklist + re-search (fall back to another source).
+        /// The <paramref name="minimumSuccessRate"/> / <paramref name="treatPreviewAsFailure"/> knobs
+        /// can only ever gate a COMPLETE album — they can never rescue an incomplete one (the hard
+        /// gate fires first). Pure function: no I/O, no host types — each plugin maps the result to
+        /// its own download-item status at its boundary.
+        /// </remarks>
+        public static bool IsAlbumDownloadSuccessful(
+            int totalTracks,
+            int successfulTracks,
+            int skippedTracks = 0,
+            double minimumSuccessRate = DefaultMinimumSuccessRate,
+            bool treatPreviewAsFailure = false,
+            bool failOnNoTracksAvailable = true)
+        {
+            if (totalTracks == 0)
+                return !failOnNoTracksAvailable;
+
+            // Hard gate: an incomplete album is unimportable, so any missing track ⇒ not successful,
+            // regardless of the threshold knobs below.
+            if (successfulTracks < totalTracks)
+                return false;
+
+            var effectiveTotal = totalTracks;
+            if (!treatPreviewAsFailure)
+                effectiveTotal -= skippedTracks;
+
+            if (effectiveTotal == 0)
+                return !failOnNoTracksAvailable;
+
+            var successRate = (double)successfulTracks / effectiveTotal;
+            return successRate >= minimumSuccessRate;
+        }
+    }
+}

--- a/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using Lidarr.Plugin.Common.Services.Download;
 
 namespace Lidarr.Plugin.Common.TestKit.Compliance;
 
@@ -732,6 +733,37 @@ public abstract partial class EcosystemParityTestBase
 
     #region Aggregator
 
+    #region Check_EnforcesAlbumCompletionPolicy
+
+    /// <summary>
+    /// Every streaming plugin must share one album-completion rule: an incomplete album (any
+    /// track missing) is NOT a successful download, so it is reported Failed (Lidarr blocklists
+    /// + re-searches / falls back) rather than Completed (which Lidarr permanently rejects as
+    /// "Has missing tracks", silently wasting the downloaded files). The rule lives in
+    /// <see cref="AlbumCompletionPolicy"/>; this guard pins it in every plugin's pinned Common,
+    /// so a plugin that delegates to it provably inherits the fix and cannot regress to
+    /// "partial album == success". (Was a live qobuz regression: Aphex Twin – Drukqs, 29/30.)
+    /// Unlike the other behavior checks this needs no <see cref="PluginAssembly"/> — it asserts
+    /// the shared rule directly, so it runs for every plugin regardless of opt-in.
+    /// </summary>
+    public virtual ComplianceResult Check_EnforcesAlbumCompletionPolicy()
+    {
+        var errors = new List<string>();
+
+        // Incomplete must never be successful — not even above the success-rate threshold.
+        if (AlbumCompletionPolicy.IsAlbumDownloadSuccessful(totalTracks: 30, successfulTracks: 29))
+            errors.Add("AlbumCompletionPolicy treats 29/30 as successful; an incomplete album must report Failed.");
+        if (AlbumCompletionPolicy.IsAlbumDownloadSuccessful(totalTracks: 10, successfulTracks: 8))
+            errors.Add("AlbumCompletionPolicy treats 8/10 as successful; an incomplete album must report Failed.");
+        // A complete album must be successful.
+        if (!AlbumCompletionPolicy.IsAlbumDownloadSuccessful(totalTracks: 10, successfulTracks: 10))
+            errors.Add("AlbumCompletionPolicy treats a complete 10/10 album as unsuccessful.");
+
+        return errors.Count == 0 ? ComplianceResult.Success : new ComplianceResult(false, errors);
+    }
+
+    #endregion
+
     /// <summary>
     /// Runs the behavior-contract checks. Returns a separate report so callers can decide
     /// whether to combine with structural results.
@@ -740,6 +772,7 @@ public abstract partial class EcosystemParityTestBase
     {
         var results = new Dictionary<string, ComplianceResult>
         {
+            [nameof(Check_EnforcesAlbumCompletionPolicy)] = Check_EnforcesAlbumCompletionPolicy(),
             [nameof(Check_UsesCommonFileTokenStore)] = Check_UsesCommonFileTokenStore(),
             [nameof(Check_UsesCommonHttpResponseCache)] = Check_UsesCommonHttpResponseCache(),
             [nameof(Check_RegistersBridgeDefaults)] = Check_RegistersBridgeDefaults(),

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -797,8 +797,9 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
     {
         var h = new Harness(_tempRepo) { AssemblyValue = null };
         var report = h.RunBehaviorContractChecks();
-        Assert.Equal(12, report.TotalCount);
-        // No assembly + no CLAUDE.md => all 12 skipped (Pass).
+        Assert.Equal(13, report.TotalCount);
+        // No assembly + no CLAUDE.md => the other 12 skip (Pass); Check_EnforcesAlbumCompletionPolicy
+        // runs unconditionally (it asserts the shared rule directly, no assembly needed) and passes.
         Assert.True(report.AllPassed);
     }
 }

--- a/tests/Services/Download/AlbumCompletionPolicyTests.cs
+++ b/tests/Services/Download/AlbumCompletionPolicyTests.cs
@@ -1,0 +1,67 @@
+using Lidarr.Plugin.Common.Services.Download;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Services.Download;
+
+/// <summary>
+/// Pins the canonical album-completion rule shared by all streaming plugins:
+/// an album download is successful ONLY when every track lands on disk
+/// (successfulTracks == totalTracks). Any deficit — a failed track OR a
+/// sample/preview-skipped one — leaves the album incomplete, which Lidarr's
+/// NoMissingOrUnmatchedTracksSpecification permanently rejects ("Has missing
+/// tracks"). So an incomplete album must report failure (→ Lidarr blocklists +
+/// re-searches / falls back) rather than Completed (→ silent permanent reject).
+/// The MinimumSuccessRate / TreatPreviewAsFailure knobs can only ever gate a
+/// COMPLETE album; they can never rescue an incomplete one. This was a live
+/// regression in qobuz (Aphex Twin – Drukqs, 29/30) and is tidal's existing rule
+/// (failedTracks &gt; 0 ⇒ Failed); this is the single source of truth for both.
+/// </summary>
+public sealed class AlbumCompletionPolicyTests
+{
+    [Theory]
+    // Hard gate: ANY missing track ⇒ incomplete ⇒ NOT successful, regardless of rate.
+    [InlineData(30, 29, 0, false)] // Drukqs: 29/30 = 96.7% ≥ 80% but one track missing ⇒ fail
+    [InlineData(10, 8, 0, false)]  // 2 failed ⇒ incomplete ⇒ fail (even at exactly 80%)
+    [InlineData(10, 9, 0, false)]  // 1 failed ⇒ incomplete ⇒ fail
+    [InlineData(10, 5, 5, false)]  // 5 downloaded + 5 sample-skipped ⇒ 5 missing ⇒ fail
+    // Complete album ⇒ successful.
+    [InlineData(10, 10, 0, true)]
+    [InlineData(1, 1, 0, true)]
+    [InlineData(53, 53, 0, true)]
+    public void IsAlbumDownloadSuccessful_GatesOnCompleteness(
+        int total, int successful, int skipped, bool expected)
+    {
+        Assert.Equal(expected, AlbumCompletionPolicy.IsAlbumDownloadSuccessful(total, successful, skipped));
+    }
+
+    [Fact]
+    public void IncompleteAlbum_IsNeverSuccessful_EvenWithPermissiveThreshold()
+    {
+        // A partial album is unimportable by Lidarr; a permissive rate must not rescue it.
+        Assert.False(AlbumCompletionPolicy.IsAlbumDownloadSuccessful(
+            totalTracks: 10, successfulTracks: 5, skippedTracks: 0, minimumSuccessRate: 0.1));
+    }
+
+    [Fact]
+    public void EmptyAlbum_FollowsFailOnNoTracksAvailable()
+    {
+        // Default: an album with no tracks available is a failure (parity with tidal's
+        // "no files on disk ⇒ Failed").
+        Assert.False(AlbumCompletionPolicy.IsAlbumDownloadSuccessful(0, 0, 0));
+        // Opt-out for callers that treat an empty album as a no-op success.
+        Assert.True(AlbumCompletionPolicy.IsAlbumDownloadSuccessful(
+            0, 0, 0, failOnNoTracksAvailable: false));
+    }
+
+    [Theory]
+    // Tidal-equivalence: tidal's rule is "any failed track ⇒ Failed", i.e. success iff
+    // every track succeeded. The default policy (minRate 0.8, no preview-as-failure)
+    // reproduces it exactly because the hard gate fires before any rate check.
+    [InlineData(12, 12, true)]
+    [InlineData(12, 11, false)]
+    [InlineData(12, 0, false)]
+    public void DefaultPolicy_MatchesTidalAllOrNothing(int total, int successful, bool expected)
+    {
+        Assert.Equal(expected, AlbumCompletionPolicy.IsAlbumDownloadSuccessful(total, successful));
+    }
+}


### PR DESCRIPTION
## What

Adds a single source of truth for the **album-completion rule** every streaming plugin needs, plus an executable parity guard.

- `src/Services/Download/AlbumCompletionPolicy.cs` — pure, side-effect-free `IsAlbumDownloadSuccessful(total, successful, skipped, minRate, treatPreviewAsFailure, failOnNoTracksAvailable)`. An album is successful **only when every track lands on disk** (`successful == total`); any deficit ⇒ not successful, regardless of the threshold knobs (which can only gate a *complete* album).
- `testkit/.../EcosystemParityTestBase.BehaviorContracts.cs` — `Check_EnforcesAlbumCompletionPolicy` guard (registered in `RunBehaviorContractChecks`) that pins the rule in every plugin's pinned Common.

## Why

Live regression on the local Lidarr instance: a partial qobuz album (Aphex Twin – Drukqs, **29/30**, one track unavailable) was reported `Completed`; Lidarr's `NoMissingOrUnmatchedTracksSpecification` then permanently rejected the import (`"Has missing tracks"`) → 29 good FLACs imported nothing, no retry, no fallback. qobuz fixed it inline (PR #286); tidal already behaved this way (`failedTracks > 0 ⇒ Failed`); apple is single-track. Three plugins, three encodings of the same rule → lift one canonical impl to Common so it can't diverge again.

The policy is a **pure function with no host types** (Common can't reference Lidarr's `DownloadItemStatus`), so each plugin maps the boolean to its own download-item status at its boundary. The logic is lifted **verbatim from qobuz's gate**, so qobuz can delegate with zero behavior change, and tidal's all-or-nothing rule is exactly the default-policy case.

## Tests (TDD)

- `tests/Services/Download/AlbumCompletionPolicyTests.cs` — RED via an intentionally-wrong stub (`return true`) that reproduced the original 29/30 bug (8 failed / 4 passed), GREEN after the gate (**12/12**). Covers the hard gate, threshold-can't-rescue-incomplete, empty-album `failOnNoTracksAvailable`, and tidal all-or-nothing equivalence.
- The parity guard asserts 29/30 ⇒ fail, 8/10 ⇒ fail, 10/10 ⇒ success — runs in every plugin's parity suite.

## Follow-ups (separate PRs)

Re-pin + delegate **qobuz** (`DownloadPolicy.IsAlbumDownloadSuccessful` → `AlbumCompletionPolicy`) and **tidal** (`TidalLidarrDownloadClient`) onto this policy, and wire the guard `[Fact]` into each plugin's parity suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
