### PR TITLE
feat(parity): harden ecosystem Common-pin drift guard before 5th plugin

### DIFF
--- a/.github/workflows/ecosystem-pin-drift.yml
+++ b/.github/workflows/ecosystem-pin-drift.yml
@@ -4,15 +4,39 @@ name: Ecosystem Pin Drift
 # in Common reaches every plugin. Complements the per-plugin verify-common-pins.yml (within-plugin
 # gitlink<->sentinel consistency) with the cross-repo agreement layer.
 #
-# Scheduled (drift alarm) + on-demand. Reads each plugin's ext-common-sha.txt via the GitHub API.
-# Uses ECOSYSTEM_PAT if present (can read private applemusicarr); otherwise falls back to the default
-# token, under which private repos are reported "unreadable" and excluded rather than failing — matching
-# how ecosystem-notify.yml already handles the private repo.
+# Reads each plugin's ext-common-sha.txt via the GitHub API. Uses ECOSYSTEM_PAT if present (can read
+# the PRIVATE applemusicarr repo); otherwise falls back to the default token, under which private repos
+# are reported "unreadable" and EXCLUDED rather than failing — matching how ecosystem-notify.yml handles
+# the private repo. If the PAT is absent the job emits a loud WARNING + step-summary note so the gap is
+# never silent.
+#
+# ── Repo-admin setup (REQUIRED to enforce the private apple repo) ────────────────────────────────
+#   Add a repository secret named ECOSYSTEM_PAT: a fine-grained or classic PAT with READ access to
+#   RicherTunes/AppleMusicarr (contents:read). Without it, apple is skipped (advisory) and the warning
+#   below fires. (The same secret already drives ecosystem-notify.yml's downstream dispatch.)
+#
+# ── Triggers ──────────────────────────────────────────────────────────────────────────────────────
+#   * schedule (every 6h) — drift alarm even when nobody pushes; tightened from daily so a bad re-pin
+#     surfaces within hours, ahead of a 5th plugin (amazonmusicarr) joining the lockstep set.
+#   * workflow_dispatch — manual on-demand run.
+#   * repository_dispatch (event_type: ecosystem-repin) — responsive trigger: a plugin can ping Common
+#     IMMEDIATELY after it re-pins, so drift is caught at re-pin time rather than up to 6h later.
+#     PLUGIN-SIDE WIRING (out of scope for this repo; do this in each plugin's submodule-pin.yml after
+#     it commits a new ext-common-sha.txt to its default branch):
+#         - name: Notify Common ecosystem-pin-drift guard
+#           if: github.ref == 'refs/heads/main'
+#           env: { GH_TOKEN: ${{ secrets.ECOSYSTEM_PAT }} }   # needs a token that can dispatch to Common
+#           run: gh api repos/RicherTunes/Lidarr.Plugin.Common/dispatches -f event_type=ecosystem-repin
+#     NOTE — architectural limit: a plugin's own PR cannot observe sibling-repo pins, so true cross-repo
+#     agreement cannot be a plugin PR gate. This out-of-band guard (schedule + dispatch) is the agreement
+#     layer; the per-plugin verify-common-pins.yml remains the in-PR within-plugin layer.
 
 on:
   schedule:
-    - cron: '17 6 * * *'   # daily 06:17 UTC
+    - cron: '17 */6 * * *'   # every 6 hours at :17 past
   workflow_dispatch:
+  repository_dispatch:
+    types: [ecosystem-repin]
 
 permissions:
   contents: read
@@ -28,6 +52,24 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+
+      # NOTE: the `secrets` context is NOT available in step-level `if:` (only in env/with), so the
+      # "PAT configured?" check is done inside the run step by testing the mapped env var for emptiness
+      # — the same pattern ecosystem-notify.yml uses.
+      - name: Warn if ECOSYSTEM_PAT is not configured (private apple will be skipped)
+        env:
+          ECOSYSTEM_PAT: ${{ secrets.ECOSYSTEM_PAT }}
+        run: |
+          if [ -z "${ECOSYSTEM_PAT}" ]; then
+            echo "::warning::ECOSYSTEM_PAT secret is not configured — the private applemusicarr repo cannot be read and is EXCLUDED from the agreement check (advisory, not enforced). Add a repo-read PAT as the ECOSYSTEM_PAT secret to enforce apple."
+            {
+              echo "> [!WARNING]"
+              echo "> \`ECOSYSTEM_PAT\` secret is **not configured**. The private \`applemusicarr\` repo is excluded from the agreement check (advisory only)."
+              echo "> Add a repository secret \`ECOSYSTEM_PAT\` (a PAT with read access to \`RicherTunes/AppleMusicarr\`) to enforce apple."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "ECOSYSTEM_PAT is configured — private repos will be read and enforced."
+          fi
 
       - name: Check ecosystem Common-pin agreement
         shell: pwsh

--- a/scripts/check-ecosystem-pins.ps1
+++ b/scripts/check-ecosystem-pins.ps1
@@ -13,13 +13,21 @@
     per-plugin reusable `verify-common-pins.yml` is the WITHIN-PLUGIN layer (does a plugin's gitlink
     match its own ext-common-sha.txt?). They are complementary.
 
+    Architectural limit (why this is a scheduled/dispatch guard, not a PR gate): a plugin's OWN pull
+    request cannot observe sibling-repo state, so cross-repo agreement is fundamentally unenforceable
+    inside a single plugin's PR checks. This out-of-band guard in Common is the agreement layer.
+
     Graceful degradation: a repo the token can't read (e.g. private applemusicarr under the default
     GITHUB_TOKEN) is reported as "unreadable" and EXCLUDED from the agreement set rather than failing the
     run — matching how `ecosystem-notify.yml` already omits the private repo. Provide a PAT with repo-read
-    scope via $env:GH_TOKEN to include it.
+    scope via $env:GH_TOKEN (CI: the ECOSYSTEM_PAT secret) to include it. When the configured streaming
+    set names a known-private repo (applemusicarr) and it is unreadable, the warning calls out the PAT
+    explicitly so the gap is loud rather than silent.
 
-    Advisory repos (brainarr) are reported for visibility but never fail the run: brainarr is an
-    import-list plugin whose Common consolidation is intentionally deferred, so it is allowed to lag.
+    Advisory repos (brainarr): reported and, when on a DIFFERENT pin than the agreed streaming SHA,
+    emit a non-failing ::warning:: — but they never fail the run. brainarr is an import-list plugin
+    whose Common consolidation is intentionally deferred (product decision), so it is allowed to lag;
+    the warning keeps that lag visible ahead of a 5th plugin joining without breaking the deferral.
 
 .PARAMETER StreamingRepos
     owner/repo of the streaming plugins that MUST agree. Default: the three streaming plugins.
@@ -30,6 +38,10 @@
 .PARAMETER CommonRepo
     owner/repo of Common, used only to report how far each plugin lags behind Common's default branch.
 
+.PARAMETER KnownPrivateRepos
+    owner/repo of repos known to be private (so an "unreadable" result is attributed to a missing PAT
+    rather than a transient error). Default: applemusicarr.
+
 .EXAMPLE
     pwsh scripts/check-ecosystem-pins.ps1
 .EXAMPLE
@@ -37,12 +49,21 @@
 #>
 [CmdletBinding()]
 param(
-    [string[]] $StreamingRepos = @('RicherTunes/Qobuzarr', 'RicherTunes/Tidalarr', 'RicherTunes/AppleMusicarr'),
-    [string[]] $AdvisoryRepos  = @('RicherTunes/Brainarr'),
-    [string]   $CommonRepo     = 'RicherTunes/Lidarr.Plugin.Common'
+    [string[]] $StreamingRepos    = @('RicherTunes/Qobuzarr', 'RicherTunes/Tidalarr', 'RicherTunes/AppleMusicarr'),
+    [string[]] $AdvisoryRepos     = @('RicherTunes/Brainarr'),
+    [string]   $CommonRepo        = 'RicherTunes/Lidarr.Plugin.Common',
+    [string[]] $KnownPrivateRepos = @('RicherTunes/AppleMusicarr'),
+
+    # Define functions and return WITHOUT touching the network. Lets unit tests dot-source this file
+    # and exercise the pure decision function (Test-EcosystemPinAgreement) hermetically.
+    [switch]   $DefineFunctionsOnly
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Re-pin command a drifted plugin must run (in the plugin repo) to converge. Surfaced in the failure
+# message so the fix is copy-pasteable. See scripts/repin-common-submodule.ps1 in each plugin.
+$script:RepinCommand = 'pwsh scripts/repin-common-submodule.ps1 -ShaFromSubmoduleHead -Stage -SubmodulePath ext/Lidarr.Plugin.Common  (after `git -C ext/Lidarr.Plugin.Common fetch && git -C ext/Lidarr.Plugin.Common checkout <SHA>`)'
 
 function Get-PinnedCommonSha {
     <# Returns the trimmed ext-common-sha.txt of a repo's default branch, or $null if unreadable. #>
@@ -61,14 +82,26 @@ function Get-PinnedCommonSha {
 function Test-EcosystemPinAgreement {
     <#
       Pure decision function (no I/O) so it is unit-testable. Given a map of streaming repo -> sha
-      (sha may be $null when unreadable), returns @{ Drifted = <bool>; Pins = <distinct readable shas> }.
+      (sha may be $null when unreadable), returns @{ Drifted = <bool>; Pins = <distinct readable shas>;
+      Agreed = <the single agreed sha or $null> }.
       Drift = two or more DISTINCT readable shas among the streaming repos.
     #>
     param([hashtable] $StreamingPins)
     $readable = @($StreamingPins.Values | Where-Object { $_ })
     $distinct = @($readable | Select-Object -Unique)
-    return @{ Drifted = ($distinct.Count -gt 1); Pins = $distinct }
+    $agreed = if ($distinct.Count -eq 1) { $distinct[0] } else { $null }
+    return @{ Drifted = ($distinct.Count -gt 1); Pins = $distinct; Agreed = $agreed }
 }
+
+function Write-Summary {
+    <# Append a line to the GitHub Actions job summary when running in CI; no-op locally. #>
+    param([string] $Line)
+    if ($env:GITHUB_STEP_SUMMARY) {
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $Line
+    }
+}
+
+if ($DefineFunctionsOnly) { return }
 
 # --- Gather pins ---------------------------------------------------------------------------------
 $commonHead = $null
@@ -86,12 +119,12 @@ Write-Host ""
 Write-Host "  Streaming plugins (must agree):"
 foreach ($r in $StreamingRepos) {
     $sha = $streamingPins[$r]
-    $shown = if ($sha) { $sha.Substring(0, 12) } else { '<unreadable — token lacks read access>' }
+    $shown = if ($sha) { $sha.Substring(0, 12) } else { '<unreadable - token lacks read access>' }
     $lag = if ($sha -and $commonHead -and $sha -ne $commonHead) { ' (behind Common HEAD)' } else { '' }
     Write-Host ("    {0,-32} {1}{2}" -f $r, $shown, $lag)
 }
 Write-Host ""
-Write-Host "  Advisory plugins (reported, never fail — consolidation deferred):"
+Write-Host "  Advisory plugins (reported, never fail - consolidation deferred):"
 foreach ($r in $AdvisoryRepos) {
     $sha = $advisoryPins[$r]
     $shown = if ($sha) { $sha.Substring(0, 12) } else { '<unreadable>' }
@@ -99,20 +132,84 @@ foreach ($r in $AdvisoryRepos) {
 }
 Write-Host ""
 
-# --- Verdict -------------------------------------------------------------------------------------
+Write-Summary "## Ecosystem Common-pin drift"
+Write-Summary ""
+if ($commonHead) { Write-Summary "Common default-branch HEAD: ``$($commonHead.Substring(0,12))``" }
+Write-Summary ""
+Write-Summary "| Repo | Tier | Pinned Common SHA |"
+Write-Summary "| --- | --- | --- |"
+foreach ($r in $StreamingRepos) {
+    $sha = $streamingPins[$r]
+    $shown = if ($sha) { $sha.Substring(0, 12) } else { 'unreadable' }
+    Write-Summary "| ``$r`` | streaming (enforced) | ``$shown`` |"
+}
+foreach ($r in $AdvisoryRepos) {
+    $sha = $advisoryPins[$r]
+    $shown = if ($sha) { $sha.Substring(0, 12) } else { 'unreadable' }
+    Write-Summary "| ``$r`` | advisory | ``$shown`` |"
+}
+Write-Summary ""
+
+# --- Unreadable / PAT diagnostics ----------------------------------------------------------------
 $result = Test-EcosystemPinAgreement -StreamingPins $streamingPins
 $unreadable = @($StreamingRepos | Where-Object { -not $streamingPins[$_] })
 if ($unreadable.Count -gt 0) {
-    Write-Host "::warning::Could not read Common pin for: $($unreadable -join ', '). Excluded from the agreement check (provide a repo-read PAT via GH_TOKEN to include private repos)."
+    $unreadablePrivate = @($unreadable | Where-Object { $KnownPrivateRepos -contains $_ })
+    if ($unreadablePrivate.Count -gt 0) {
+        # A known-private repo (apple) is unreadable: almost always the ECOSYSTEM_PAT secret is missing.
+        $msg = "Private repo(s) unreadable and EXCLUDED from the agreement check: $($unreadablePrivate -join ', '). " +
+               "Configure a repo-read PAT as the ECOSYSTEM_PAT secret (CI) or `$env:GH_TOKEN (local) so these are ENFORCED, not silently skipped."
+        Write-Host "::warning::$msg"
+        Write-Summary "> [!WARNING]"
+        Write-Summary "> $msg"
+    }
+    $unreadableOther = @($unreadable | Where-Object { $KnownPrivateRepos -notcontains $_ })
+    if ($unreadableOther.Count -gt 0) {
+        Write-Host "::warning::Could not read Common pin for: $($unreadableOther -join ', '). Excluded from the agreement check (transient error or missing read access)."
+    }
 }
 
+# --- Advisory drift (brainarr): warn-but-never-fail when it lags the agreed streaming SHA ---------
+if ($result.Agreed) {
+    foreach ($r in $AdvisoryRepos) {
+        $sha = $advisoryPins[$r]
+        if ($sha -and $sha -ne $result.Agreed) {
+            $msg = "Advisory plugin $r pins Common $($sha.Substring(0,12)) but the streaming set agrees on $($result.Agreed.Substring(0,12)). " +
+                   "Allowed (consolidation deferred) but flagged for visibility."
+            Write-Host "::warning::$msg"
+            Write-Summary "> [!NOTE]"
+            Write-Summary "> $msg"
+        }
+    }
+}
+
+# --- Verdict -------------------------------------------------------------------------------------
 if ($result.Drifted) {
-    $detail = ($StreamingRepos | Where-Object { $streamingPins[$_] } | ForEach-Object { "$_=$($streamingPins[$_].Substring(0,12))" }) -join '; '
+    # Name the drifted repos, the expected SHA (the most common pin among the streaming set), and the
+    # exact re-pin command — make the failure actionable, not just an alarm.
+    $pairs = @($StreamingRepos | Where-Object { $streamingPins[$_] } | ForEach-Object { [pscustomobject]@{ Repo = $_; Sha = $streamingPins[$_] } })
+    $expected = ($pairs | Group-Object Sha | Sort-Object Count -Descending | Select-Object -First 1).Name
+    $detail = ($pairs | ForEach-Object { "$($_.Repo)=$($_.Sha.Substring(0,12))" }) -join '; '
+    $drifted = @($pairs | Where-Object { $_.Sha -ne $expected } | ForEach-Object { $_.Repo })
+
     Write-Host "::error::Streaming plugins pin DIFFERENT Common SHAs (drift): $detail"
+    Write-Host "::error::Expected (majority) Common SHA: $expected"
+    Write-Host "::error::Drifted repo(s) to re-pin: $($drifted -join ', ')"
+    Write-Host "::error::Re-pin each drifted plugin to $expected, e.g.: $($script:RepinCommand)"
     Write-Host "::error::A shared-behavior fix in Common will not reach all plugins until they re-pin to one SHA."
+
+    Write-Summary "> [!CAUTION]"
+    Write-Summary "> **Ecosystem pin DRIFT detected.** Streaming plugins disagree on the Common pin."
+    Write-Summary ">"
+    Write-Summary "> - Pins: $detail"
+    Write-Summary "> - Expected (majority) SHA: ``$expected``"
+    Write-Summary "> - Drifted repo(s): $($drifted -join ', ')"
+    Write-Summary "> - Re-pin each drifted plugin to ``$expected`` via: ``$($script:RepinCommand)``"
     exit 1
 }
 
-$agreed = if ($result.Pins.Count -eq 1) { $result.Pins[0].Substring(0, 12) } else { '(none readable)' }
+$agreed = if ($result.Agreed) { $result.Agreed.Substring(0, 12) } else { '(none readable)' }
 Write-Host "OK: all readable streaming plugins agree on Common pin $agreed."
+Write-Summary ""
+Write-Summary "**Result:** all readable streaming plugins agree on Common pin ``$agreed``."
 exit 0

--- a/scripts/tests/Test-EcosystemPins.ps1
+++ b/scripts/tests/Test-EcosystemPins.ps1
@@ -1,0 +1,123 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Self-tests for check-ecosystem-pins.ps1 — the cross-repo Common-pin drift guard.
+
+.DESCRIPTION
+    Exercises the pure decision function Test-EcosystemPinAgreement hermetically (no network).
+    The guard dot-sources cleanly via -DefineFunctionsOnly, so these tests pin the agreement
+    semantics that gate the consolidation program:
+
+      - all readable streaming plugins on one SHA  => CONVERGED (Drifted=$false, Agreed=<sha>)
+      - two or more DISTINCT readable SHAs          => DRIFT     (Drifted=$true)
+      - unreadable repos ($null) are EXCLUDED, never counted as a distinct pin
+      - a single readable pin amid unreadables      => CONVERGED on that pin
+      - no readable pins                            => not drift, Agreed=$null
+#>
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$ScriptDir = $PSScriptRoot
+$RepoRoot  = Split-Path -Parent (Split-Path -Parent $ScriptDir)
+$Guard     = Join-Path $RepoRoot "scripts/check-ecosystem-pins.ps1"
+
+# Dot-source: define functions only (no network).
+. $Guard -DefineFunctionsOnly
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Ecosystem Pin Guard Self-Tests" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+$passed = 0
+$failed = 0
+
+function Test-Assertion {
+    param(
+        [string]$Name,
+        [scriptblock]$Test
+    )
+    Write-Host "  Testing: $Name..." -NoNewline
+    try {
+        $result = & $Test
+        if ($result) {
+            Write-Host " PASS" -ForegroundColor Green
+            $script:passed++
+        } else {
+            Write-Host " FAIL" -ForegroundColor Red
+            $script:failed++
+        }
+    }
+    catch {
+        Write-Host " ERROR: $_" -ForegroundColor Red
+        $script:failed++
+    }
+}
+
+$shaA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+$shaB = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+Write-Host "Function availability:" -ForegroundColor White
+
+Test-Assertion "Test-EcosystemPinAgreement is defined after dot-source" {
+    (Get-Command Test-EcosystemPinAgreement -ErrorAction SilentlyContinue) -ne $null
+}
+
+Write-Host ""
+Write-Host "Agreement semantics:" -ForegroundColor White
+
+Test-Assertion "all three on same SHA => not drifted, Agreed=that sha" {
+    $r = Test-EcosystemPinAgreement -StreamingPins @{ q = $shaA; t = $shaA; a = $shaA }
+    (-not $r.Drifted) -and ($r.Agreed -eq $shaA) -and ($r.Pins.Count -eq 1)
+}
+
+Test-Assertion "two distinct readable SHAs => drifted, Agreed is null" {
+    $r = Test-EcosystemPinAgreement -StreamingPins @{ q = $shaA; t = $shaA; a = $shaB }
+    $r.Drifted -and ($r.Pins.Count -eq 2) -and ($null -eq $r.Agreed)
+}
+
+Test-Assertion "unreadable pin is excluded, not a distinct value => readable pair agrees" {
+    $r = Test-EcosystemPinAgreement -StreamingPins @{ q = $shaA; t = $shaA; a = $null }
+    (-not $r.Drifted) -and ($r.Agreed -eq $shaA)
+}
+
+Test-Assertion "single readable pin amid unreadables => converged on it" {
+    $r = Test-EcosystemPinAgreement -StreamingPins @{ q = $shaA; t = $null; a = $null }
+    (-not $r.Drifted) -and ($r.Agreed -eq $shaA) -and ($r.Pins.Count -eq 1)
+}
+
+Test-Assertion "no readable pins => not drift, Agreed is null, zero pins" {
+    $r = Test-EcosystemPinAgreement -StreamingPins @{ q = $null; t = $null; a = $null }
+    (-not $r.Drifted) -and ($null -eq $r.Agreed) -and ($r.Pins.Count -eq 0)
+}
+
+Test-Assertion "one readable plus one unreadable => never drift (null excluded)" {
+    # A single readable repo can never 'drift' against an unreadable one (null is excluded).
+    $r = Test-EcosystemPinAgreement -StreamingPins @{ q = $shaB; t = $null }
+    (-not $r.Drifted) -and ($r.Agreed -eq $shaB)
+}
+
+Write-Host ""
+Write-Host "End-to-end (live guard, real repos) — converged exit code:" -ForegroundColor White
+
+Test-Assertion "guard exits 0 against live repos when ecosystem is converged" {
+    # Best-effort live check: only assert exit 0 (converged). If the network/gh is unavailable the
+    # guard still exits 0 (all-unreadable is not drift), so this never produces a false failure.
+    & pwsh -NoProfile -File $Guard *> $null
+    $LASTEXITCODE -eq 0
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Results: $passed passed, $failed failed" -ForegroundColor $(if ($failed -eq 0) { 'Green' } else { 'Red' })
+Write-Host "========================================" -ForegroundColor Cyan
+
+if ($failed -gt 0) {
+    exit 1
+}
+
+Write-Host ""
+Write-Host "[OK] All ecosystem pin guard tests passed." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
Hardens the cross-plugin Common-pin drift guard from #564 (merged) so ecosystem-pin drift is harder to miss before **amazonmusicarr** joins the lockstep set. The 4 plugins are currently re-aligned to Common main `10245bc` — the guard reports **CONVERGED**.

## What changed

### `.github/workflows/ecosystem-pin-drift.yml`
- **Trigger** daily → **every 6h** (`17 */6 * * *`) so a bad re-pin surfaces within hours, plus a new **`repository_dispatch` (type `ecosystem-repin`)** responsive trigger. Plugin-side wiring (in each plugin's `submodule-pin.yml`) is documented in-file. A true cross-repo *PR* gate is architecturally infeasible (a plugin's own PR can't observe sibling-repo pins) — documented; this out-of-band guard is the agreement layer, complementing the in-PR `verify-common-pins.yml`.
- **ECOSYSTEM_PAT wiring + WARN.** Keeps the `secrets.ECOSYSTEM_PAT || github.token` fallback and adds a step that **warns (log + step summary) when `ECOSYSTEM_PAT` is unset**, so the private `applemusicarr` repo being excluded is loud, not silent. (The PAT check runs via a mapped env var, not a step `if:` — the `secrets` context isn't allowed there; verified with `actionlint`.) Repo-admin setup documented in a comment.

### `scripts/check-ecosystem-pins.ps1`
- **Actionable failure:** names the drifted repos + the expected (majority) SHA + the exact re-pin command (`repin-common-submodule.ps1`).
- **Step summary:** pin table + caution/warning/note blocks.
- **PAT-specific warning** when a known-private repo (apple) is unreadable.
- **brainarr stays ADVISORY** (consolidation intentionally deferred — product decision) but now emits a **non-failing warning when it lags the agreed streaming SHA**. Rationale: hard-enforcing would contradict the documented deferral; pure-silent lets a regression slip — advisory+warn is the proportionate middle ground.
- Adds `-DefineFunctionsOnly` so the pure decision function is dot-sourceable/unit-testable.

### `scripts/tests/Test-EcosystemPins.ps1` (new)
- Auto-discovered by `pr-validation.yml`. Unit-tests the agreement semantics hermetically (converge / drift / unreadable-excluded / single-readable / none) + a best-effort live converged-exit-0 check.

## Verification
- `pwsh scripts/check-ecosystem-pins.ps1` → **CONVERGED**, exit 0 (Qobuzarr/Tidalarr/AppleMusicarr + Brainarr all on `10245bc9e74a`).
- Drift / advisory-lag / PAT-unreadable message paths exercised via a `gh`-shadow harness (drift → exit 1 with actionable message + summary; advisory-lag → warn + exit 0; PAT-unreadable → PAT-specific warn + exit 0).
- `actionlint` clean; `powershell-yaml` parses the workflow.
- New self-tests: **8/8 pass**.

Decisions (per task): trigger = 6h cron + `repository_dispatch` (plugin-side wiring documented, not done here — out of scope); brainarr = advisory-but-warns; cross-repo PR gate = noted as infeasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)