### PR TITLE
chore(net6): retire .NET 6 support (build-only residue; net6 retired 2026-03-31)

### DIFF
--- a/.claude/skills/release-automation/SKILL.md
+++ b/.claude/skills/release-automation/SKILL.md
@@ -37,7 +37,7 @@ Automate and streamline releases for the Lidarr.Plugin.Common shared library, en
 - Manage package references in consuming projects
 
 ### 5. Release Validation
-- Run full test suite across all TFMs (net6.0, net8.0)
+- Run full test suite across all TFMs (net8.0)
 - Validate public API against previous release
 - Check documentation is current
 - Verify package metadata
@@ -48,7 +48,7 @@ Automate and streamline releases for the Lidarr.Plugin.Common shared library, en
 ### Lidarr.Plugin.Common Infrastructure
 - **Current Status**: Enterprise-grade (release.yml exists)
 - **Package Type**: NuGet library (.nupkg)
-- **Target Frameworks**: net6.0, net8.0 (multi-targeting)
+- **Target Framework**: net8.0
 - **Packages**:
   - Lidarr.Plugin.Abstractions (host-owned ABI)
   - Lidarr.Plugin.Common (main library)
@@ -139,7 +139,7 @@ See [MIGRATION.md](docs/migration/v1.1-to-v1.2.md) for detailed upgrade instruct
 ```bash
 # Generate public API files
 dotnet tool restore
-dotnet public-api-generator src/Lidarr.Plugin.Common.csproj -o .config/PublicAPI/net6.0/PublicAPI.Shipped.txt
+dotnet public-api-generator src/Lidarr.Plugin.Common.csproj -o .config/PublicAPI/net8.0/PublicAPI.Shipped.txt
 ```
 
 ### Package Build
@@ -166,8 +166,8 @@ dotnet apicompat --package Lidarr.Plugin.Common --package-version 1.1.5 --assemb
 
 ### GitHub Actions Release Flow
 1. **Trigger**: Tag push `v*.*.*` or manual dispatch
-2. **Build**: Restore and build for net6.0 + net8.0
-3. **Validate**: Public API drift checks for both TFMs
+2. **Build**: Restore and build for net8.0
+3. **Validate**: Public API drift checks for net8.0
 4. **Test**: Run test suite (with timing flake filters on tags)
 5. **Pack**: Create NuGet packages with ContinuousIntegrationBuild=true
 6. **API Check**: Validate compatibility with previous release
@@ -213,8 +213,8 @@ dotnet apicompat --package Lidarr.Plugin.Common --package-version 1.1.5 --assemb
 2. Run with same TFM as CI (net8.0)
 3. Consider adding test filters for known flakes
 
-### Multi-TFM Build Issues
-**Problem**: Build succeeds for net6.0 but fails for net8.0
+### Build Issues (net8.0)
+**Problem**: Build fails for net8.0 (net6.0 is retired; net8.0 is the only TFM)
 **Solution**:
 1. Check conditional dependencies in csproj
 2. Verify framework-specific code paths

--- a/.github/actions/build-plugin/action.yml
+++ b/.github/actions/build-plugin/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: 'Release'
   target-framework:
-    description: 'Target framework (net6.0 or net8.0)'
+    description: 'Target framework (net8.0)'
     required: false
     default: 'net8.0'
   lidarr-docker-version:

--- a/.github/workflows/multi-plugin-smoke-test.yml
+++ b/.github/workflows/multi-plugin-smoke-test.yml
@@ -351,7 +351,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Resolve plugin selection and refs

--- a/build/PluginPackaging.targets
+++ b/build/PluginPackaging.targets
@@ -42,7 +42,7 @@
       <_CommonLibraryPath>$(MSBuildThisFileDirectory)../src/bin/$(Configuration)/$(TargetFramework)</_CommonLibraryPath>
       <_AbstractionsPath>$(MSBuildThisFileDirectory)../src/Abstractions/bin/$(Configuration)/$(TargetFramework)</_AbstractionsPath>
       <!-- Paths to Lidarr assemblies (for reference resolution, typically at repo root/ext/Lidarr) -->
-      <_LidarrAssembliesPath Condition="'$(LidarrAssembliesPath)' == ''">$(MSBuildProjectDirectory)/../../ext/Lidarr/_output/net6.0;$(MSBuildProjectDirectory)/../../ext/Lidarr/_output/net8.0</_LidarrAssembliesPath>
+      <_LidarrAssembliesPath Condition="'$(LidarrAssembliesPath)' == ''">$(MSBuildProjectDirectory)/../../ext/Lidarr/_output/net8.0</_LidarrAssembliesPath>
       <_LidarrAssembliesPath Condition="'$(LidarrAssembliesPath)' != ''">$(LidarrAssembliesPath)</_LidarrAssembliesPath>
       <!-- Combined library paths for ILRepack - plugin output first (has all NuGet deps) -->
       <_ILRepackLibraryPaths>$(_PluginOutputDir);$(_LidarrAssembliesPath);$(_CommonLibraryPath);$(_AbstractionsPath)</_ILRepackLibraryPaths>

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -6,9 +6,9 @@ Keep `Lidarr.Plugin.Common`, `Lidarr.Plugin.Abstractions`, and the host aligned 
 
 | Host (Lidarr) | Abstractions | Common | TFMs | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 2.14.x | 1.x | 1.1.4 | net8.0, net6.0 | Active | Current release train. |
-| 2.13.x | 1.x | 1.1.3 | net6.0 | Maintenance | Security fixes only; no new features. |
-| 2.12.x | 0.x | 1.0.x | net6.0 | Deprecated (EOL 2025-12-31) | Schedule upgrade to 1.x ABI. |
+| 2.14.x | 1.x | 1.1.4 | net8.0 | Active | Current release train. |
+| 2.13.x | 1.x | 1.1.3 | net6.0 | Maintenance | Security fixes only; no new features — net6.0 retired 2026-03-31. |
+| 2.12.x | 0.x | 1.0.x | net6.0 | Deprecated (EOL 2025-12-31) | Schedule upgrade to 1.x ABI — net6.0 retired 2026-03-31. |
 
 ### Versioning policy
 
@@ -18,13 +18,13 @@ Keep `Lidarr.Plugin.Common`, `Lidarr.Plugin.Abstractions`, and the host aligned 
 
 ### Target frameworks
 
-- `net8.0` is the preferred target for new plugins.
-- `net6.0` remains supported until **31 March 2026** (after that, drop the compat build).
+- `net8.0` is the target for all plugins.
+- `net6.0` is now **RETIRED** (was supported through **31 March 2026**); the compat build has been dropped.
 - Plugin manifests should list supported TFMs via `targets` for diagnostics.
 
 ## Contract
 
 - Host upgrades that break the ABI must ship new `Lidarr.Plugin.Abstractions` majors and update `apiVersion` guidance.
 - Common releases must remain compatible with all supported Abstractions majors (no shared static state across plugins).
-- CI must run both TFMs (`dotnet test -f net8.0` + `net6.0`) until net6 is retired.
+- CI runs net8.0 only (`dotnet test -f net8.0`); net6.0 is retired.
 - The compatibility matrix must be updated alongside every release so plugin authors know when to migrate.

--- a/docs/ECOSYSTEM_PROMOTION_CHECKLIST.md
+++ b/docs/ECOSYSTEM_PROMOTION_CHECKLIST.md
@@ -30,7 +30,7 @@ Run this checklist before promoting a new Common release to all plugin repos.
 
 ## CI Rules (future — requires billing unblock)
 - [ ] Exactly one concrete IPlugin per plugin assembly
-- [ ] No new net6.0 references in build files
+- [ ] No net6.0 references in build files (net6 retired)
 - [ ] All shipped bridge contracts have: default impl + compliance test + consumer test
 - [ ] `.bridge-exempt` repos excluded from bridge parity checks
 

--- a/docs/FAQ_FOR_PLUGIN_AUTHORS.md
+++ b/docs/FAQ_FOR_PLUGIN_AUTHORS.md
@@ -22,7 +22,7 @@ Use the public API baselining scripts:
 ./tools/Update-PublicApiBaselines.ps1 -Project src/Abstractions/Lidarr.Plugin.Abstractions.csproj
 ```
 
-Run this under both `net6.0` and `net8.0` when you add or remove public surface area.
+Run this under `net8.0` when you add or remove public surface area.
 
 ## Packaging script is noisy (warnings or unexpected DLLs). How do I diagnose it?
 Run `New-PluginPackage` with `-Verbose` to inspect each step. Verify the publish directory contains only plugin-owned assemblies before packaging, and confirm `ManifestCheck.ps1` passes to catch mismatched versions early.

--- a/docs/MANUAL_ENFORCEMENT_RUNBOOK.md
+++ b/docs/MANUAL_ENFORCEMENT_RUNBOOK.md
@@ -24,11 +24,11 @@
    ```
    Expected: all pass (Tidalarr 10, Qobuzarr 11, AppleMusicarr 10)
 
-4. **No net6.0 regressions**
+4. **No net6.0 references (net6 retired)**
    ```bash
    grep -r "net6\.0" --include="*.csproj" --include="*.props" --include="*.ps1" --include="*.sh" --include="*.yml" . | grep -v ext/ | grep -v obj/ | grep -v .git/
    ```
-   Expected: 0 matches (Common is allowed 2 in tooling)
+   Expected: 0 matches
 
 5. **Single IPlugin** (plugin repos only)
    ```bash


### PR DESCRIPTION
## What
Retires the leftover .NET 6 residue. The build has been **net8.0-only** for some time (all csproj are single-target net8.0); this removes the vestigial net6 support now that it's past the repo's own documented retirement date (**2026-03-31**, per `COMPATIBILITY.md`) and 2.13.x is no longer supported.

## Changes
- **Delete** orphaned `src/PublicAPI/net6.0/` baselines (~1.98k lines) — the csproj only reads `PublicAPI/$(TargetFramework)/` = net8.0, so these were never consumed (also closes the long-standing net6/net8 PublicAPI mismatch).
- `build/PluginPackaging.targets` — drop the `ext/Lidarr/_output/net6.0;` segment from the ILRepack `_LidarrAssembliesPath` default (keep net8.0).
- `.github/workflows/multi-plugin-smoke-test.yml` — remove the unused `6.0.x` SDK install.
- `.github/actions/build-plugin/action.yml` — `target-framework` description → `net8.0`.
- `docs/COMPATIBILITY.md` — 2.14.x (Active) TFM → `net8.0`; older rows annotated "net6.0 retired 2026-03-31"; policy + CI lines updated (net6 RETIRED, CI net8-only).
- Guidance docs (`ECOSYSTEM_PROMOTION_CHECKLIST`, `MANUAL_ENFORCEMENT_RUNBOOK`, `FAQ_FOR_PLUGIN_AUTHORS`, `release-automation` skill) → net8-only.

## Deliberately NOT touched (collision / by-design)
- `release-plugin.yml` + `scripts/extract-lidarr-net6.sh` — **open PR #568** touches `release-plugin.yml`; defer to avoid collision (follow-up once #568 lands).
- `AGENTS.md` — **open PR #540** touches it; defer.
- `PluginIsolationAssertions.cs` net6-tolerant check — harmless, and tightening this shared test-helper risks other plugins' tests.
- `forbiddenTargetFrameworks` list keeps `net6.0` — it must, to *enforce* net6's absence.
- Historical/audit docs left as records.

No `.csproj`/`Directory.Build.props` changed (already net8-only). All four plugins are net8-only; this is net-neutral for consumers and flows to them on the next pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)