### PR TITLE
feat(streaming): manifest-parser seam + spec-correct DASH parser (additive)

### DIFF
--- a/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -68,3 +68,44 @@ Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner
 Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.RequiresSigning(string! endpoint) -> bool
 Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.Sign(System.Net.Http.HttpRequestMessage! request) -> void
 Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder.WithSigner(Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner! signer) -> Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.IStreamManifestParser
+Lidarr.Plugin.Common.Services.Streaming.Manifests.IStreamManifestParser.CanParse(string! mimeTypeOrContent) -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.IStreamManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.StreamManifest(System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>! Variants, System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment!>! Segments, string! Codec, string! FileExtension, bool IsEncrypted, string? KeyId, string? Pssh) -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Variants.get -> System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Variants.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Segments.get -> System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment!>!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Segments.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Codec.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Codec.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.FileExtension.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.FileExtension.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.IsEncrypted.get -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.IsEncrypted.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.KeyId.get -> string?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.KeyId.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Pssh.get -> string?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Pssh.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.StreamVariant(int BandwidthBps, string! Url, string? Codec) -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.BandwidthBps.get -> int
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.BandwidthBps.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Url.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Url.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Codec.get -> string?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Codec.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.StreamSegment(int Index, string! Url, double? DurationSeconds) -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Index.get -> int
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Index.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Url.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Url.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.DurationSeconds.get -> double?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.DurationSeconds.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.DashManifestParser() -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.CanParse(string! mimeTypeOrContent) -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector
+static Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector.SelectByBandwidthCeiling(System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>! variants, int ceilingBps) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant?

--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -97,3 +97,44 @@ Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner
 Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.RequiresSigning(string! endpoint) -> bool
 Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner.Sign(System.Net.Http.HttpRequestMessage! request) -> void
 Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder.WithSigner(Lidarr.Plugin.Common.Services.Http.IHttpRequestSigner! signer) -> Lidarr.Plugin.Common.Services.Http.StreamingApiRequestBuilder!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.IStreamManifestParser
+Lidarr.Plugin.Common.Services.Streaming.Manifests.IStreamManifestParser.CanParse(string! mimeTypeOrContent) -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.IStreamManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.StreamManifest(System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>! Variants, System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment!>! Segments, string! Codec, string! FileExtension, bool IsEncrypted, string? KeyId, string? Pssh) -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Variants.get -> System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Variants.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Segments.get -> System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment!>!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Segments.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Codec.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Codec.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.FileExtension.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.FileExtension.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.IsEncrypted.get -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.IsEncrypted.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.KeyId.get -> string?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.KeyId.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Pssh.get -> string?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest.Pssh.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.StreamVariant(int BandwidthBps, string! Url, string? Codec) -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.BandwidthBps.get -> int
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.BandwidthBps.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Url.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Url.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Codec.get -> string?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant.Codec.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.StreamSegment(int Index, string! Url, double? DurationSeconds) -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Index.get -> int
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Index.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Url.get -> string!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.Url.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.DurationSeconds.get -> double?
+Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamSegment.DurationSeconds.init -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.DashManifestParser() -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.CanParse(string! mimeTypeOrContent) -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector
+static Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector.SelectByBandwidthCeiling(System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>! variants, int ceilingBps) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant?

--- a/src/Services/Streaming/Manifests/DashManifestParser.cs
+++ b/src/Services/Streaming/Manifests/DashManifestParser.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Lidarr.Plugin.Common.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Spec-correct MPEG-DASH (MPD) manifest parser, shared across plugins whose service delivers
+    /// DASH (Amazon Music's <c>getDashManifestsV2</c>, Tidal's <c>application/dash+xml</c>).
+    ///
+    /// <para>
+    /// <b>Parse-only (see <see cref="IStreamManifestParser"/>):</b> turns the MPD index into an ordered
+    /// segment list and a variant list, and surfaces any <c>ContentProtection</c> PSSH/KID as opaque
+    /// <b>data</b>. It contains no decrypt, key-derivation, or CDM logic.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>SegmentTimeline correctness:</b> per the DASH spec (ISO/IEC 23009-1, <c>SegmentTimeline.S@r</c>),
+    /// <c>r</c> is the count of <b>additional</b> repeats of a segment of duration <c>d</c>, so an entry
+    /// <c>&lt;S t d r=N/&gt;</c> yields <c>N + 1</c> segments. <c>SegmentTemplate@startNumber</c> (default
+    /// <c>1</c>) is the <c>$Number$</c> of the first media segment and increments per segment thereafter.
+    /// </para>
+    /// </summary>
+    public sealed class DashManifestParser : IStreamManifestParser
+    {
+        // Widevine DRM system id used by ContentProtection@schemeIdUri (case-insensitive).
+        private const string WidevineSystemId = "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
+
+        // Matches $Number%0Nd$ (width-padded $Number$), e.g. $Number%06d$. Group "w" = the N digits of width.
+        private static readonly Regex PaddedNumberToken =
+            new(@"\$Number%0(?<w>\d+)d\$", RegexOptions.Compiled);
+
+        /// <inheritdoc />
+        public bool CanParse(string mimeTypeOrContent)
+        {
+            if (string.IsNullOrWhiteSpace(mimeTypeOrContent))
+            {
+                return false;
+            }
+
+            string s = mimeTypeOrContent;
+            if (s.IndexOf("dash+xml", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+
+            // Sniff content: a DASH document's root element is <MPD ...> (optionally with an XML declaration first).
+            string trimmed = s.TrimStart();
+            if (trimmed.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase))
+            {
+                int gt = trimmed.IndexOf('>');
+                if (gt >= 0 && gt + 1 < trimmed.Length)
+                {
+                    trimmed = trimmed.Substring(gt + 1).TrimStart();
+                }
+            }
+
+            return trimmed.StartsWith("<MPD", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <inheritdoc />
+        public StreamManifest Parse(string manifestContent, string baseUrl)
+        {
+            if (string.IsNullOrWhiteSpace(manifestContent))
+            {
+                throw new ArgumentException("Manifest content is empty.", nameof(manifestContent));
+            }
+
+            XDocument doc = XDocument.Parse(manifestContent);
+            XElement mpd = doc.Root ?? throw new FormatException("DASH manifest has no root element.");
+            XNamespace ns = mpd.GetDefaultNamespace();
+
+            // Resolve the effective base: fetch URL, then MPD-level <BaseURL>, then Period-level <BaseURL>.
+            string effectiveBase = baseUrl ?? string.Empty;
+            effectiveBase = ApplyBaseUrlChild(mpd, ns, effectiveBase);
+
+            XElement? period = mpd.Elements(ns + "Period").FirstOrDefault();
+            if (period == null)
+            {
+                return new StreamManifest(Array.Empty<StreamVariant>(), Array.Empty<StreamSegment>(), string.Empty, ".m4a", false, null, null);
+            }
+
+            effectiveBase = ApplyBaseUrlChild(period, ns, effectiveBase);
+
+            // Audio-first: pick the AdaptationSet whose contentType/mimeType is audio when annotated,
+            // else the first AdaptationSet (Amazon/Tidal audio manifests typically carry a single set).
+            List<XElement> adaptationSets = period.Elements(ns + "AdaptationSet").ToList();
+            XElement? adaptationSet =
+                adaptationSets.FirstOrDefault(a => IsAudio(a)) ?? adaptationSets.FirstOrDefault();
+
+            if (adaptationSet == null)
+            {
+                return new StreamManifest(Array.Empty<StreamVariant>(), Array.Empty<StreamSegment>(), string.Empty, ".m4a", false, null, null);
+            }
+
+            effectiveBase = ApplyBaseUrlChild(adaptationSet, ns, effectiveBase);
+
+            List<XElement> representations = adaptationSet.Elements(ns + "Representation").ToList();
+
+            // Build the variant list (one per Representation).
+            var variants = new List<StreamVariant>(representations.Count);
+            foreach (XElement rep in representations)
+            {
+                int bandwidth = ParseInt(rep.Attribute("bandwidth")?.Value, 0);
+                string repCodec = rep.Attribute("codecs")?.Value ?? adaptationSet.Attribute("codecs")?.Value ?? string.Empty;
+                string repId = rep.Attribute("id")?.Value ?? string.Empty;
+                string variantUrl = VariantUrl(rep, adaptationSet, ns, effectiveBase, repId, bandwidth);
+                variants.Add(new StreamVariant(bandwidth, variantUrl, string.IsNullOrEmpty(repCodec) ? null : repCodec));
+            }
+
+            // Generate segments from the highest-bandwidth representation (the canonical rendition to fetch).
+            XElement? chosen = representations
+                .OrderByDescending(r => ParseInt(r.Attribute("bandwidth")?.Value, 0))
+                .FirstOrDefault();
+
+            string codec = chosen?.Attribute("codecs")?.Value
+                           ?? adaptationSet.Attribute("codecs")?.Value
+                           ?? string.Empty;
+
+            List<StreamSegment> segments = chosen != null
+                ? BuildSegments(chosen, adaptationSet, ns, effectiveBase)
+                : new List<StreamSegment>();
+
+            string fileExtension = DetermineFileExtension(codec, segments);
+
+            (string? pssh, string? keyId) = ExtractContentProtection(adaptationSet, chosen, ns);
+            bool isEncrypted = !string.IsNullOrWhiteSpace(pssh) || !string.IsNullOrWhiteSpace(keyId);
+
+            return new StreamManifest(variants, segments, codec, fileExtension, isEncrypted, keyId, pssh);
+        }
+
+        private static bool IsAudio(XElement adaptationSet)
+        {
+            string contentType = adaptationSet.Attribute("contentType")?.Value ?? string.Empty;
+            string mimeType = adaptationSet.Attribute("mimeType")?.Value ?? string.Empty;
+            return contentType.Equals("audio", StringComparison.OrdinalIgnoreCase)
+                   || mimeType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Applies a single child <c>&lt;BaseURL&gt;</c> of <paramref name="element"/> on top of
+        /// <paramref name="current"/>, resolving it as relative when it is not already absolute.
+        /// </summary>
+        private static string ApplyBaseUrlChild(XElement element, XNamespace ns, string current)
+        {
+            string? child = element.Elements(ns + "BaseURL").FirstOrDefault()?.Value?.Trim();
+            if (string.IsNullOrEmpty(child))
+            {
+                return current;
+            }
+
+            return ResolveUrl(current, child);
+        }
+
+        private static string VariantUrl(
+            XElement rep, XElement adaptationSet, XNamespace ns, string baseUrl, string repId, int bandwidth)
+        {
+            // Prefer the representation's own <BaseURL> when present; otherwise expose the (resolved)
+            // media template as the variant's identifying URL so callers have something to key on.
+            string? repBase = rep.Elements(ns + "BaseURL").FirstOrDefault()?.Value?.Trim();
+            if (!string.IsNullOrEmpty(repBase))
+            {
+                return ResolveUrl(baseUrl, repBase);
+            }
+
+            XElement? template = rep.Elements(ns + "SegmentTemplate").FirstOrDefault()
+                                 ?? adaptationSet.Elements(ns + "SegmentTemplate").FirstOrDefault();
+            string? media = template?.Attribute("media")?.Value;
+            if (!string.IsNullOrEmpty(media))
+            {
+                string substituted = SubstituteTemplate(media!, repId, bandwidth, null);
+                return ResolveUrl(baseUrl, substituted);
+            }
+
+            return baseUrl;
+        }
+
+        /// <summary>
+        /// Builds the ordered segment list for a representation. Honors (in priority order):
+        /// the init segment from <c>SegmentTemplate@initialization</c> (index 0), then either a
+        /// <c>SegmentTimeline</c> (expanding each <c>&lt;S t d r/&gt;</c> to <c>r + 1</c> segments) or a
+        /// duration-based <c>SegmentTemplate</c> (<c>@duration</c> + media-presentation/period duration),
+        /// using <c>@startNumber</c> (default <c>1</c>) as the first <c>$Number$</c>.
+        /// </summary>
+        private static List<StreamSegment> BuildSegments(
+            XElement rep, XElement adaptationSet, XNamespace ns, string baseUrl)
+        {
+            var segments = new List<StreamSegment>();
+            string repId = rep.Attribute("id")?.Value ?? string.Empty;
+            int bandwidth = ParseInt(rep.Attribute("bandwidth")?.Value, 0);
+
+            XElement? template = rep.Elements(ns + "SegmentTemplate").FirstOrDefault()
+                                 ?? adaptationSet.Elements(ns + "SegmentTemplate").FirstOrDefault();
+
+            // No SegmentTemplate: fall back to a single media segment from <BaseURL>, if any.
+            if (template == null)
+            {
+                string? single = rep.Elements(ns + "BaseURL").FirstOrDefault()?.Value?.Trim();
+                if (!string.IsNullOrEmpty(single))
+                {
+                    segments.Add(new StreamSegment(0, ResolveUrl(baseUrl, single!), null));
+                }
+
+                return segments;
+            }
+
+            int timescale = ParseInt(template.Attribute("timescale")?.Value, 1);
+            if (timescale <= 0)
+            {
+                timescale = 1;
+            }
+
+            // startNumber: the $Number$ of the FIRST media segment (default 1 per spec).
+            long startNumber = ParseLong(template.Attribute("startNumber")?.Value, 1);
+
+            int index = 0;
+
+            // Init segment is index 0 when present. It is NOT a numbered media segment, so $Number$ is not substituted here.
+            string? initialization = template.Attribute("initialization")?.Value;
+            if (!string.IsNullOrEmpty(initialization))
+            {
+                string initUrl = ResolveUrl(baseUrl, SubstituteTemplate(initialization!, repId, bandwidth, null));
+                segments.Add(new StreamSegment(index++, initUrl, null));
+            }
+
+            string media = template.Attribute("media")?.Value ?? string.Empty;
+            if (string.IsNullOrEmpty(media))
+            {
+                return segments;
+            }
+
+            XElement? timeline = template.Elements(ns + "SegmentTimeline").FirstOrDefault();
+            if (timeline != null)
+            {
+                long number = startNumber;
+                foreach (XElement s in timeline.Elements(ns + "S"))
+                {
+                    long d = ParseLong(s.Attribute("d")?.Value, 0);
+                    // r = ADDITIONAL repeats -> r + 1 segments total for this <S>. (A negative r meaning
+                    // "repeat to the end" is not used by Amazon/Tidal audio manifests; treat <0 as 0.)
+                    int r = ParseInt(s.Attribute("r")?.Value, 0);
+                    if (r < 0)
+                    {
+                        r = 0;
+                    }
+
+                    double? durationSeconds = d > 0 ? d / (double)timescale : (double?)null;
+
+                    for (int i = 0; i <= r; i++)
+                    {
+                        string url = ResolveUrl(baseUrl, SubstituteTemplate(media, repId, bandwidth, number));
+                        segments.Add(new StreamSegment(index++, url, durationSeconds));
+                        number++;
+                    }
+                }
+
+                return segments;
+            }
+
+            // Duration-based SegmentTemplate (no timeline): segment count = ceil(totalDuration / segmentDuration).
+            long segDuration = ParseLong(template.Attribute("duration")?.Value, 0);
+            double totalSeconds = ParseDuration(
+                rep.Document?.Root?.Attribute("mediaPresentationDuration")?.Value
+                ?? (rep.Ancestors(ns + "Period").FirstOrDefault()?.Attribute("duration")?.Value));
+
+            if (segDuration > 0 && totalSeconds > 0)
+            {
+                double segSeconds = segDuration / (double)timescale;
+                int count = (int)Math.Ceiling(totalSeconds / segSeconds);
+                long number = startNumber;
+                for (int i = 0; i < count; i++)
+                {
+                    string url = ResolveUrl(baseUrl, SubstituteTemplate(media, repId, bandwidth, number));
+                    segments.Add(new StreamSegment(index++, url, segSeconds));
+                    number++;
+                }
+            }
+
+            return segments;
+        }
+
+        /// <summary>
+        /// Substitutes the DASH identifier tokens in a SegmentTemplate string: <c>$RepresentationID$</c>,
+        /// <c>$Bandwidth$</c>, <c>$Number$</c>, and width-padded <c>$Number%0Nd$</c>. <c>$$</c> is the
+        /// literal-dollar escape. A null <paramref name="number"/> leaves <c>$Number$</c> tokens untouched
+        /// (used for the init segment / variant identity).
+        /// </summary>
+        private static string SubstituteTemplate(string template, string repId, int bandwidth, long? number)
+        {
+            string result = template
+                .Replace("$RepresentationID$", repId)
+                .Replace("$Bandwidth$", bandwidth.ToString(CultureInfo.InvariantCulture));
+
+            if (number.HasValue)
+            {
+                result = PaddedNumberToken.Replace(
+                    result,
+                    m =>
+                    {
+                        int width = int.Parse(m.Groups["w"].Value, CultureInfo.InvariantCulture);
+                        return number.Value.ToString(CultureInfo.InvariantCulture).PadLeft(width, '0');
+                    });
+                result = result.Replace("$Number$", number.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Unescape $$ last so a literal dollar in the source can't be misread as a token delimiter.
+            result = result.Replace("$$", "$");
+            return result;
+        }
+
+        /// <summary>
+        /// Extracts Widevine PSSH (<c>cenc:pssh</c>) and KID (<c>@cenc:default_KID</c>) from
+        /// <c>ContentProtection</c> elements as <b>opaque data</b>. Prefers the Widevine-scheme element for
+        /// PSSH; falls back to any <c>cenc:pssh</c>. KID is read from the <c>mp4protection</c>/<c>cenc</c>
+        /// scheme's <c>default_KID</c> when present. No key handling is performed.
+        /// </summary>
+        private static (string? Pssh, string? KeyId) ExtractContentProtection(
+            XElement adaptationSet, XElement? representation, XNamespace ns)
+        {
+            XNamespace cenc = "urn:mpeg:cenc:2013";
+
+            IEnumerable<XElement> protections = adaptationSet.Elements(ns + "ContentProtection");
+            if (representation != null)
+            {
+                protections = protections.Concat(representation.Elements(ns + "ContentProtection"));
+            }
+
+            List<XElement> all = protections.ToList();
+
+            string? keyId = null;
+            foreach (XElement cp in all)
+            {
+                string? kid = cp.Attribute(cenc + "default_KID")?.Value
+                              ?? cp.Attribute("default_KID")?.Value;
+                if (!string.IsNullOrWhiteSpace(kid))
+                {
+                    keyId = kid.Trim();
+                    break;
+                }
+            }
+
+            // Prefer the Widevine-scheme ContentProtection's cenc:pssh; otherwise any cenc:pssh present.
+            string? pssh = null;
+            XElement? widevine = all.FirstOrDefault(cp =>
+                (cp.Attribute("schemeIdUri")?.Value ?? string.Empty)
+                .IndexOf(WidevineSystemId, StringComparison.OrdinalIgnoreCase) >= 0);
+
+            XElement? psshElement =
+                widevine?.Elements(cenc + "pssh").FirstOrDefault()
+                ?? all.SelectMany(cp => cp.Elements(cenc + "pssh")).FirstOrDefault();
+
+            string? psshValue = psshElement?.Value?.Trim();
+            if (!string.IsNullOrWhiteSpace(psshValue))
+            {
+                pssh = psshValue;
+            }
+
+            return (pssh, keyId);
+        }
+
+        private static string DetermineFileExtension(string codec, IReadOnlyList<StreamSegment> segments)
+        {
+            // DASH audio is delivered in an MP4/M4A container regardless of the codec inside (incl. FLAC-in-MP4).
+            // Prefer a concrete extension sniffed from a segment URL when present.
+            foreach (StreamSegment seg in segments)
+            {
+                string u = seg.Url;
+                if (u.IndexOf(".mp4", StringComparison.OrdinalIgnoreCase) >= 0
+                    || u.IndexOf(".m4s", StringComparison.OrdinalIgnoreCase) >= 0
+                    || u.IndexOf(".m4a", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return ".m4a";
+                }
+            }
+
+            if (!string.IsNullOrEmpty(codec) && codec.IndexOf("mp4a", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return ".m4a";
+            }
+
+            return ".m4a";
+        }
+
+        /// <summary>
+        /// Resolves <paramref name="reference"/> against <paramref name="baseUrl"/>. Absolute references
+        /// are returned as-is; when no usable base is available the reference is returned unchanged.
+        /// </summary>
+        private static string ResolveUrl(string baseUrl, string reference)
+        {
+            if (string.IsNullOrEmpty(reference))
+            {
+                return baseUrl ?? string.Empty;
+            }
+
+            if (Uri.TryCreate(reference, UriKind.Absolute, out Uri? abs))
+            {
+                return abs.ToString();
+            }
+
+            if (!string.IsNullOrEmpty(baseUrl)
+                && Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri? baseUri)
+                && Uri.TryCreate(baseUri, reference, out Uri? combined))
+            {
+                return combined.ToString();
+            }
+
+            return reference;
+        }
+
+        private static int ParseInt(string? value, int fallback) =>
+            int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int v) ? v : fallback;
+
+        private static long ParseLong(string? value, long fallback) =>
+            long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long v) ? v : fallback;
+
+        /// <summary>Parses an ISO-8601 duration (e.g. <c>PT3M30.5S</c>) to seconds; returns 0 when absent/invalid.</summary>
+        private static double ParseDuration(string? iso)
+        {
+            if (string.IsNullOrWhiteSpace(iso))
+            {
+                return 0;
+            }
+
+            try
+            {
+                return XmlConvertDuration(iso!);
+            }
+            catch (FormatException)
+            {
+                return 0;
+            }
+            catch (OverflowException)
+            {
+                return 0;
+            }
+        }
+
+        private static double XmlConvertDuration(string iso) =>
+            System.Xml.XmlConvert.ToTimeSpan(iso).TotalSeconds;
+    }
+}

--- a/src/Services/Streaming/Manifests/IStreamManifestParser.cs
+++ b/src/Services/Streaming/Manifests/IStreamManifestParser.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+
+namespace Lidarr.Plugin.Common.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Parser seam for streaming-service playback manifests (the small index document a
+    /// service returns describing how its already-licensed media is segmented and where each
+    /// segment lives). Implementations turn a manifest document into the protocol-neutral
+    /// <see cref="StreamManifest"/> shape so plugins parse manifests through one shared code path
+    /// instead of each maintaining its own subtly-divergent parser.
+    ///
+    /// <para>
+    /// <b>Parsing-only stance (no circumvention):</b> reading a manifest is reading a playlist —
+    /// it enumerates segment URLs the same way an <c>.m3u8</c> or <c>.mpd</c> does. This seam and its
+    /// implementations contain <b>NO decrypt logic, NO key derivation, and NO CDM / license-challenge
+    /// code</b>. When a manifest declares content protection, the parser surfaces the
+    /// <see cref="StreamManifest.Pssh"/> and <see cref="StreamManifest.KeyId"/> values <b>as opaque
+    /// data only</b> and flags <see cref="StreamManifest.IsEncrypted"/>; any actual decryption is the
+    /// responsibility of an out-of-tree handler (see
+    /// <see cref="Lidarr.Plugin.Common.Services.Drm.IExternalDownloadHandler"/>).
+    /// </para>
+    ///
+    /// <para>
+    /// The seam is deliberately small so a second protocol (e.g. HLS for Apple Music) can slot in as
+    /// another <see cref="IStreamManifestParser"/> without changing callers:
+    /// <see cref="DashManifestParser"/> handles MPEG-DASH (Amazon Music's <c>getDashManifestsV2</c>,
+    /// Tidal's <c>application/dash+xml</c>); an HLS parser would handle <c>.m3u8</c>.
+    /// </para>
+    /// </summary>
+    public interface IStreamManifestParser
+    {
+        /// <summary>
+        /// Returns <c>true</c> when this parser can handle the supplied manifest, identified either by
+        /// MIME type (e.g. <c>application/dash+xml</c>) or by a sniff of the manifest content itself
+        /// (e.g. an opening <c>&lt;MPD</c> tag). Callers may pass either; implementations should accept both.
+        /// </summary>
+        /// <param name="mimeTypeOrContent">A MIME type string, or the (start of the) manifest content.</param>
+        bool CanParse(string mimeTypeOrContent);
+
+        /// <summary>
+        /// Parses <paramref name="manifestContent"/> into the protocol-neutral <see cref="StreamManifest"/>.
+        /// Relative segment / variant URLs are resolved against <paramref name="baseUrl"/> (and any
+        /// manifest-internal base, e.g. DASH <c>&lt;BaseURL&gt;</c>).
+        /// </summary>
+        /// <param name="manifestContent">The raw manifest document (already decoded text, not base64).</param>
+        /// <param name="baseUrl">
+        /// Absolute URL the manifest was fetched from, used to resolve relative URLs. May be empty when
+        /// the manifest only contains absolute URLs.
+        /// </param>
+        StreamManifest Parse(string manifestContent, string baseUrl);
+    }
+
+    /// <summary>
+    /// Protocol-neutral result of parsing a streaming manifest. Carries the selectable
+    /// <see cref="Variants"/> (quality renditions), the ordered <see cref="Segments"/> to fetch, and
+    /// content-protection <b>data</b> (<see cref="Pssh"/> / <see cref="KeyId"/>) when present — never
+    /// any key/decrypt logic (see <see cref="IStreamManifestParser"/>).
+    /// </summary>
+    /// <param name="Variants">Selectable quality renditions, in manifest order. May be empty.</param>
+    /// <param name="Segments">Ordered media segments to fetch (an init segment, when present, is index 0).</param>
+    /// <param name="Codec">Best-known codec string for the selected/first representation (e.g. <c>flac</c>, <c>mp4a.40.2</c>), or empty.</param>
+    /// <param name="FileExtension">Container file extension for the fetched media (e.g. <c>.m4a</c>, <c>.mp4</c>).</param>
+    /// <param name="IsEncrypted">True when the manifest declares content protection (i.e. <see cref="Pssh"/> or <see cref="KeyId"/> is present).</param>
+    /// <param name="KeyId">DRM key identifier (KID) as declared in the manifest, or <c>null</c>. Opaque data only.</param>
+    /// <param name="Pssh">Base64 PSSH init data (Widevine) as declared in the manifest, or <c>null</c>. Opaque data only.</param>
+    public sealed record StreamManifest(
+        IReadOnlyList<StreamVariant> Variants,
+        IReadOnlyList<StreamSegment> Segments,
+        string Codec,
+        string FileExtension,
+        bool IsEncrypted,
+        string? KeyId,
+        string? Pssh);
+
+    /// <summary>A selectable quality rendition (one DASH <c>Representation</c> / one HLS variant playlist).</summary>
+    /// <param name="BandwidthBps">Declared bandwidth in bits per second (the value quality selection ranks on).</param>
+    /// <param name="Url">Resolved URL identifying the variant (its media template / playlist), absolute when resolvable.</param>
+    /// <param name="Codec">Codec string for this variant (e.g. <c>flac</c>, <c>mp4a.40.2</c>), or <c>null</c> when unspecified.</param>
+    public sealed record StreamVariant(int BandwidthBps, string Url, string? Codec);
+
+    /// <summary>A single ordered media segment to fetch.</summary>
+    /// <param name="Index">Zero-based position of the segment within <see cref="StreamManifest.Segments"/>.</param>
+    /// <param name="Url">Resolved segment URL, absolute when resolvable against the base URL.</param>
+    /// <param name="DurationSeconds">Segment duration in seconds when derivable from the manifest timescale, else <c>null</c>.</param>
+    public sealed record StreamSegment(int Index, string Url, double? DurationSeconds);
+}

--- a/src/Services/Streaming/Manifests/QualitySelector.cs
+++ b/src/Services/Streaming/Manifests/QualitySelector.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Lidarr.Plugin.Common.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Protocol-neutral helpers for picking a <see cref="StreamVariant"/> from a parsed manifest's
+    /// rendition list. Selection is by declared <see cref="StreamVariant.BandwidthBps"/> only; this
+    /// type performs no fetching and no decryption.
+    /// </summary>
+    public static class QualitySelector
+    {
+        /// <summary>
+        /// Returns the highest-bandwidth variant whose <see cref="StreamVariant.BandwidthBps"/> is
+        /// less than or equal to <paramref name="ceilingBps"/>. When every variant exceeds the ceiling
+        /// (so none qualifies), returns the single lowest-bandwidth variant so a playable stream is
+        /// always chosen rather than nothing. Returns <c>null</c> only when <paramref name="variants"/>
+        /// is null or empty.
+        /// </summary>
+        /// <param name="variants">Candidate renditions (e.g. from <see cref="StreamManifest.Variants"/>).</param>
+        /// <param name="ceilingBps">Inclusive upper bound on bandwidth, in bits per second.</param>
+        public static StreamVariant? SelectByBandwidthCeiling(IReadOnlyList<StreamVariant> variants, int ceilingBps)
+        {
+            if (variants == null || variants.Count == 0)
+            {
+                return null;
+            }
+
+            StreamVariant? best = null;
+            foreach (StreamVariant v in variants)
+            {
+                if (v.BandwidthBps <= ceilingBps && (best == null || v.BandwidthBps > best.BandwidthBps))
+                {
+                    best = v;
+                }
+            }
+
+            if (best != null)
+            {
+                return best;
+            }
+
+            // Nothing at or below the ceiling: fall back to the lowest available so playback can proceed.
+            StreamVariant lowest = variants[0];
+            foreach (StreamVariant v in variants.Skip(1))
+            {
+                if (v.BandwidthBps < lowest.BandwidthBps)
+                {
+                    lowest = v;
+                }
+            }
+
+            return lowest;
+        }
+    }
+}

--- a/tests/Lidarr.Plugin.Common.Tests.csproj
+++ b/tests/Lidarr.Plugin.Common.Tests.csproj
@@ -30,6 +30,8 @@
   <!-- Include golden fixture files as embedded resources -->
   <ItemGroup>
     <None Include="fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <!-- DASH manifest golden fixtures for DashManifestParser tests -->
+    <None Include="fixtures\**\*.mpd" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Services/Streaming/Manifests/DashManifestParserTests.cs
+++ b/tests/Services/Streaming/Manifests/DashManifestParserTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Lidarr.Plugin.Common.Services.Streaming.Manifests;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Golden-file tests for <see cref="DashManifestParser"/>. These assert EXACT segment counts,
+    /// ordering, <c>$Number$</c>-substituted URLs, and the parsed variant list against realistic MPD
+    /// fixtures. They are the regression guard for the two correctness invariants the shared parser
+    /// must get right (and which the two pre-consolidation Tidal parsers disagreed on):
+    /// <list type="number">
+    ///   <item><c>SegmentTimeline S@r</c> is the count of ADDITIONAL repeats, so <c>&lt;S d r=N/&gt;</c>
+    ///   yields <c>N + 1</c> segments.</item>
+    ///   <item><c>SegmentTemplate@startNumber</c> (default 1) is the <c>$Number$</c> of the FIRST media
+    ///   segment and increments thereafter (off-by-one guard).</item>
+    /// </list>
+    /// </summary>
+    public sealed class DashManifestParserTests
+    {
+        private readonly DashManifestParser _parser = new();
+
+        private static string LoadFixture(string name)
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "fixtures", "manifests", name);
+            return File.ReadAllText(path);
+        }
+
+        [Theory]
+        [InlineData("application/dash+xml")]
+        [InlineData("<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\">")]
+        [InlineData("<?xml version=\"1.0\"?>\n<MPD>")]
+        public void CanParse_RecognizesDashByMimeOrContent(string input)
+        {
+            Assert.True(_parser.CanParse(input));
+        }
+
+        [Theory]
+        [InlineData("application/vnd.apple.mpegurl")]
+        [InlineData("#EXTM3U")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CanParse_RejectsNonDash(string? input)
+        {
+            Assert.False(_parser.CanParse(input!));
+        }
+
+        // --- Fixture 1: SegmentTimeline with an r-repeat + non-1 startNumber (the off-by-one guard) ---
+
+        [Fact]
+        public void SegmentTimeline_RRepeatYieldsNPlusOne_AndHonorsStartNumber()
+        {
+            StreamManifest manifest = _parser.Parse(LoadFixture("tidal_segment_timeline.mpd"), "https://manifest.example.com/track-42/manifest.mpd");
+
+            // <S d=44100 r=2/> => 3 segments, <S d=22050 r=0/> => 1 segment => 4 media + 1 init = 5 total.
+            Assert.Equal(5, manifest.Segments.Count);
+
+            // Index 0 is the init segment (no $Number$ substitution), resolved against the <BaseURL>.
+            Assert.Equal("https://cdn.example.com/audio/track-42/init_flac_lossless.mp4", manifest.Segments[0].Url);
+            Assert.Equal(0, manifest.Segments[0].Index);
+
+            // Media segments are numbered from startNumber=5: 5,6,7,8 (zero-padded to width 6).
+            string[] expectedMedia =
+            {
+                "https://cdn.example.com/audio/track-42/seg_flac_lossless_000005.m4s",
+                "https://cdn.example.com/audio/track-42/seg_flac_lossless_000006.m4s",
+                "https://cdn.example.com/audio/track-42/seg_flac_lossless_000007.m4s",
+                "https://cdn.example.com/audio/track-42/seg_flac_lossless_000008.m4s",
+            };
+            Assert.Equal(expectedMedia, manifest.Segments.Skip(1).Select(s => s.Url).ToArray());
+
+            // Ordering / indices are contiguous 0..4.
+            Assert.Equal(new[] { 0, 1, 2, 3, 4 }, manifest.Segments.Select(s => s.Index).ToArray());
+
+            // Per-segment duration derived from d/timescale: first three are 44100/44100 = 1.0s, last is 0.5s.
+            Assert.Equal(new double?[] { null, 1.0, 1.0, 1.0, 0.5 }, manifest.Segments.Select(s => s.DurationSeconds).ToArray());
+        }
+
+        [Fact]
+        public void SegmentTimeline_SingleRepresentation_ProducesOneVariant_WithCodecAndBandwidth()
+        {
+            StreamManifest manifest = _parser.Parse(LoadFixture("tidal_segment_timeline.mpd"), "https://manifest.example.com/track-42/manifest.mpd");
+
+            StreamVariant variant = Assert.Single(manifest.Variants);
+            Assert.Equal(1129000, variant.BandwidthBps);
+            Assert.Equal("flac", variant.Codec);
+        }
+
+        [Fact]
+        public void SegmentTimeline_SurfacesWidevinePsshAndKid_AsOpaqueData_AndFlagsEncrypted()
+        {
+            StreamManifest manifest = _parser.Parse(LoadFixture("tidal_segment_timeline.mpd"), "https://manifest.example.com/track-42/manifest.mpd");
+
+            Assert.True(manifest.IsEncrypted);
+            Assert.Equal("9eb4050d-e44b-4802-932e-27d75083e266", manifest.KeyId);
+            Assert.Equal(
+                "AAAAW3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADsIARIQnrQFDeRLSAKTLifXUIPiZhoNd2lkZXZpbmVfdGVzdCIQbWFuaWZlc3RfdGVzdF9pZA==",
+                manifest.Pssh);
+            Assert.Equal("flac", manifest.Codec);
+            Assert.Equal(".m4a", manifest.FileExtension);
+        }
+
+        // --- Fixture 2: multi-Representation, duration-based SegmentTemplate (no timeline) ---
+
+        [Fact]
+        public void MultiRepresentation_ProducesVariantPerRepresentation_InOrder()
+        {
+            StreamManifest manifest = _parser.Parse(LoadFixture("amazon_multi_representation.mpd"), "https://music.example.com/dash/x/manifest.mpd");
+
+            Assert.Equal(3, manifest.Variants.Count);
+            Assert.Equal(new[] { 64000, 128000, 256000 }, manifest.Variants.Select(v => v.BandwidthBps).ToArray());
+            Assert.All(manifest.Variants, v => Assert.Equal("mp4a.40.2", v.Codec));
+        }
+
+        [Fact]
+        public void DurationBased_SegmentCountIsCeilOfTotalOverSegmentDuration_NumberedFromStartNumber()
+        {
+            StreamManifest manifest = _parser.Parse(LoadFixture("amazon_multi_representation.mpd"), "https://music.example.com/dash/x/manifest.mpd");
+
+            // Segment duration = duration/timescale = 48000/48000 = 1.0s. Total = PT20S.
+            // => ceil(20 / 1.0) = 20 media segments + 1 init = 21 total.
+            Assert.Equal(21, manifest.Segments.Count);
+
+            // Segments come from the HIGHEST-bandwidth Representation ("hi"), numbered from startNumber=1.
+            Assert.Equal("https://music.example.com/dash/x/hi/init.mp4", manifest.Segments[0].Url);
+            Assert.Equal("https://music.example.com/dash/x/hi/seg-1-256000.m4s", manifest.Segments[1].Url);
+            Assert.Equal("https://music.example.com/dash/x/hi/seg-2-256000.m4s", manifest.Segments[2].Url);
+            Assert.Equal("https://music.example.com/dash/x/hi/seg-20-256000.m4s", manifest.Segments[20].Url);
+
+            // Each 1.0s segment carries its derived duration.
+            Assert.All(manifest.Segments.Skip(1), s => Assert.Equal(1.0, s.DurationSeconds));
+
+            // Indices contiguous, init first.
+            Assert.Equal(Enumerable.Range(0, 21).ToArray(), manifest.Segments.Select(s => s.Index).ToArray());
+        }
+
+        [Fact]
+        public void MultiRepresentation_NoContentProtection_IsNotEncrypted()
+        {
+            StreamManifest manifest = _parser.Parse(LoadFixture("amazon_multi_representation.mpd"), "https://music.example.com/dash/x/manifest.mpd");
+
+            Assert.False(manifest.IsEncrypted);
+            Assert.Null(manifest.Pssh);
+            Assert.Null(manifest.KeyId);
+        }
+    }
+}

--- a/tests/Services/Streaming/Manifests/QualitySelectorTests.cs
+++ b/tests/Services/Streaming/Manifests/QualitySelectorTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Lidarr.Plugin.Common.Services.Streaming.Manifests;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Covers <see cref="QualitySelector.SelectByBandwidthCeiling"/>: highest variant at or below the
+    /// ceiling, with a lowest-variant fallback when every rendition exceeds the ceiling.
+    /// </summary>
+    public sealed class QualitySelectorTests
+    {
+        private static IReadOnlyList<StreamVariant> Variants(params int[] bandwidths)
+        {
+            var list = new List<StreamVariant>();
+            foreach (int b in bandwidths)
+            {
+                list.Add(new StreamVariant(b, $"https://example/{b}.mpd", "mp4a.40.2"));
+            }
+
+            return list;
+        }
+
+        [Fact]
+        public void PicksHighestAtOrBelowCeiling()
+        {
+            StreamVariant? chosen = QualitySelector.SelectByBandwidthCeiling(Variants(64000, 128000, 256000), 200000);
+
+            Assert.NotNull(chosen);
+            Assert.Equal(128000, chosen!.BandwidthBps);
+        }
+
+        [Fact]
+        public void CeilingExactlyMatchesAVariant_IsInclusive()
+        {
+            StreamVariant? chosen = QualitySelector.SelectByBandwidthCeiling(Variants(64000, 128000, 256000), 128000);
+
+            Assert.Equal(128000, chosen!.BandwidthBps);
+        }
+
+        [Fact]
+        public void WhenAllExceedCeiling_FallsBackToLowest()
+        {
+            StreamVariant? chosen = QualitySelector.SelectByBandwidthCeiling(Variants(256000, 320000, 1129000), 100000);
+
+            Assert.NotNull(chosen);
+            Assert.Equal(256000, chosen!.BandwidthBps);
+        }
+
+        [Fact]
+        public void CeilingAboveAll_PicksHighest()
+        {
+            StreamVariant? chosen = QualitySelector.SelectByBandwidthCeiling(Variants(64000, 128000, 256000), int.MaxValue);
+
+            Assert.Equal(256000, chosen!.BandwidthBps);
+        }
+
+        [Fact]
+        public void EmptyOrNull_ReturnsNull()
+        {
+            Assert.Null(QualitySelector.SelectByBandwidthCeiling(Array.Empty<StreamVariant>(), 100000));
+            Assert.Null(QualitySelector.SelectByBandwidthCeiling(null!, 100000));
+        }
+    }
+}

--- a/tests/fixtures/manifests/amazon_multi_representation.mpd
+++ b/tests/fixtures/manifests/amazon_multi_representation.mpd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Golden fixture: multi-Representation DASH audio manifest using a duration-based
+  SegmentTemplate (no SegmentTimeline). Shape mirrors Amazon Music's getDashManifestsV2.
+  Pins:
+    1. Variant list = one StreamVariant per Representation (3 here), with bandwidth + codec.
+    2. Duration-based segment count = ceil(mediaPresentationDuration / (duration/timescale)).
+       mediaPresentationDuration=PT20S, duration=48000, timescale=48000 => 1.0s per segment
+       => ceil(20/1) = 20 media segments + 1 init = 21 total, numbered from startNumber=1.
+    3. $Number$ (unpadded) and $Bandwidth$ substitution; relative URLs resolved against the
+       fetch base URL (no <BaseURL> element present).
+    4. No ContentProtection => IsEncrypted=false, Pssh/KeyId null.
+  Segments are generated from the HIGHEST-bandwidth Representation (hi -> bandwidth 256000).
+-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011"
+     type="static"
+     mediaPresentationDuration="PT20S"
+     minBufferTime="PT2S">
+  <Period>
+    <AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true">
+      <Representation id="lo" codecs="mp4a.40.2" bandwidth="64000" audioSamplingRate="44100">
+        <SegmentTemplate initialization="$RepresentationID$/init.mp4"
+                         media="$RepresentationID$/seg-$Number$-$Bandwidth$.m4s"
+                         timescale="48000"
+                         duration="48000"
+                         startNumber="1"/>
+      </Representation>
+      <Representation id="mid" codecs="mp4a.40.2" bandwidth="128000" audioSamplingRate="44100">
+        <SegmentTemplate initialization="$RepresentationID$/init.mp4"
+                         media="$RepresentationID$/seg-$Number$-$Bandwidth$.m4s"
+                         timescale="48000"
+                         duration="48000"
+                         startNumber="1"/>
+      </Representation>
+      <Representation id="hi" codecs="mp4a.40.2" bandwidth="256000" audioSamplingRate="48000">
+        <SegmentTemplate initialization="$RepresentationID$/init.mp4"
+                         media="$RepresentationID$/seg-$Number$-$Bandwidth$.m4s"
+                         timescale="48000"
+                         duration="48000"
+                         startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/fixtures/manifests/tidal_segment_timeline.mpd
+++ b/tests/fixtures/manifests/tidal_segment_timeline.mpd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Golden fixture: single-Representation DASH audio manifest using SegmentTimeline.
+  Designed to pin the two correctness invariants:
+    1. SegmentTimeline S@r is ADDITIONAL repeats -> <S d=.. r=N/> yields N+1 segments.
+       Here: <S d="44100" r="2"/> (=> 3) and <S d="22050" r="0"/> (=> 1) => 4 media segments.
+    2. SegmentTemplate@startNumber=5 -> first media $Number$ is 5, then 6,7,8.
+  Also exercises: init segment (index 0, no $Number$ substitution), $Number%06d$ padded
+  substitution, $RepresentationID$ substitution, relative-URL resolution against <BaseURL>,
+  and Widevine ContentProtection (cenc:pssh + cenc:default_KID) surfaced as opaque data.
+  Shape mirrors Tidal's application/dash+xml audio manifests (FLAC-in-MP4).
+-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     xmlns:cenc="urn:mpeg:cenc:2013"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011"
+     type="static"
+     minBufferTime="PT2S">
+  <Period>
+    <AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true">
+      <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"
+                         cenc:default_KID="9eb4050d-e44b-4802-932e-27d75083e266"/>
+      <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cenc:pssh>AAAAW3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADsIARIQnrQFDeRLSAKTLifXUIPiZhoNd2lkZXZpbmVfdGVzdCIQbWFuaWZlc3RfdGVzdF9pZA==</cenc:pssh>
+      </ContentProtection>
+      <BaseURL>https://cdn.example.com/audio/track-42/</BaseURL>
+      <Representation id="flac_lossless" codecs="flac" bandwidth="1129000" audioSamplingRate="44100">
+        <SegmentTemplate initialization="init_$RepresentationID$.mp4"
+                         media="seg_$RepresentationID$_$Number%06d$.m4s"
+                         timescale="44100"
+                         startNumber="5">
+          <SegmentTimeline>
+            <S t="0" d="44100" r="2"/>
+            <S d="22050" r="0"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
## What

ADDITIVE lift into Common of a **parsing-only** streaming-manifest seam plus a spec-correct MPEG-DASH parser, so plugins parse DASH manifests (Amazon's `getDashManifestsV2`; Tidal's `application/dash+xml`) through **one shared implementation** instead of each maintaining a subtly-divergent parser. **No tidal/apple migration in this PR.**

New namespace `Lidarr.Plugin.Common.Services.Streaming.Manifests` (folder convention matches `src/Services/*` → `Services.*`):

- **`IStreamManifestParser`** — `bool CanParse(string mimeTypeOrContent)` + `StreamManifest Parse(string manifestContent, string baseUrl)`. Small on purpose so an HLS parser (Apple) can slot in behind the same seam later.
- **Records** — `StreamManifest(Variants, Segments, Codec, FileExtension, IsEncrypted, KeyId, Pssh)`, `StreamVariant(BandwidthBps, Url, Codec?)`, `StreamSegment(Index, Url, DurationSeconds?)`.
- **`DashManifestParser : IStreamManifestParser`** — MPD XML → AdaptationSet/Representation variants; `SegmentTemplate` (`$Number$`/`$RepresentationID$`/`$Bandwidth$`/padded `$Number%0Nd$`) + `SegmentTimeline` (`<S t d r>`) **and** duration-based templates → ordered segments; relative-URL resolution against `baseUrl` + `<BaseURL>`; Widevine `ContentProtection` `cenc:pssh` / `cenc:default_KID` surfaced as **opaque data** (sets `IsEncrypted`).
- **`QualitySelector.SelectByBandwidthCeiling`** — highest variant ≤ ceiling, else lowest.

### Parsing-only, no circumvention
Reading a manifest is reading a playlist (enumerates segment URLs like `.m3u8`/`.mpd`). This PR adds **no decrypt, no key derivation, and no CDM/license logic** — PSSH/KeyId are exposed only as data. Decryption stays out-of-tree behind the existing `IExternalDownloadHandler` (DRM) seam.

## Correctness (the off-by-one this guards against)

Per DASH spec (ISO/IEC 23009-1):
- `SegmentTimeline` `S@r` = count of **additional** repeats → `<S d r=N/>` yields **N+1** segments.
- `SegmentTemplate@startNumber` (default 1) = `$Number$` of the **first** media segment; increments thereafter.

**Tidalarr finding:** both existing Tidal DASH parsers already compute the `r` repeat as `r+1` (`TidalManifestParser.cs:192`; `TidalStreamManifest.cs:137-138` — its `1+r` comment is a no-op since `1+r == r+1`). The **real divergence is `startNumber`**: `TidalManifestParser.cs:189` hardcodes `number = 1` and **ignores `@startNumber`** (off-by-one when `startNumber != 1`), whereas `TidalStreamManifest.cs:114,132` reads `@startNumber` and is **spec-correct**. `DashManifestParser` implements the spec-correct behavior.

## Golden-file fixtures (the regression guard)

- `tests/fixtures/manifests/tidal_segment_timeline.mpd` — SegmentTimeline with `r=2` repeat + `startNumber=5` + init segment + Widevine pssh/KID. Asserts **exactly 5 segments**, media `$Number$` = `5,6,7,8` (padded `_000005` … `_000008`), correct ordering/indices, per-segment durations, a single variant (`flac`, 1129000 bps), and `IsEncrypted` + exact KID/PSSH.
- `tests/fixtures/manifests/amazon_multi_representation.mpd` — 3 Representations + duration-based template (`PT20S` / 1.0s segments) + relative URLs (no `<BaseURL>`). Asserts **3 variants** (64k/128k/256k, `mp4a.40.2`), `ceil(20/1)=20`+init = **21 segments** numbered from `startNumber=1` off the highest-bandwidth rendition, resolved against the fetch base URL, and **not encrypted**.

18 new tests (DASH golden-file + `QualitySelector`). 452 pass across the Streaming/Drm suites (incl. these).

## Verification
- `dotnet build` (solution, Release): clean, 0 errors.
- `dotnet format src/Lidarr.Plugin.Common.csproj analyzers --verify-no-changes --diagnostics RS0016,RS0017 -p:TargetFramework=net8.0`: **no changes** (baseline exact).
- `PublicAPI.Unshipped.txt` updated for **net8.0 and net6.0**.

## Open-PR conflict check
`gh pr list --state open` — none of the open PRs touch `src/Services/Streaming/Manifests/**` or the new test/fixture files (all-new). PR #575 (net6 retirement) deletes the net6.0 PublicAPI files; if #575 merges first, the net6.0 `PublicAPI.Unshipped.txt` hunk here drops out cleanly (net8.0 is unaffected). No conflict otherwise.

## Migration surface (LATER task — NOT in this PR)
- **tidalarr**: collapse `TidalManifestParser` + `TidalStreamManifest` DASH paths onto `DashManifestParser` (also fixes the `startNumber` off-by-one in `TidalManifestParser`). Tidal's BTS path stays plugin-side.
- **applemusicarr**: add an HLS `IStreamManifestParser` behind the same seam.
- Add an `EcosystemParityTestBase` guard asserting plugins parse DASH via Common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)