### PR TITLE
feat(http): add request-level signing seam (IHttpRequestSigner) for ADP-style RSA signing

### DIFF
--- a/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -64,3 +64,7 @@ Lidarr.Plugin.Common.Services.Drm.DrmTrack.IsDrmProtected.get -> bool
 Lidarr.Plugin.Common.Services.Drm.DrmTrack.Clone() -> object!
 Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader
 static Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader.TryLoad(string? assemblyPath = null, string? typeName = null, Microsoft.Extensions.Logging.ILogger? logger = null, string? assemblyPathEnvVar = null, string? typeNameEnvVar = null) -> Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler?
+Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner
+Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.RequiresSigning(string! endpoint) -> bool
+Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.Sign(System.Net.Http.HttpRequestMessage! request) -> void
+Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder.WithSigner(Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner! signer) -> Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder!

--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -93,3 +93,7 @@ Lidarr.Plugin.Common.Services.Drm.DrmTrack.IsDrmProtected.get -> bool
 Lidarr.Plugin.Common.Services.Drm.DrmTrack.Clone() -> object!
 Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader
 static Lidarr.Plugin.Common.Services.Drm.ExternalDownloadHandlerLoader.TryLoad(string? assemblyPath = null, string? typeName = null, Microsoft.Extensions.Logging.ILogger? logger = null, string? assemblyPathEnvVar = null, string? typeNameEnvVar = null) -> Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler?
+Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner
+Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.RequiresSigning(string! endpoint) -> bool
+Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.Sign(System.Net.Http.HttpRequestMessage! request) -> void
+Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder.WithSigner(Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner! signer) -> Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder!

--- a/src/Services/Http/IHttpRequestSigner.cs
+++ b/src/Services/Http/IHttpRequestSigner.cs
@@ -1,0 +1,55 @@
+using System.Net.Http;
+
+namespace Lidarr.Plugin.Common.Services.Http
+{
+    /// <summary>
+    /// Request-level signing seam for streaming APIs whose authentication is computed over the
+    /// <b>fully-built</b> HTTP request (method + URL + headers + body) rather than over a flat
+    /// query-parameter map.
+    ///
+    /// <para>
+    /// This is intentionally distinct from <see cref="IRequestSigner"/>. That interface signs by
+    /// mutating a <c>parameters</c> dictionary before the URL is assembled (the Qobuz/MD5
+    /// <c>Sign(endpoint, parameters, appId, appSecret)</c> shape) and cannot express schemes such as
+    /// Amazon's ADP RSA-SHA256, where the signature canonicalizes the final request line, a curated
+    /// set of headers, and the request body, then emits its own canonical/signature headers. Both
+    /// seams are additive and optional; plugins pick whichever matches their service. Common does not
+    /// migrate existing <see cref="IRequestSigner"/> users onto this seam.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Crypto-out-of-Common stance:</b> Lidarr.Plugin.Common defines this seam and invokes it as the
+    /// last mutation of a built request; it ships <b>no signing implementation</b>. All signing
+    /// <i>math</i> — canonicalization (which request components are covered and in what order), key
+    /// handling (RSA/HMAC private-key material, key IDs), digest/algorithm choice, and the names and
+    /// formats of the headers that carry the canonical string and signature — is the <b>plugin's</b>
+    /// responsibility. No RSA, HMAC, or other cryptography is performed in Common.
+    /// </para>
+    /// </summary>
+    public interface IHttpRequestSigner
+    {
+        /// <summary>
+        /// Returns <c>true</c> if requests to the given endpoint must be signed. Allows a plugin to
+        /// sign only a subset of endpoints (e.g. authenticated calls) and leave the rest untouched.
+        /// </summary>
+        /// <param name="endpoint">The request endpoint path (as supplied to the builder), used by the
+        /// plugin to decide whether signing applies.</param>
+        bool RequiresSigning(string endpoint);
+
+        /// <summary>
+        /// Signs the already-built <paramref name="request"/> by mutating it in place — typically by
+        /// computing a canonical string over the final method/URL/headers/body and adding the
+        /// resulting canonical and signature headers.
+        ///
+        /// <para>
+        /// Common guarantees this is invoked as the <b>last</b> mutation before the request is returned
+        /// from the builder (URL, headers, and content are all final), so the implementation may safely
+        /// canonicalize over the complete request. The signing math (canonicalization, key handling,
+        /// header names/formats) lives entirely in the implementing plugin; Common contributes none of
+        /// it.
+        /// </para>
+        /// </summary>
+        /// <param name="request">The fully-constructed request to sign in place.</param>
+        void Sign(HttpRequestMessage request);
+    }
+}

--- a/src/Services/Http/StreamingApiRequestBuilder.cs
+++ b/src/Services/Http/StreamingApiRequestBuilder.cs
@@ -24,6 +24,7 @@ namespace Lidarr.Plugin.Common.Services.Http
         private TimeSpan? _timeout;
         private ResiliencePolicy _policy;
         private string _authScopeToken;
+        private IHttpRequestSigner _signer;
 
         public StreamingApiRequestBuilder(string baseUrl)
         {
@@ -237,6 +238,19 @@ namespace Lidarr.Plugin.Common.Services.Http
         }
 
         /// <summary>
+        /// Attaches a request-level signer invoked by <see cref="Build"/> as the last mutation of the
+        /// constructed request (after URL, headers, and content are final). When set and
+        /// <see cref="IHttpRequestSigner.RequiresSigning"/> returns <c>true</c> for this request's
+        /// endpoint, the signer mutates the request in place (e.g. adds canonical/signature headers).
+        /// All signing math lives in the signer; the builder only invokes the seam.
+        /// </summary>
+        public StreamingApiRequestBuilder WithSigner(IHttpRequestSigner signer)
+        {
+            _signer = signer ?? throw new ArgumentNullException(nameof(signer));
+            return this;
+        }
+
+        /// <summary>
         /// Adds cache control headers to prevent caching.
         /// </summary>
         public StreamingApiRequestBuilder NoCache()
@@ -305,6 +319,19 @@ namespace Lidarr.Plugin.Common.Services.Http
             catch
             {
                 // Options are best-effort; avoid throwing from builder
+            }
+
+            // Request-level signing is the LAST mutation: the URL, headers, and content are now all
+            // final, so a signer may canonicalize over the complete request. Unlike the best-effort
+            // Options block above, signing failures are NOT swallowed — a missing/invalid signature
+            // would otherwise surface only as an opaque downstream 401/403.
+            if (_signer != null)
+            {
+                var endpointForSigning = string.IsNullOrWhiteSpace(_endpoint) ? string.Empty : "/" + _endpoint;
+                if (_signer.RequiresSigning(endpointForSigning))
+                {
+                    _signer.Sign(request);
+                }
             }
 
             return request;

--- a/tests/Services/Http/StreamingApiRequestBuilderTests.cs
+++ b/tests/Services/Http/StreamingApiRequestBuilderTests.cs
@@ -581,6 +581,127 @@ namespace Lidarr.Plugin.Common.Tests.Services.Http
 
         #endregion
 
+        #region WithSigner
+
+        /// <summary>
+        /// Records each <see cref="IHttpRequestSigner.Sign"/> invocation and a snapshot of the request
+        /// state at signing time, so tests can assert the signer ran exactly once and saw the FINAL
+        /// request (URL + headers + body all present).
+        /// </summary>
+        private sealed class RecordingSigner : IHttpRequestSigner
+        {
+            private readonly bool _requiresSigning;
+
+            public RecordingSigner(bool requiresSigning) => _requiresSigning = requiresSigning;
+
+            public int RequiresSigningCalls { get; private set; }
+            public int SignCalls { get; private set; }
+            public string? SeenEndpoint { get; private set; }
+
+            // Snapshot of the request as it was when Sign() ran.
+            public bool SawAuthorizationHeader { get; private set; }
+            public bool SawContent { get; private set; }
+
+            public bool RequiresSigning(string endpoint)
+            {
+                RequiresSigningCalls++;
+                SeenEndpoint = endpoint;
+                return _requiresSigning;
+            }
+
+            public void Sign(HttpRequestMessage request)
+            {
+                SignCalls++;
+                SawAuthorizationHeader = request.Headers.Contains("Authorization");
+                SawContent = request.Content != null;
+                // A real signer would add canonical/signature headers here; we just mark that it ran.
+                request.Headers.TryAddWithoutValidation("X-Signature", "signed");
+            }
+        }
+
+        [Fact]
+        public void WithSigner_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new StreamingApiRequestBuilder(BaseUrl).WithSigner(null!));
+        }
+
+        [Fact]
+        public void Build_NoSigner_DoesNotSign()
+        {
+            // No signer attached: build must not add any signature.
+            var request = new StreamingApiRequestBuilder(BaseUrl)
+                .Endpoint("search")
+                .Build();
+
+            Assert.False(request.Headers.Contains("X-Signature"));
+        }
+
+        [Fact]
+        public void Build_SignerRequiresSigningFalse_DoesNotSign()
+        {
+            var signer = new RecordingSigner(requiresSigning: false);
+
+            var request = new StreamingApiRequestBuilder(BaseUrl)
+                .Endpoint("search")
+                .WithSigner(signer)
+                .Build();
+
+            Assert.Equal(1, signer.RequiresSigningCalls);
+            Assert.Equal(0, signer.SignCalls);
+            Assert.False(request.Headers.Contains("X-Signature"));
+        }
+
+        [Fact]
+        public void Build_SignerRequiresSigningTrue_SignsExactlyOnce()
+        {
+            var signer = new RecordingSigner(requiresSigning: true);
+
+            var request = new StreamingApiRequestBuilder(BaseUrl)
+                .Endpoint("orders")
+                .WithSigner(signer)
+                .Build();
+
+            Assert.Equal(1, signer.SignCalls);
+            Assert.True(request.Headers.Contains("X-Signature"));
+        }
+
+        [Fact]
+        public void Build_Signer_ReceivesLeadingSlashEndpoint()
+        {
+            var signer = new RecordingSigner(requiresSigning: true);
+
+            new StreamingApiRequestBuilder(BaseUrl)
+                .Endpoint("/v2/orders")
+                .WithSigner(signer)
+                .Build();
+
+            // Matches the canonical endpoint form the builder uses for request Options.
+            Assert.Equal("/v2/orders", signer.SeenEndpoint);
+        }
+
+        [Fact]
+        public void Build_Signer_RunsLast_SeesFinalHeadersAndBody()
+        {
+            // The signer must observe the request AFTER URL, headers, and content are all set,
+            // so a real implementation can canonicalize over the complete request.
+            var signer = new RecordingSigner(requiresSigning: true);
+
+            new StreamingApiRequestBuilder(BaseUrl)
+                .Endpoint("orders")
+                .Post()
+                .BearerToken("tok123")
+                .JsonBody(new { item = "abc" })
+                .WithSigner(signer)
+                .Build();
+
+            Assert.Equal(1, signer.SignCalls);
+            Assert.True(signer.SawAuthorizationHeader); // header was applied before signing
+            Assert.True(signer.SawContent);             // body was applied before signing
+        }
+
+        #endregion
+
         #region Fluent Chaining
 
         [Fact]


### PR DESCRIPTION
## What

Adds an **additive, request-level** signing seam to `Lidarr.Plugin.Common` so plugins whose authentication is computed over the **fully-built** HTTP request (method + URL + headers + body) — notably **Amazon Music's ADP RSA-SHA256** — can plug into the shared `StreamingApiRequestBuilder`.

## Why a new seam (and not `IRequestSigner`)

The existing `IRequestSigner` signs by mutating a flat `parameters` dictionary *before* the URL is assembled — the Qobuz/MD5 `Sign(endpoint, parameters, appId, appSecret)` shape. It cannot express schemes like ADP, which canonicalize the **final** request line, a curated set of headers, and the request **body**, then emit their own canonical/signature **headers**.

- `IRequestSigner` is left **completely untouched**.
- Qobuz is **not** migrated.
- Both seams are additive and optional; a plugin picks whichever matches its service.

This eliminates the divergence where Qobuz signs by *bypassing* the builder; Amazon will instead sign *through* it via this seam.

## Changes

- **`src/Services/Http/IHttpRequestSigner.cs`** (new)
  - `bool RequiresSigning(string endpoint)`
  - `void Sign(HttpRequestMessage request)` — mutates the already-built request in place.
  - XML-doc makes the **crypto-out-of-Common** stance explicit: all signing **math** (canonicalization, key handling, digest/algorithm, header names/formats) is the **plugin's** responsibility. **No RSA/HMAC/crypto in Common** — it defines the seam and invokes it.
- **`StreamingApiRequestBuilder`**
  - `WithSigner(IHttpRequestSigner signer)` — fluent, stored in a private `_signer` field, null-guarded (consistent with `WithPolicy`/`WithStreamingDefaults`).
  - `Build()` — after the `HttpRequestMessage` is fully constructed (URL + headers + content all set) and after the best-effort `Options` block, if a signer is present and `RequiresSigning(endpoint)` is `true`, `Sign(request)` runs as the **last mutation** before return. The signer receives the same leading-slash endpoint form used for request `Options`. Signing failures are **not** swallowed (unlike the best-effort options) since a bad signature would otherwise surface only as an opaque 401/403.
- **Tests** (`StreamingApiRequestBuilderTests.cs`, new `#region WithSigner`) — fake recording signer asserts:
  - signed **exactly once** and **last** (observes final `Authorization` header + body) when `RequiresSigning` is `true`;
  - **not** invoked when no signer is set;
  - **not** invoked when `RequiresSigning` is `false`;
  - receives the leading-slash endpoint;
  - `WithSigner(null)` throws `ArgumentNullException`.
- **PublicAPI** — `PublicAPI.Unshipped.txt` updated for both `net8.0` and `net6.0` with the new interface, both methods, and the builder method.

## Verification

- `dotnet build src/Lidarr.Plugin.Common.csproj -c Release`: **0 warnings, 0 errors**.
- Build with analyzers forced on (`-p:RunAnalyzersDuringBuild=true -p:EnableNETAnalyzers=true`): **no RS0016/RS0017** for the new surface (the 4 emitted warnings — 3× CA1416 in `TokenProtectorFactory`, 1× RS0025 `CircuitBreaker` ctor dup in *Shipped*.txt — are all pre-existing and unrelated).
- `dotnet test --filter StreamingApiRequestBuilderTests`: **54 passed, 0 failed** (test project builds clean under `TreatWarningsAsErrors=true`).

## Not in scope

No concrete signer. Amazon's `AdpRequestSigner` is plugin-side and lands later in amazonmusicarr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)