### PR TITLE
feat(drm): lift external DRM download seam into Common (interface + DrmTrack + loader)

### DIFF
--- a/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -32,3 +32,35 @@ Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.Dispose() -> void
 Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
 Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource, Lidarr.Plugin.Common.Services.Lyrics.LrclibClient! lrclibClient, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
 Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.TryEnrichAsync(string! audioFilePath, string! artistName, string! trackName, string! albumName, int durationSeconds, bool allowLrclibFallback, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task!
+Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler
+Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler.DownloadAsync(Lidarr.Plugin.Common.Services.Drm.DrmTrack! track, string! outputPath, System.IProgress<Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress!>? progress = null, System.Threading.CancellationToken ct = default) -> System.Threading.Tasks.Task<bool>!
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.ExternalDownloadProgress(double? Percent, string? Message) -> void
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Percent.get -> double?
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Percent.init -> void
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Message.get -> string?
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Message.init -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.DrmTrack() -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Id.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Id.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Title.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Title.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Artists.get -> System.Collections.Generic.List<string!>!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Artists.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ManifestUrl.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ManifestUrl.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Pssh.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Pssh.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.KeyId.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.KeyId.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.BitrateKbps.get -> int
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.BitrateKbps.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.SourceUrl.get -> string?
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.SourceUrl.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ServiceHints.get -> System.Collections.Generic.Dictionary<string!, string!>!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ServiceHints.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.IsDrmProtected.get -> bool
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Clone() -> object!
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader
+static Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader.TryLoad(string? assemblyPath = null, string? typeName = null, Microsoft.Extensions.Logging.ILogger? logger = null, string? assemblyPathEnvVar = null, string? typeNameEnvVar = null) -> Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler?

--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -61,3 +61,35 @@ Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.Dispose() -> void
 Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
 Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.LyricsEnricher(Lidarr.Plugin.Common.Services.Lyrics.INativeLyricsSource? nativeSource, Lidarr.Plugin.Common.Services.Lyrics.LrclibClient! lrclibClient, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
 Lidarr.Plugin.Common.Services.Lyrics.LyricsEnricher.TryEnrichAsync(string! audioFilePath, string! artistName, string! trackName, string! albumName, int durationSeconds, bool allowLrclibFallback, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task!
+Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler
+Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler.DownloadAsync(Lidarr.Plugin.Common.Services.Drm.DrmTrack! track, string! outputPath, System.IProgress<Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress!>? progress = null, System.Threading.CancellationToken ct = default) -> System.Threading.Tasks.Task<bool>!
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.ExternalDownloadProgress(double? Percent, string? Message) -> void
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Percent.get -> double?
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Percent.init -> void
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Message.get -> string?
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadProgress.Message.init -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.DrmTrack() -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Id.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Id.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Title.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Title.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Artists.get -> System.Collections.Generic.List<string!>!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Artists.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ManifestUrl.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ManifestUrl.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Pssh.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Pssh.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.KeyId.get -> string!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.KeyId.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.BitrateKbps.get -> int
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.BitrateKbps.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.SourceUrl.get -> string?
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.SourceUrl.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ServiceHints.get -> System.Collections.Generic.Dictionary<string!, string!>!
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.ServiceHints.set -> void
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.IsDrmProtected.get -> bool
+Lidarr.Plugin.Common.Services.Drm.DrmTrack.Clone() -> object!
+Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader
+static Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader.TryLoad(string? assemblyPath = null, string? typeName = null, Microsoft.Extensions.Logging.ILogger? logger = null, string? assemblyPathEnvVar = null, string? typeNameEnvVar = null) -> Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler?

--- a/src/Services/Drm/DrmTrack.cs
+++ b/src/Services/Drm/DrmTrack.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace Lidarr.Plugin.Common.Services.Drm
+{
+    /// <summary>
+    /// Minimal, <b>service-neutral</b> DRM/playback metadata for a single track, passed across
+    /// the <see cref="IExternalDownloadHandler"/> seam to an out-of-tree downloader/decryptor.
+    ///
+    /// <para>
+    /// This is the shared, neutralized promotion of each DRM plugin's local track model. It carries
+    /// only the data a generic fetch/decrypt/mux step needs and contains <b>no decrypt logic, no key
+    /// material derivation, and no service-specific behavior</b> — see <see cref="IExternalDownloadHandler"/>
+    /// for the DRM-out-of-Common stance. Service-specific identifiers (e.g. Amazon's ASIN, a license
+    /// endpoint, an Apple Adam ID) belong in <see cref="ServiceHints"/> so this model stays neutral
+    /// for both HLS and DASH sources and across services.
+    /// </para>
+    /// </summary>
+    public sealed class DrmTrack : ICloneable
+    {
+        /// <summary>Service-specific track identifier (opaque to Common).</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Track title.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>Track artists.</summary>
+        public List<string> Artists { get; set; } = new();
+
+        /// <summary>
+        /// URL of the streaming manifest. Neutral across protocols: an HLS <c>.m3u8</c> playlist
+        /// (Apple Music) or a DASH <c>.mpd</c> manifest (Amazon Music). Renamed from the
+        /// Apple-specific <c>M3U8Url</c> during promotion to Common.
+        /// </summary>
+        public string ManifestUrl { get; set; } = string.Empty;
+
+        /// <summary>Base64 PSSH box carrying DRM init data. Empty when the track is not DRM-protected.</summary>
+        public string Pssh { get; set; } = string.Empty;
+
+        /// <summary>DRM key identifier (KID), when known.</summary>
+        public string KeyId { get; set; } = string.Empty;
+
+        /// <summary>Target/selected bitrate in kbps, when known.</summary>
+        public int BitrateKbps { get; set; }
+
+        /// <summary>Optional originating URL hint for handlers (album/playlist/song page).</summary>
+        public string? SourceUrl { get; set; }
+
+        /// <summary>
+        /// Free-form, service-specific hints for the out-of-tree handler (e.g. Amazon ASIN,
+        /// license-acquisition endpoint, marketplace/region). Keeps <see cref="DrmTrack"/> neutral
+        /// while letting each plugin pass what its decryptor needs. Never interpreted by Common.
+        /// </summary>
+        public Dictionary<string, string> ServiceHints { get; set; } = new();
+
+        /// <summary>
+        /// True when DRM init data (<see cref="Pssh"/>) is present, indicating the track needs a
+        /// license challenge / decrypt step. This is the only "logic" in the model — a presence
+        /// check, not any form of key handling.
+        /// </summary>
+        public bool IsDrmProtected => !string.IsNullOrWhiteSpace(Pssh);
+
+        /// <summary>
+        /// Returns a deep copy (the <see cref="Artists"/> list and <see cref="ServiceHints"/>
+        /// dictionary are cloned, not shared) so a handler can mutate its copy safely.
+        /// </summary>
+        public object Clone()
+        {
+            return new DrmTrack
+            {
+                Id = Id,
+                Title = Title,
+                Artists = new List<string>(Artists),
+                ManifestUrl = ManifestUrl,
+                Pssh = Pssh,
+                KeyId = KeyId,
+                BitrateKbps = BitrateKbps,
+                SourceUrl = SourceUrl,
+                ServiceHints = new Dictionary<string, string>(ServiceHints)
+            };
+        }
+    }
+}

--- a/src/Services/Drm/ExternalDownloadHandlerLoader.cs
+++ b/src/Services/Drm/ExternalDownloadHandlerLoader.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace Lidarr.Plugin.Common.Services.Drm
+{
+    /// <summary>
+    /// Reflection loader that resolves an <b>out-of-tree</b> <see cref="IExternalDownloadHandler"/>
+    /// at runtime via <see cref="Assembly.LoadFrom(string)"/>, configured by explicit arguments or
+    /// environment variables.
+    ///
+    /// <para>
+    /// <b>Common ships NO handler implementation — not even a mock.</b> No key derivation, no CDM,
+    /// no license-challenge and no decrypt logic live in this library (see
+    /// <see cref="IExternalDownloadHandler"/>). The concrete decryptor is supplied out-of-tree by
+    /// the user; this loader merely locates and casts it. <see cref="TryLoad(string, string, ILogger, string, string)"/>
+    /// returns <c>null</c> whenever no handler is configured (the default), so a plugin with no
+    /// external downloader simply runs without one.
+    /// </para>
+    /// </summary>
+    public static class ExternalDownloadHandlerLoader
+    {
+        /// <summary>
+        /// Attempts to load and instantiate an <see cref="IExternalDownloadHandler"/> from an
+        /// assembly on disk.
+        ///
+        /// <para>
+        /// Resolution order for each input: the explicit argument if non-empty, otherwise the
+        /// corresponding environment variable. When the resulting assembly path or type name is
+        /// missing, the method returns <c>null</c> (no handler configured). It also returns
+        /// <c>null</c> — and logs — when the assembly/type cannot be loaded, when instantiation
+        /// fails, or when the resolved type does not implement <see cref="IExternalDownloadHandler"/>.
+        /// The method never throws.
+        /// </para>
+        /// </summary>
+        /// <param name="assemblyPath">
+        /// Path to the assembly containing the handler. When null/empty, falls back to the
+        /// <paramref name="assemblyPathEnvVar"/> environment variable.
+        /// </param>
+        /// <param name="typeName">
+        /// Fully-qualified type name of the handler. When null/empty, falls back to the
+        /// <paramref name="typeNameEnvVar"/> environment variable.
+        /// </param>
+        /// <param name="logger">Optional logger for diagnostics. No logging occurs when null.</param>
+        /// <param name="assemblyPathEnvVar">
+        /// Environment variable consulted when <paramref name="assemblyPath"/> is null/empty.
+        /// Plugins pass their own (e.g. <c>AMAZONMUSICARR_EXTERNAL_DOWNLOADER_PATH</c>).
+        /// </param>
+        /// <param name="typeNameEnvVar">
+        /// Environment variable consulted when <paramref name="typeName"/> is null/empty
+        /// (e.g. <c>AMAZONMUSICARR_EXTERNAL_DOWNLOADER_TYPE</c>).
+        /// </param>
+        /// <returns>The loaded handler, or <c>null</c> when none is configured or loading fails.</returns>
+        public static IExternalDownloadHandler? TryLoad(
+            string? assemblyPath = null,
+            string? typeName = null,
+            ILogger? logger = null,
+            string? assemblyPathEnvVar = null,
+            string? typeNameEnvVar = null)
+        {
+            try
+            {
+                var resolvedPath = FirstNonEmpty(assemblyPath, ReadEnv(assemblyPathEnvVar));
+                var resolvedType = FirstNonEmpty(typeName, ReadEnv(typeNameEnvVar));
+
+                // No handler configured: this is the normal default, not an error.
+                if (string.IsNullOrWhiteSpace(resolvedPath) || string.IsNullOrWhiteSpace(resolvedType))
+                {
+                    return null;
+                }
+
+                var fullPath = Path.GetFullPath(resolvedPath!);
+                var assembly = Assembly.LoadFrom(fullPath);
+                var type = assembly.GetType(resolvedType!, throwOnError: true, ignoreCase: false);
+
+                var instance = Activator.CreateInstance(type!);
+                if (instance is IExternalDownloadHandler handler)
+                {
+                    return handler;
+                }
+
+                logger?.LogWarning(
+                    "Type {TypeName} from {AssemblyPath} does not implement IExternalDownloadHandler.",
+                    resolvedType,
+                    fullPath);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Failed to load external download handler.");
+                return null;
+            }
+        }
+
+        private static string? ReadEnv(string? name)
+            => string.IsNullOrWhiteSpace(name) ? null : Environment.GetEnvironmentVariable(name!);
+
+        private static string? FirstNonEmpty(string? a, string? b)
+            => !string.IsNullOrWhiteSpace(a) ? a : (!string.IsNullOrWhiteSpace(b) ? b : null);
+    }
+}

--- a/src/Services/Drm/IExternalDownloadHandler.cs
+++ b/src/Services/Drm/IExternalDownloadHandler.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lidarr.Plugin.Common.Services.Drm
+{
+    /// <summary>
+    /// Extension seam for integrating an <b>out-of-tree</b> downloader/DRM implementation
+    /// shared across plugins that pull from DRM-protected streaming services
+    /// (e.g. Apple Music, Amazon Music).
+    ///
+    /// <para>
+    /// <b>DRM-out-of-Common stance:</b> Lidarr.Plugin.Common is public and shippable.
+    /// It deliberately ships <b>only this seam</b> — the interface, the <see cref="DrmTrack"/>
+    /// value model, the <see cref="ExternalDownloadProgress"/> record, and the reflection
+    /// <see cref="ExternalDownloadHandlerLoader"/>. Common ships <b>NO handler implementation
+    /// (not even a mock)</b>: no key derivation, no CDM, no license-challenge, and no
+    /// decrypt/mux logic ever enters this library. The concrete decryptor is supplied
+    /// out-of-tree by the user and loaded at runtime (see <see cref="ExternalDownloadHandlerLoader"/>).
+    /// Implementations are solely responsible for any legal compliance.
+    /// </para>
+    ///
+    /// <para>
+    /// The seam is intentionally narrow: given a <see cref="DrmTrack"/> and an output file
+    /// path, perform the end-to-end fetch/decrypt/mux and return <c>true</c> on success.
+    /// </para>
+    /// </summary>
+    public interface IExternalDownloadHandler
+    {
+        /// <summary>
+        /// Fetches, decrypts and muxes <paramref name="track"/> to <paramref name="outputPath"/>.
+        /// Returns <c>true</c> on success. The implementation lives out-of-tree (see the type
+        /// remarks); Common never provides one.
+        /// </summary>
+        /// <param name="track">DRM/playback metadata for the track to download.</param>
+        /// <param name="outputPath">Absolute destination file path for the finished, decrypted file.</param>
+        /// <param name="progress">Optional progress sink reporting percent/message updates.</param>
+        /// <param name="ct">Cancellation token.</param>
+        Task<bool> DownloadAsync(DrmTrack track, string outputPath, IProgress<ExternalDownloadProgress>? progress = null, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// Progress update emitted by an <see cref="IExternalDownloadHandler"/> during a download.
+    /// Both fields are optional so handlers can report a percentage, a status message, or both.
+    /// </summary>
+    /// <param name="Percent">Completion fraction in the range 0..100, or <c>null</c> when unknown.</param>
+    /// <param name="Message">Human-readable status message, or <c>null</c>.</param>
+    public sealed record ExternalDownloadProgress(double? Percent, string? Message);
+}

--- a/tests/Drm/DrmDownloadSeamTests.cs
+++ b/tests/Drm/DrmDownloadSeamTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using Lidarr.Plugin.Common.Services.Drm;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// Covers the DRM download seam lifted into Common: <see cref="DrmTrack.IsDrmProtected"/>
+    /// (a pure presence check on the PSSH init data — the only "logic" in the value model) and
+    /// <see cref="ExternalDownloadHandlerLoader.TryLoad"/>'s default null-when-unconfigured path.
+    /// Common ships no handler implementation (not even a mock), so an unconfigured loader must
+    /// return <c>null</c> rather than throw.
+    /// </summary>
+    public sealed class DrmDownloadSeamTests
+    {
+        [Fact]
+        public void IsDrmProtected_True_WhenPsshPresent()
+        {
+            var track = new DrmTrack { Pssh = "AAAAW3Bzc2gAAAAA..." };
+
+            Assert.True(track.IsDrmProtected);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void IsDrmProtected_False_WhenPsshMissingOrWhitespace(string pssh)
+        {
+            var track = new DrmTrack { Pssh = pssh };
+
+            Assert.False(track.IsDrmProtected);
+        }
+
+        [Fact]
+        public void IsDrmProtected_False_ByDefault()
+        {
+            Assert.False(new DrmTrack().IsDrmProtected);
+        }
+
+        [Fact]
+        public void Clone_IsDeep_CollectionsNotShared()
+        {
+            var original = new DrmTrack
+            {
+                Id = "id-1",
+                Title = "Song",
+                ManifestUrl = "https://example/manifest.mpd",
+                Artists = new List<string> { "A" },
+                ServiceHints = new Dictionary<string, string> { ["asin"] = "B000" }
+            };
+
+            var clone = (DrmTrack)original.Clone();
+            clone.Artists.Add("B");
+            clone.ServiceHints["region"] = "US";
+
+            Assert.Equal("https://example/manifest.mpd", clone.ManifestUrl);
+            Assert.Single(original.Artists);
+            Assert.Single(original.ServiceHints);
+        }
+
+        [Fact]
+        public void TryLoad_ReturnsNull_WhenNothingConfigured()
+        {
+            // No explicit args and no env-var names supplied: the normal default.
+            var handler = ExternalDownloadHandlerLoader.TryLoad();
+
+            Assert.Null(handler);
+        }
+
+        [Fact]
+        public void TryLoad_ReturnsNull_WhenConfiguredEnvVarsAreUnset()
+        {
+            // Env-var names are provided but the variables themselves are not set in the
+            // environment, so resolution yields nothing -> null (no handler).
+            var handler = ExternalDownloadHandlerLoader.TryLoad(
+                assemblyPathEnvVar: "BRAINARR_TEST_DRM_DL_PATH_UNSET",
+                typeNameEnvVar: "BRAINARR_TEST_DRM_DL_TYPE_UNSET");
+
+            Assert.Null(handler);
+        }
+    }
+}


### PR DESCRIPTION
## What

Lifts the **DRM-download extension seam** (only the seam — never a decryptor) into `Lidarr.Plugin.Common` under a new namespace `Lidarr.Plugin.Common.Services.Drm`, so DRM-protected plugins (applemusicarr today, the new amazonmusicarr next) share **one** set of types instead of maintaining divergent local copies.

**Purely additive** — new files only; nothing existing changes (verified: 0 warnings/errors, PublicApiAnalyzer clean).

## DRM-out-of-Common stance (Common is public/shippable)

Common ships **only the seam**: the interface, the value model, the progress record, and a reflection loader. It ships **NO handler implementation — not even a mock**. No key derivation, no CDM, no license-challenge, no decrypt/mux logic enters this library. The concrete decryptor is supplied **out-of-tree** by the user and loaded at runtime. Each type documents this in XML docs.

## New types (`src/Services/Drm/`)

| Type | Notes |
|------|-------|
| `IExternalDownloadHandler` | `Task<bool> DownloadAsync(DrmTrack track, string outputPath, IProgress<ExternalDownloadProgress>? progress = null, CancellationToken ct = default)` |
| `ExternalDownloadProgress` | `record (double? Percent, string? Message)` |
| `DrmTrack` | promoted + **neutralized** from applemusicarr's local model (see below) |
| `ExternalDownloadHandlerLoader` | `TryLoad(...)` reflection loader; returns `null` when unconfigured; never throws |

### `DrmTrack` neutralization (vs applemusicarr's `Downloader/Models/DrmTrack.cs`)

- **`M3U8Url` → `ManifestUrl`** — neutral for HLS `.m3u8` (Apple) **or** DASH `.mpd` (Amazon).
- **Added `ServiceHints`** (`Dictionary<string,string>`) — per-service identifiers (Amazon ASIN, license endpoint, region) live here so the shape stays neutral.
- Dropped Apple-specific `AlbumInfo` / `IsAtmosEnabled`.
- Kept `Id`, `Title`, `Artists`, `Pssh`, `KeyId`, `BitrateKbps`, `SourceUrl?`.
- `IsDrmProtected => !string.IsNullOrWhiteSpace(Pssh)`.
- `Clone()` deep-copies `Artists` + `ServiceHints`.

### `ExternalDownloadHandlerLoader`

Mirrors applemusicarr's out-of-tree loader (`Runtime/AppleMusicPluginRuntime.cs:388-421`): `Assembly.LoadFrom` + `IExternalDownloadHandler` cast, configurable by explicit args **or** per-plugin env vars (caller passes its own var names, e.g. `AMAZONMUSICARR_EXTERNAL_DOWNLOADER_PATH/_TYPE`). Returns `null` whenever no handler is configured (the default) and on any load/instantiate/cast failure (logged). **No mock branch** — unlike apple's local copy, Common does not ship one.

## Not in this PR (by design)

- applemusicarr is **not** migrated — its local copy keeps working; consolidation onto these types is a separate later task.
- No decrypt/CDM/license code.

## Tests

`tests/Drm/DrmDownloadSeamTests.cs` (7 tests, all green): `IsDrmProtected` true/false/whitespace/default, deep-`Clone` independence, and `TryLoad` null-when-unconfigured (no args; unset env-var names).

## PublicAPI

New public symbols added to `src/PublicAPI/net8.0/PublicAPI.Unshipped.txt` (build-active) and `src/PublicAPI/net6.0/PublicAPI.Unshipped.txt` (parity). PublicApiAnalyzer (forced run) reports **0 RS0016/RS0017** for the new surface (only a pre-existing unrelated RS0025 dup on `CircuitBreaker` in Shipped).

## Verification

- `dotnet build src/Lidarr.Plugin.Common.csproj` → Build succeeded, 0 warnings, 0 errors.
- PublicApiAnalyzer forced on → 0 errors for new types.
- `dotnet test --filter DrmDownloadSeamTests` → 7 passed.

## Open-PR conflict check

Checked all 7 open PRs (#540, #542, #546, #550, #554, #567, #568) via `gh pr list --json files`. None touch `src/Services/Drm/**`, `tests/Drm/**`, or the PublicAPI baselines — all-new files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)