### PR TITLE
refactor(download): SimpleDownloadOrchestrator delegates completeness to AlbumCompletionPolicy

### DIFF
--- a/src/Services/Download/SimpleDownloadOrchestrator.cs
+++ b/src/Services/Download/SimpleDownloadOrchestrator.cs
@@ -191,11 +191,18 @@ namespace Lidarr.Plugin.Common.Services.Download
             }
 
             var failures = result.TrackResults.Where(tr => !tr.Success).ToList();
-            if (failures.Count > 0)
+            // Delegate the completeness decision to Common's canonical AlbumCompletionPolicy:
+            // an album is successful ONLY when every track lands (successfulTracks == totalTracks).
+            // Incomplete => the host reports Failed so Lidarr can fall back to another source instead
+            // of importing a partial album that NoMissingOrUnmatchedTracksSpecification permanently
+            // rejects ("Has missing tracks"). Equivalent to the prior failures.Count > 0 gate.
+            var successfulTracks = result.TrackResults.Count - failures.Count;
+            if (!AlbumCompletionPolicy.IsAlbumDownloadSuccessful(result.TrackResults.Count, successfulTracks))
             {
                 result.Success = false;
-                var first = failures[0];
-                result.ErrorMessage = $"Failed to download {failures.Count}/{result.TrackResults.Count} tracks. First error: {first.ErrorMessage}";
+                result.ErrorMessage = failures.Count > 0
+                    ? $"Failed to download {failures.Count}/{result.TrackResults.Count} tracks. First error: {failures[0].ErrorMessage}"
+                    : $"Incomplete album: only {successfulTracks}/{result.TrackResults.Count} tracks downloaded.";
             }
             else if (files.Count == 0)
             {


### PR DESCRIPTION
## What

Common's `SimpleDownloadOrchestrator` now **delegates** its album-completeness decision to `AlbumCompletionPolicy` (added in #569), making that policy the single source of truth for **every** download path.

## Why

qobuz's `DownloadPolicy` already delegates to `AlbumCompletionPolicy` (qobuz #287). The orchestrator — used by **tidal**, **apple**, and the CLIs via `DownloadResult.Success` — computed completeness inline (`failures.Count > 0 ⇒ not successful`). Delegating it means one rule everywhere, and the `Check_EnforcesAlbumCompletionPolicy` parity guard now protects the behaviour the orchestrator-based plugins **actually use** (not just a symbolic presence check).

## Behaviour

Identical: `successfulTracks == totalTracks ⟺ failures.Count == 0`. The `files.Count == 0` and `files.Count != trackResults` safety checks are retained; the `failures[0]` access is now guarded against the (early-returned) zero-track edge. `SimpleDownloadOrchestratorTests`: **28/28 green**.

## Follow-up

Re-pin tidal (and qobuz #287) to this SHA and wire the guard `[Fact]` into tidal's parity suite — then tidal/apple provably flow through the one policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
