### PR TITLE
docs(wiki): plugin-author wiki for Lidarr.Plugin.Common (orientation layer)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -160,7 +160,17 @@
     "normalise",
     "Normalise",
     "synchronisation",
-    "alikes"
+    "alikes",
+    "initialising",
+    "optimise",
+    "optimisation",
+    "standardised",
+    "enumerables",
+    "sanitising",
+    "sanitises",
+    "serialisation",
+    "reloadable",
+    "retriable"
   ],
   "ignorePaths": [
     "**/bin",

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -1,0 +1,42 @@
+# Architecture Overview
+
+This page is the orientation map for plugin authors.
+It tells you **what exists and where to find it** — for the details, follow the links.
+
+## AssemblyLoadContext Isolation
+
+Each plugin loads Common inside its own `AssemblyLoadContext`, so multiple plugins never share types or state.
+The host owns the ABI surface via the **Lidarr.Plugin.Abstractions** assembly — everything a plugin sees crosses that boundary.
+
+- How isolation works and why: [PLUGIN_ISOLATION.md](../docs/PLUGIN_ISOLATION.md)
+- Multi-plugin ALC validation and edge cases: [MULTI_PLUGIN_ALC_VALIDATION.md](../docs/MULTI_PLUGIN_ALC_VALIDATION.md)
+- Key types: [`PluginLoadContext`](../src/Abstractions/Hosting/PluginLoadContext.cs), [`PluginHandle`](../src/Abstractions/Hosting/PluginHandle.cs)
+
+## Bridge / Runtime Model
+
+The **HostBridge** layer mediates between the host process and the plugin's isolated context.
+A plugin author typically extends [`StreamingPlugin<TModule, TSettings>`](../src/Hosting/StreamingPlugin.cs) (the abstract base that wires up DI, settings, and lifecycle) and optionally [`HostBridgeRuntimeCache<TRuntime, TSettings>`](../src/HostBridge/HostBridgeRuntimeCache.cs).
+
+Orchestration and download tracking live in [`HostBridgeDownloadOrchestrator`](../src/HostBridge/HostBridgeDownloadOrchestrator.cs) and [`HostBridgeDownloadTracker`](../src/HostBridge/HostBridgeDownloadTracker.cs).
+
+- Full bridge contract and flow: [PLUGIN_BRIDGE.md](../docs/PLUGIN_BRIDGE.md)
+- End-to-end message flow diagrams: [Flow.md](../docs/Flow.md)
+- Lifecycle helpers: [`PluginLifecycle`](../src/Hosting/PluginLifecycle.cs)
+
+## Where Things Live
+
+| Area | Directory | Purpose |
+|---|---|---|
+| **Abstractions** | `src/Abstractions/` | Host-owned contracts (`IPlugin`, `IPluginContext`, manifest types, result types). Shipped as a separate assembly the host loads directly. |
+| **Base** | `src/Base/` | Abstract bases for plugin implementations ([`BaseStreamingIndexer<T>`](../src/Base/BaseStreamingIndexer.cs), [`BaseStreamingDownloadClient<T>`](../src/Base/BaseStreamingDownloadClient.cs)). |
+| **HostBridge** | `src/HostBridge/` | Runtime bridge — orchestration, download tracking, URI helpers, path-traversal guard. |
+| **Hosting** | `src/Hosting/` | Plugin entry point ([`StreamingPlugin`](../src/Hosting/StreamingPlugin.cs)), lifecycle, settings binder. |
+| **Providers** | `src/Providers/` | LLM provider integrations (e.g. `ClaudeCode`). |
+| **Resilience** | `src/Resilience/` | Backend health caching and retry policies. |
+| **Security** | `src/Security/` | Credential management, token protection, sanitization. |
+| **Services** | `src/Services/` | Cross-cutting services — authentication, caching, deduplication, download, DRM, HTTP, metadata, quality, validation, and more. |
+| **Streaming** | `src/Streaming/` | SSE framing, stream decoders, timeout/cancellation policies. |
+| **Testing** | `src/Testing/` | Mock factories for unit-testing plugins. |
+
+- Complete architecture status and module inventory: [ARCHITECTURE_STATUS.md](../docs/ARCHITECTURE_STATUS.md)
+- Abstractions surface catalogue: [ABSTRACTIONS.md](../docs/ABSTRACTIONS.md)

--- a/wiki/CI-and-Packaging.md
+++ b/wiki/CI-and-Packaging.md
@@ -1,0 +1,41 @@
+# CI and Packaging
+
+Plugin builds are packaged by **PluginPack.psm1** and driven through reusable GitHub Actions workflows. This page points you to the right tools and docs.
+
+## Packaging module
+
+[`tools/PluginPack.psm1`](../tools/PluginPack.psm1) is the PowerShell module that standardises every plugin release. Its main entry point is `New-PluginPackage`, which orchestrates building, manifest validation, host-assembly stripping, and ZIP packaging. Other exported functions — `Get-PluginOutput`, `Test-PluginManifest`, `Invoke-PluginCleanup`, `Invoke-PluginMerge`, `Install-CanonicalAbstractions`, `Assert-CanonicalAbstractions` — can be called individually for advanced scenarios.
+
+A copy is shipped inside the NuGet package at `ext/Lidarr.Plugin.Common/tools/PluginPack.psm1`.
+
+Full usage details and the recommended folder-based flow → [**Packaging Plugins**](../docs/PACKAGING.md).
+
+## Reusable workflows
+
+Common ships several reusable workflow definitions under `.github/workflows/`:
+
+| Workflow | Purpose |
+|---|---|
+| `release-plugin.yml` | Build, package, and publish a plugin release |
+| `codeql-reusable.yml` | CodeQL security analysis |
+| `quarantine-review-reusable.yml` | Quarantine-gate review |
+| `multi-plugin-smoke-test.yml` | Multi-plugin integration smoke test |
+
+Plugin repos call these via `uses: ./.github/workflows/<name>.yml` after initialising the Common submodule.
+
+Proposal details and calling conventions → [**CI Reusable Workflows**](../docs/CI_REUSABLE_WORKFLOWS.md).
+
+## SHA-pinning policy
+
+All references to Common workflows **must** use a pinned commit SHA, not a branch tag. Enforcement is automated:
+
+- [`verify-common-pins.yml`](../.github/workflows/verify-common-pins.yml) — CI check that fails on unpinned references.
+- [`lint-workflow-sha-pins.ps1`](../scripts/lint-workflow-sha-pins.ps1) — local linter for the same rule.
+- [`repin-common-submodule.ps1`](../scripts/repin-common-submodule.ps1) — updates the submodule and rewrites all workflow pins in one step.
+- [`ecosystem-pin-drift.yml`](../.github/workflows/ecosystem-pin-drift.yml) — cross-repo monitor ensuring all plugins share the same pinned SHA.
+
+Full inventory of pinned actions and the allowlist mechanism → [**CI SHA Pins**](../docs/CI_SHA_PINS.md).
+
+## CI lane strategy
+
+Workflows are split into fast PR-required lanes and expensive nightly-only lanes to optimise CI billing. The lane definitions and rationale → [**CI Lane Strategy**](../docs/CI_LANE_STRATEGY.md).

--- a/wiki/Ecosystem-Parity-and-Guards.md
+++ b/wiki/Ecosystem-Parity-and-Guards.md
@@ -1,0 +1,31 @@
+# Ecosystem Parity and Guards
+
+`lidarr.plugin.common` is the single source of truth for every shared concern across the plugin ecosystem (Tidalarr, Qobuzarr, AppleMusicarr, Brainarr). Parity — the guarantee that all plugins follow the same canonical patterns — is enforced mechanically through guard tests shipped in Common's testkit, not by convention alone.
+
+## How parity is tracked
+
+- **[Ecosystem Parity Matrix](../docs/ECOSYSTEM_PARITY_MATRIX.md)** — the single source of truth for per-plugin, per-concern adoption status (packaging, auth lifecycle, concurrency, E2E gates, etc.). Every cell links to source evidence.
+- **[Ecosystem Parity Roadmap](../docs/ECOSYSTEM_PARITY_ROADMAP.md)** — current progress toward full structural and behavioral parity, with notes on architecturally-applicable divergences (e.g. AppleMusicarr is metadata-only, so download orchestration axes are N/A).
+
+## How parity is enforced
+
+Common ships an abstract test base that each plugin repo inherits and runs in CI. The guards live in `testkit/Compliance/`:
+
+- [`EcosystemParityTestBase`](../testkit/Compliance/EcosystemParityTestBase.cs) — structural parity checks (correct DI registrations, no forbidden types, file-to-class naming conventions).
+- [`EcosystemParityTestBase.BehaviorContracts`](../testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs) — behavioral parity checks (no plugin-local forks of Common interfaces, correct shutdown registration, allowed token-store patterns).
+
+Common's own repo exercises these bases in `tests/Compliance/`:
+
+- [`EcosystemParityTestBaseExtensionTests`](../tests/Compliance/EcosystemParityTestBaseExtensionTests.cs) — validates the harness itself with fixture types.
+- [`ParityFixtures_CommonNamespace`](../tests/Compliance/ParityFixtures_CommonNamespace.cs) — internalized fixture types used by the extension tests.
+
+## Promotion and version contract
+
+Before a new Common release propagates to all plugins:
+
+- **[Ecosystem Promotion Checklist](../docs/ECOSYSTEM_PROMOTION_CHECKLIST.md)** — the per-plugin verification matrix (submodule bump, build, runtime sandbox, full test suite).
+- **[Ecosystem Version Contract](../docs/ECOSYSTEM_VERSION_CONTRACT.md)** — machine-checkable invariants encoded in `scripts/parity-spec.json` and enforced by `ecosystem-parity-lint.ps1` in CI.
+
+## Summary
+
+For plugin authors: if Common already solves a problem, use Common's implementation — the parity guards will catch drift. Start with the [Parity Matrix](../docs/ECOSYSTEM_PARITY_MATRIX.md) to see what is covered, and inherit `EcosystemParityTestBase` in your plugin's test project to run the same checks locally.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,37 @@
+# Lidarr.Plugin.Common — Wiki
+
+**Lidarr.Plugin.Common** is the shared library that underpins the RicherTunes Lidarr streaming/AI plugins — Qobuzarr, Tidalarr, Applemusicarr, and Brainarr.
+It ships resilience policies, HTTP helpers, bridge contracts, packaging tooling, and a TestKit so every plugin follows the same canonical patterns.
+Each plugin carries its own copy of Common inside a private AssemblyLoadContext; the host-owned ABI lives in `Lidarr.Plugin.Abstractions`.
+
+This wiki is for **plugin authors** building on Common.
+Its job is orientation — what exists, where to find it, and where the canonical docs live.
+
+## Wiki pages
+
+| Page | Scope |
+|------|-------|
+| [Architecture Overview](./Architecture-Overview.md) | ALC isolation, bridge runtime, layer diagram |
+| [SDK and Extension Points](./SDK-and-Extension-Points.md) | `StreamingPlugin<TModule,TSettings>`, DI seams, provider interfaces |
+| [Shared Helpers Catalog](./Shared-Helpers-Catalog.md) | Resilience, HTTP defaults, collections, validation, diagnostics |
+| [Ecosystem Parity and Guards](./Ecosystem-Parity-and-Guards.md) | Parity matrix, promotion checklist, drift enforcement |
+| [Versioning and Submodule Pinning](./Versioning-and-Submodule-Pinning.md) | Version contract, submodule workflow, upgrade checklist |
+| [Testing with the TestKit](./Testing-with-the-TestKit.md) | TestKit fixtures, HTTP handlers, ALC harness |
+| [CI and Packaging](./CI-and-Packaging.md) | `PluginPack.psm1`, reusable workflows, SHA pins |
+
+## Key references
+
+All links point to canonical documentation in `docs/`:
+
+- [FAQ for Plugin Authors](../docs/FAQ_FOR_PLUGIN_AUTHORS.md) — common pitfalls (duplicate assemblies, API baselining, NuGet feeds).
+- [Architecture Status](../docs/ARCHITECTURE_STATUS.md) — bridge-runtime migration baseline and current state.
+- [Abstractions](../docs/ABSTRACTIONS.md) — host-owned ABI (`IPlugin`, `IIndexer`, `IDownloadClient`).
+- [Plugin Bridge](../docs/PLUGIN_BRIDGE.md) — `StreamingPlugin<TModule,TSettings>` quickstart and extension model.
+- [Plugin Isolation](../docs/PLUGIN_ISOLATION.md) — how plugins load inside dedicated AssemblyLoadContexts.
+- [Glossary](../docs/GLOSSARY.md) — shared terminology across the ecosystem.
+- [Ecosystem Parity Matrix](../docs/ECOSYSTEM_PARITY_MATRIX.md) — single source of truth for cross-plugin pattern parity.
+- [Ecosystem Version Contract](../docs/ECOSYSTEM_VERSION_CONTRACT.md) — version-coordination rules and `commonVersion` enforcement.
+- [Testing with the TestKit](../docs/TESTING_WITH_TESTKIT.md) — fixtures, HTTP handlers, manifest helpers.
+- [Packaging](../docs/PACKAGING.md) — `PluginPack.psm1` standardised publish flow.
+- [Compatibility](../docs/COMPATIBILITY.md) — supported Common / Abstractions / host version combinations.
+- [Upgrading](../docs/UPGRADING.md) — per-release bump checklist for downstream plugin repos.

--- a/wiki/SDK-and-Extension-Points.md
+++ b/wiki/SDK-and-Extension-Points.md
@@ -1,0 +1,123 @@
+# SDK and Extension Points
+
+This page maps the types a plugin author **implements or extends** to build on Common.
+It links to source and canonical docs — it does not restate them.
+
+Start at [Plugin Registration](#plugin-registration) and branch out by capability.
+
+For the host-owned ABI contracts and cross-ALC boundary rules, see
+[Abstractions](../docs/ABSTRACTIONS.md).
+
+## Plugin Registration
+
+These types form the entry point every plugin must satisfy.
+
+| Type | Purpose | Source / Doc |
+|------|---------|-------------|
+| `IPlugin` | Host-facing contract — manifest, initialization, factory methods for indexer/download client. | [ABSTRACTIONS.md](../docs/ABSTRACTIONS.md) &middot; [IPlugin.cs](../src/Abstractions/Contracts/IPlugin.cs) |
+| `StreamingPlugin<TModule, TSettings>` | Base `IPlugin` implementation that wires DI, manifest loading, and strongly typed settings. Derive from this to focus on domain logic. | [PLUGIN_BRIDGE.md](../docs/PLUGIN_BRIDGE.md) &middot; [StreamingPlugin.cs](../src/Hosting/StreamingPlugin.cs) |
+| `StreamingPluginModule` | Abstract base for declaring service registrations, capabilities, and metadata. Consumed by `StreamingPlugin<TModule, TSettings>`. | [StreamingPluginModule.cs](../src/Services/Registration/StreamingPluginModule.cs) |
+| `PluginManifest` | Immutable metadata loaded from `plugin.json` (id, version, apiVersion, capabilities, compatibility checks). | [PLUGIN_MANIFEST.md](../docs/PLUGIN_MANIFEST.md) &middot; [PluginManifest.cs](../src/Abstractions/Manifest/PluginManifest.cs) |
+| `PluginCapability` | Flags enum a module advertises (indexer, download client, caching, OAuth, hi-res audio, etc.). | [PluginCapability.cs](../src/Abstractions/Capabilities/PluginCapability.cs) |
+
+## Indexer — Search and Discovery
+
+Implement these to expose search/indexing to the host.
+
+| Type | Purpose | Source / Doc |
+|------|---------|-------------|
+| `IIndexer` | Core search contract — album/track search, streaming enumerables, album lookup by id. | [ABSTRACTIONS.md](../docs/ABSTRACTIONS.md) &middot; [IIndexer.cs](../src/Abstractions/Contracts/IIndexer.cs) |
+| `IIndexerWithMetadata` | Extends `IIndexer` with protocol, page size, service name, and RSS support flag for host UI routing. | [IIndexer.cs:50](../src/Abstractions/Contracts/IIndexer.cs) |
+| `BaseStreamingIndexer<TSettings>` | Shared base: authentication, request building, pagination helpers, deduplication, performance monitoring. Override abstract members for service-specific behaviour. | [BaseStreamingIndexer.cs](../src/Base/BaseStreamingIndexer.cs) |
+| `IIndexerRequestBuilder` | Optional seam to decompose request construction. | [IIndexerRequestBuilder.cs](../src/Abstractions/Contracts/IIndexerRequestBuilder.cs) |
+| `IIndexerResponseParser<T>` | Optional seam to decompose response parsing. | [IIndexerResponseParser.cs](../src/Abstractions/Contracts/IIndexerResponseParser.cs) |
+| `IIndexerStatusReporter` | Reports indexer health/state back to the host. | [IIndexerStatusReporter.cs](../src/Abstractions/Contracts/IIndexerStatusReporter.cs) |
+| `IRateLimitReporter` | Reports rate-limit status back to the host. | [IRateLimitReporter.cs](../src/Abstractions/Contracts/IRateLimitReporter.cs) |
+| `IRssFeedProvider` | Optional RSS feed capability for indexers that support it. | [IRssFeedProvider.cs](../src/Abstractions/Contracts/IRssFeedProvider.cs) |
+| `StreamingIndexerHelpers` | Static helpers for indexer operations (paging, normalization). | [StreamingIndexerHelpers.cs](../src/Base/StreamingIndexerHelpers.cs) |
+
+## Download Client — Fetching Content
+
+Implement these to handle download orchestration.
+
+| Type | Purpose | Source / Doc |
+|------|---------|-------------|
+| `IDownloadClient` | Host-facing contract — enqueue, remove, and query downloads. | [ABSTRACTIONS.md](../docs/ABSTRACTIONS.md) &middot; [IDownloadClient.cs](../src/Abstractions/Contracts/IDownloadClient.cs) |
+| `BaseStreamingDownloadClient<TSettings>` | Shared base: concurrency control, retry logic with resume, metadata tagging, progress tracking. | [BaseStreamingDownloadClient.cs](../src/Base/BaseStreamingDownloadClient.cs) |
+| `IStreamingDownloadOrchestrator` | Plugin-internal seam for coordinating album/track downloads and quality selection. | [IStreamingTokenProvider.cs:60](../src/Interfaces/IStreamingTokenProvider.cs) |
+| `IDownloadStatusReporter` | Reports download progress/state back to the host. | [IDownloadStatusReporter.cs](../src/Abstractions/Contracts/IDownloadStatusReporter.cs) |
+
+## Authentication and Tokens
+
+Plug in auth flows and token lifecycle.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `IAuthFailureHandler` | Propagates auth failures to the host for UI notification; reports status and recovery. | [IAuthFailureHandler.cs](../src/Abstractions/Contracts/IAuthFailureHandler.cs) |
+| `IStreamingAuthenticationService<TSession, TCredentials>` | Generic auth service with session and credential types. | [IStreamingAuthenticationService.cs](../src/Interfaces/IStreamingAuthenticationService.cs) |
+| `IStreamingTokenProvider` | Access/refresh token lifecycle, validation, and cache clearing. | [IStreamingTokenProvider.cs](../src/Interfaces/IStreamingTokenProvider.cs) |
+| `ITokenStore<TSession>` | Persistent storage for token sessions. | [ITokenStore.cs](../src/Interfaces/ITokenStore.cs) |
+| `ITokenProtector` | Encrypts/decrypts token data at rest. | [ITokenProtector.cs](../src/Interfaces/ITokenProtector.cs) |
+| `IStringProtector` | General-purpose string encryption (DPAPI-style). | [IStringProtector.cs](../src/Interfaces/IStringProtector.cs) |
+
+## HTTP and Resilience
+
+Seams for signing, caching, and rate-limiting HTTP calls.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `IHttpRequestSigner` | Request-level signing seam for APIs whose auth is computed over the fully-built request. | [IHttpRequestSigner.cs](../src/Services/Http/IHttpRequestSigner.cs) |
+| `ICachePolicyProvider` | Supplies cache policies for upstream API responses. | [ICachePolicyProvider.cs](../src/Interfaces/ICachePolicyProvider.cs) |
+| `IStreamingResponseCache` | Caches streaming API responses. | [IStreamingResponseCache.cs](../src/Interfaces/IStreamingResponseCache.cs) |
+| `IConditionalRequestState` | Manages ETag / Last-Modified conditional-request state. | [IConditionalRequestState.cs](../src/Interfaces/IConditionalRequestState.cs) |
+| `IRateLimitObserver` | Observes and reacts to upstream rate-limit signals. | [IRateLimitObserver.cs](../src/Interfaces/IRateLimitObserver.cs) |
+
+## Audio Pipeline
+
+Hooks for audio stream handling, post-processing, and metadata.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `IAudioStreamProvider` | Provides audio streams for download. | [IAudioStreamProvider.cs](../src/Interfaces/IAudioStreamProvider.cs) |
+| `IAudioPostProcessor` | Post-download audio processing hook. | [IAudioPostProcessor.cs](../src/Interfaces/IAudioPostProcessor.cs) |
+| `IAudioMetadataApplier` | Applies metadata tags to downloaded files (consumed by `BaseStreamingDownloadClient`). | [IAudioMetadataApplier.cs](../src/Interfaces/IAudioMetadataApplier.cs) |
+
+## LLM Integration
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `ILlmProvider` | Core abstraction for LLM providers (streaming, tool calls, usage tracking). | [ILlmProvider.cs](../src/Abstractions/Llm/ILlmProvider.cs) |
+
+## Host Bridge
+
+Types that span the plugin/host boundary. See [PLUGIN_BRIDGE.md](../docs/PLUGIN_BRIDGE.md) for the full bridge model.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `HostBridgeRuntimeCache<TRuntime, TSettings>` | Abstract base for runtime caching across the plugin/host boundary. | [HostBridgeRuntimeCache.cs](../src/HostBridge/HostBridgeRuntimeCache.cs) |
+| `HostBridgeDownloadOrchestrator` | Coordinates downloads across the bridge. | [HostBridgeDownloadOrchestrator.cs](../src/HostBridge/HostBridgeDownloadOrchestrator.cs) |
+| `HostBridgeDownloadTrackerStore<TItem>` | Tracks download items in bridge storage. | [HostBridgeDownloadTracker.cs](../src/HostBridge/HostBridgeDownloadTracker.cs) |
+| `AlbumReleaseInfoBuilder` | Builds album release info for the host. | [AlbumReleaseInfoBuilder.cs](../src/HostBridge/AlbumReleaseInfoBuilder.cs) |
+| `AlbumDownloadUri` | Static helper for building album download URIs. | [AlbumDownloadUri.cs](../src/HostBridge/AlbumDownloadUri.cs) |
+| `PrefixedReleaseGuidParser` | Static helper for parsing prefixed release GUIDs. | [PrefixedReleaseGuidParser.cs](../src/HostBridge/PrefixedReleaseGuidParser.cs) |
+| `PathTraversalGuard` | Static guard against path-traversal attacks in bridge paths. | [PathTraversalGuard.cs](../src/HostBridge/PathTraversalGuard.cs) |
+| `PlaceholderSearchUri` | Static helper for placeholder search URIs. | [PlaceholderSearchUri.cs](../src/HostBridge/PlaceholderSearchUri.cs) |
+
+## Settings
+
+| Type | Purpose | Source / Doc |
+|------|---------|-------------|
+| `BaseStreamingSettings` | Abstract base with common properties (BaseUrl, auth fields, rate limit, caching, locale). Derive for service-specific settings. | [BaseStreamingSettings.cs](../src/Base/BaseStreamingSettings.cs) |
+| `ISettingsProvider` | Host-facing settings operations (describe, validate, apply). | [SETTINGS_PROVIDER.md](../docs/SETTINGS_PROVIDER.md) &middot; [ISettingsProvider.cs](../src/Abstractions/Contracts/ISettingsProvider.cs) |
+| `IPluginContext` | Runtime context provided to the plugin during initialization. | [IPluginContext.cs](../src/Abstractions/Contracts/IPluginContext.cs) |
+
+## Related Docs
+
+- [Plugin Bridge](../docs/PLUGIN_BRIDGE.md) — `StreamingPlugin<TModule,TSettings>` quickstart and extension model.
+- [Plugin Manifest](../docs/PLUGIN_MANIFEST.md) — manifest schema and compatibility checks.
+- [Plugin Isolation](../docs/PLUGIN_ISOLATION.md) — how plugins load inside dedicated AssemblyLoadContexts.
+- [Abstractions](../docs/ABSTRACTIONS.md) — host-owned ABI (`IPlugin`, `IIndexer`, `IDownloadClient`).
+- [Streaming Support](../docs/STREAMING_SUPPORT.md) — streaming feature coverage.
+- [Testing with the TestKit](../docs/TESTING_WITH_TESTKIT.md) — fixtures, HTTP handlers, manifest helpers.
+- [FAQ for Plugin Authors](../docs/FAQ_FOR_PLUGIN_AUTHORS.md) — common pitfalls and patterns.
+- [Glossary](../docs/GLOSSARY.md) — shared terminology.

--- a/wiki/Shared-Helpers-Catalog.md
+++ b/wiki/Shared-Helpers-Catalog.md
@@ -1,0 +1,313 @@
+# Shared Helpers Catalog
+
+Quick-reference catalog of the reusable helpers in **Lidarr.Plugin.Common** that a plugin author consumes.
+Each entry is a one-line purpose and a link to its source; full details live in the linked docs and code.
+
+For architecture context, see [Architecture Overview](Architecture-Overview.md) and the
+[doc hub](../docs/README.md).
+
+---
+
+## Security
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `PathTraversalGuard` | Blocks directory-traversal attacks in download paths | [`HostBridge/PathTraversalGuard.cs`](../src/HostBridge/PathTraversalGuard.cs) |
+| `Sanitize` | Static helpers for sanitising user-supplied strings | [`Security/Sanitize.cs`](../src/Security/Sanitize.cs) |
+| `SecureMemory` | Pin and clear cryptographic key material from the GC heap | [`Security/SecureMemory.cs`](../src/Security/SecureMemory.cs) |
+| `SecureCredentialManager` | Holds and disposes credentials in pinned memory | [`Security/SecureCredentialManager.cs`](../src/Security/SecureCredentialManager.cs) |
+| `TokenProtectorFactory` | Creates the platform-appropriate `ITokenProtector` (DPAPI / Keychain / SecretService) | [`Security/TokenProtection/TokenProtectorFactory.cs`](../src/Security/TokenProtection/TokenProtectorFactory.cs) |
+| `LlmPromptSanitizer` | Strips sensitive data from LLM prompts before logging | [`Security/Llm/LlmPromptSanitizer.cs`](../src/Security/Llm/LlmPromptSanitizer.cs) |
+| `LlmJsonSerializer` | Deterministic JSON serialisation with PII redaction for LLM payloads | [`Security/Llm/LlmJsonSerializer.cs`](../src/Security/Llm/LlmJsonSerializer.cs) |
+
+See also: [Security Hardening Overview](../docs/SECURITY_HARDENING_OVERVIEW.md),
+[COM-005/COM-011 Remediation](../docs/SECURITY/COM-005-COM-011-REMEDIATION.md),
+[Phase 3.1 — SecureMemory](../docs/SECURITY/COMMON-HELPERS-PHASE-3-1.md).
+
+---
+
+## Resilience
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `ICircuitBreaker` | Circuit-breaker contract with state-change events | [`Services/Resilience/ICircuitBreaker.cs`](../src/Services/Resilience/ICircuitBreaker.cs) |
+| `CircuitBreaker` | Count-based circuit-breaker implementation | [`Services/Resilience/CircuitBreaker.cs`](../src/Services/Resilience/CircuitBreaker.cs) |
+| `AdvancedCircuitBreaker` | Adaptive circuit-breaker with per-endpoint health tracking | [`Services/Resilience/AdvancedCircuitBreaker.cs`](../src/Services/Resilience/AdvancedCircuitBreaker.cs) |
+| `IRetryPolicy` / `ExponentialBackoffRetryPolicy` | Retry policy with configurable back-off | [`Services/Resilience/RetryPolicy.cs`](../src/Services/Resilience/RetryPolicy.cs) |
+| `DefensiveServiceWrapper<T>` | Wraps a service so every call is guarded by retry + circuit-breaker | [`Services/Resilience/DefensiveServiceWrapper.cs`](../src/Services/Resilience/DefensiveServiceWrapper.cs) |
+| `IResilienceSettingsProvider` | Named resilience profiles ("auth", "search", "download", etc.) | [`Services/Resilience/IResilienceSettingsProvider.cs`](../src/Services/Resilience/IResilienceSettingsProvider.cs) |
+| `StaticResiliencePolicyProvider` | Hard-coded profile map for simple plugins | [`Services/Resilience/StaticResiliencePolicyProvider.cs`](../src/Services/Resilience/StaticResiliencePolicyProvider.cs) |
+| `FileResiliencePolicyProvider` | Hot-reloadable profiles from a JSON file | [`Services/Resilience/FileResiliencePolicyProvider.cs`](../src/Services/Resilience/FileResiliencePolicyProvider.cs) |
+| `BackendHealthCache` | Marks a backend host as "down" after connection-class failures | [`Resilience/BackendHealthCache.cs`](../src/Resilience/BackendHealthCache.cs) |
+| `TokenBucketRateLimiter` | Token-bucket rate limiter with presets | [`Services/Resilience/TokenBucketRateLimiter.cs`](../src/Services/Resilience/TokenBucketRateLimiter.cs) |
+| `RequestDeduplicator` | Coalesces identical concurrent requests into a single flight | [`Services/Deduplication/RequestDeduplicator.cs`](../src/Services/Deduplication/RequestDeduplicator.cs) |
+| `NetworkResilienceService` | Batch operations with adaptive retries and network-health monitoring | [`Services/Network/NetworkResilienceService.cs`](../src/Services/Network/NetworkResilienceService.cs) |
+
+---
+
+## HTTP Pipeline
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `PluginHttpOptions` | Named HTTP client options constants for DI registration | [`Services/Http/PluginHttpOptions.cs`](../src/Services/Http/PluginHttpOptions.cs) |
+| `DefaultProfiles` | Pre-built resilience profiles for standard HTTP operations | [`Services/Http/DefaultProfiles.cs`](../src/Services/Http/DefaultProfiles.cs) |
+| `CachingHttpExecutor` | Executes HTTP requests with ETag/Last-Modified revalidation | [`Services/Http/CachingHttpExecutor.cs`](../src/Services/Http/CachingHttpExecutor.cs) |
+| `BackendHealthDelegatingHandler` | `DelegatingHandler` that short-circuits when the backend is marked down | [`Services/Http/BackendHealthDelegatingHandler.cs`](../src/Services/Http/BackendHealthDelegatingHandler.cs) |
+| `AdaptiveRateLimitingHandler` | `DelegatingHandler` that throttles requests based on 429 headers | [`Services/Http/AdaptiveRateLimitingHandler.cs`](../src/Services/Http/AdaptiveRateLimitingHandler.cs) |
+| `DiagnosticTapHandler` | `DelegatingHandler` that logs request/response telemetry | [`Services/Http/DiagnosticTapHandler.cs`](../src/Services/Http/DiagnosticTapHandler.cs) |
+| `ContentDecodingSnifferHandler` | Detects and decompresses mislabeled content encodings | [`Services/Http/ContentDecodingSnifferHandler.cs`](../src/Services/Http/ContentDecodingSnifferHandler.cs) |
+| `HttpResponseHelpers` | Static helpers for reading and validating HTTP responses | [`Services/Http/HttpResponseHelpers.cs`](../src/Services/Http/HttpResponseHelpers.cs) |
+| `OAuthDelegatingHandler` | `DelegatingHandler` that injects OAuth bearer tokens | [`Services/Http/OAuthDelegatingHandler.cs`](../src/Services/Http/OAuthDelegatingHandler.cs) |
+| `IRequestSigner` | Signs a parameter dictionary (e.g. Qobuz MD5 concat) | [`Utilities/RequestSigning.cs`](../src/Utilities/RequestSigning.cs) |
+| `IHttpRequestSigner` | Signs a fully-built `HttpRequestMessage` (e.g. ADP RSA-SHA256) | [`Services/Http/IHttpRequestSigner.cs`](../src/Services/Http/IHttpRequestSigner.cs) |
+
+See also: [HTTP Defaults](../docs/HTTPDefaults.md), [HTTP Flow](../docs/Flow.md).
+
+---
+
+## Authentication & Tokens
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `BaseStreamingAuthenticationService<T,S>` | Template-method base for streaming-service auth flows | [`Services/Authentication/BaseStreamingAuthenticationService.cs`](../src/Services/Authentication/BaseStreamingAuthenticationService.cs) |
+| `OAuthStreamingAuthenticationService<T,S>` | OAuth 2.0 + PKCE authentication base class | [`Services/Authentication/OAuthStreamingAuthenticationService.cs`](../src/Services/Authentication/OAuthStreamingAuthenticationService.cs) |
+| `StreamingTokenManager<T,S>` | Manages token lifecycle (acquire, refresh, revoke) | [`Services/Authentication/StreamingTokenManager.cs`](../src/Services/Authentication/StreamingTokenManager.cs) |
+| `FileTokenStore<T>` | Persisted, encrypted token store backed by a JSON file | [`Services/Authentication/FileTokenStore.cs`](../src/Services/Authentication/FileTokenStore.cs) |
+| `AuthFailureGate` | Latches auth failures so downstream code sees a consistent "auth broken" state | [`Services/Bridge/AuthFailureGate.cs`](../src/Services/Bridge/AuthFailureGate.cs) |
+| `AuthFailureDelegatingHandler` | `DelegatingHandler` that triggers the gate on 401/403 | [`Services/Bridge/AuthFailureDelegatingHandler.cs`](../src/Services/Bridge/AuthFailureDelegatingHandler.cs) |
+| `SlidingWindowAuthFailureHandler` | Rate-limits auth-retry attempts with a sliding window | [`Services/Bridge/SlidingWindowAuthFailureHandler.cs`](../src/Services/Bridge/SlidingWindowAuthFailureHandler.cs) |
+
+Key interfaces: `ITokenStore<T>`, `ITokenProtector`, `IStringProtector`, `IStreamingAuthenticationService<T,S>`,
+`IAuthFailureHandler` — see [`Interfaces/`](../src/Interfaces/) and
+[`Abstractions/Contracts/`](../src/Abstractions/Contracts/).
+
+---
+
+## Caching
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `StreamingResponseCache` | Abstract base for API response caching with ETag support | [`Services/Caching/StreamingResponseCache.cs`](../src/Services/Caching/StreamingResponseCache.cs) |
+| `FileStreamingResponseCache` | Disk-backed response cache implementation | [`Services/Caching/FileStreamingResponseCache.cs`](../src/Services/Caching/FileStreamingResponseCache.cs) |
+| `SmartCache<K,V>` | Size-bounded cache with eviction statistics and priority levels | [`Services/Caching/SmartCache.cs`](../src/Services/Caching/SmartCache.cs) |
+| `CachePolicy` | TTL, staleness, and hit-mode configuration for cache entries | [`Services/Caching/CachePolicy.cs`](../src/Services/Caching/CachePolicy.cs) |
+| `ArrCachingHeaders` | Lidarr-standard cache-control header constants | [`Services/Caching/ArrCachingHeaders.cs`](../src/Services/Caching/ArrCachingHeaders.cs) |
+| `IStreamingResponseCache` | Generic response-cache contract | [`Interfaces/IStreamingResponseCache.cs`](../src/Interfaces/IStreamingResponseCache.cs) |
+| `ICacheStorage<T>` / `ICacheSerializer<T>` / `ICacheEvictionStrategy<T>` | Pluggable cache storage seams | [`Services/Caching/`](../src/Services/Caching/) |
+
+---
+
+## Download Pipeline
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `SimpleDownloadOrchestrator` | Orchestrates multi-track downloads with retry and telemetry | [`Services/Download/SimpleDownloadOrchestrator.cs`](../src/Services/Download/SimpleDownloadOrchestrator.cs) |
+| `AlbumCompletionPolicy` | Decides whether an album download is complete | [`Services/Download/AlbumCompletionPolicy.cs`](../src/Services/Download/AlbumCompletionPolicy.cs) |
+| `ChunkedHttpAssembler` | Downloads and reassembles chunked files | [`Services/Download/ChunkedHttpAssembler.cs`](../src/Services/Download/ChunkedHttpAssembler.cs) |
+| `HttpFileDownloadService` | Default `IHttpFileDownloadService` implementation | [`Services/Download/HttpFileDownloadService.cs`](../src/Services/Download/HttpFileDownloadService.cs) |
+| `DownloadPathValidator` | Validates download destination paths (traversal, length, special names) | [`Services/Validation/DownloadPathValidator.cs`](../src/Services/Validation/DownloadPathValidator.cs) |
+| `DownloadTelemetry` | Canonical per-track telemetry record shared by all plugins | [`Services/Download/DownloadTelemetry.cs`](../src/Services/Download/DownloadTelemetry.cs) |
+| `DrmTrack` | Represents a DRM-protected track for external download delegation | [`Services/Drm/DrmTrack.cs`](../src/Services/Drm/DrmTrack.cs) |
+| `IExternalDownloadHandler` | Seam for delegating DRM downloads to an external handler | [`Services/Drm/IExternalDownloadHandler.cs`](../src/Services/Drm/IExternalDownloadHandler.cs) |
+
+---
+
+## Streaming (SSE / LLM)
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `SseFramingReader` | Low-level SSE frame parser (field-per-line) | [`Streaming/SseFramingReader.cs`](../src/Streaming/SseFramingReader.cs) |
+| `IStreamDecoder` | Adapts a provider-specific SSE stream into `LlmStreamChunk` records | [`Streaming/IStreamDecoder.cs`](../src/Streaming/IStreamDecoder.cs) |
+| `OpenAiStreamDecoder` | Decoder for OpenAI-compatible SSE streams | [`Streaming/Decoders/OpenAiStreamDecoder.cs`](../src/Streaming/Decoders/OpenAiStreamDecoder.cs) |
+| `AnthropicStreamDecoder` | Decoder for Anthropic SSE streams | [`Streaming/Decoders/AnthropicStreamDecoder.cs`](../src/Streaming/Decoders/AnthropicStreamDecoder.cs) |
+| `GeminiStreamDecoder` | Decoder for Google Gemini SSE streams | [`Streaming/Decoders/GeminiStreamDecoder.cs`](../src/Streaming/Decoders/GeminiStreamDecoder.cs) |
+| `ZaiStreamDecoder` | Decoder for Z.AI/GLM SSE streams | [`Streaming/Decoders/ZaiStreamDecoder.cs`](../src/Streaming/Decoders/ZaiStreamDecoder.cs) |
+| `StreamingCancellation` | Cooperative cancellation with reason tracking | [`Streaming/StreamingCancellation.cs`](../src/Streaming/StreamingCancellation.cs) |
+| `StreamingTimeoutPolicy` | Configurable timeout record for streaming operations | [`Streaming/StreamingTimeoutPolicy.cs`](../src/Streaming/StreamingTimeoutPolicy.cs) |
+| `RateLimitedEventLogger` | Throttles repeated rate-limit log messages | [`Streaming/RateLimitedEventLogger.cs`](../src/Streaming/RateLimitedEventLogger.cs) |
+
+LLM abstractions (`ILlmProvider`, `LlmRequest`, `LlmResponse`, `LlmStreamChunk`, `LlmUsage`,
+`LlmTool`, `LlmToolCall`, `LlmToolResult`, `LlmThinkingHint`) live in
+[`Abstractions/Llm/`](../src/Abstractions/Llm/).
+The Claude Code provider implementation is in [`Providers/ClaudeCode/`](../src/Providers/ClaudeCode/).
+
+---
+
+## Bridge & Host Integration
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `PathTraversalGuard` | Validates paths passed to the host are within allowed directories | [`HostBridge/PathTraversalGuard.cs`](../src/HostBridge/PathTraversalGuard.cs) |
+| `HostBridgeDownloadTrackerStore<T>` | Per-download state tracker that survives host round-trips | [`HostBridge/HostBridgeDownloadTracker.cs`](../src/HostBridge/HostBridgeDownloadTracker.cs) |
+| `HostBridgeDownloadOrchestrator` | Coordinates bridge download lifecycle (track → item → completion) | [`HostBridge/HostBridgeDownloadOrchestrator.cs`](../src/HostBridge/HostBridgeDownloadOrchestrator.cs) |
+| `HostBridgeRuntimeCache<T,S>` | Caches auth tokens and configuration across host re-loads | [`HostBridge/HostBridgeRuntimeCache.cs`](../src/HostBridge/HostBridgeRuntimeCache.cs) |
+| `AlbumReleaseInfoBuilder` | Builds the release-info payload Lidarr expects | [`HostBridge/AlbumReleaseInfoBuilder.cs`](../src/HostBridge/AlbumReleaseInfoBuilder.cs) |
+| `AlbumDownloadUri` | Constructs album-level download URIs for the host | [`HostBridge/AlbumDownloadUri.cs`](../src/HostBridge/AlbumDownloadUri.cs) |
+| `PlaceholderSearchUri` | Returns a placeholder search URI for the initial host query | [`HostBridge/PlaceholderSearchUri.cs`](../src/HostBridge/PlaceholderSearchUri.cs) |
+| `StreamingPlugin<T,S>` | Abstract base class that wires a plugin into the host lifecycle | [`Hosting/StreamingPlugin.cs`](../src/Hosting/StreamingPlugin.cs) |
+| `StreamingPluginModule` | DI module base class with auto-registration attribute scanning | [`Services/Registration/StreamingPluginModule.cs`](../src/Services/Registration/StreamingPluginModule.cs) |
+| `PluginLifecycle` | Startup/shutdown hooks for the plugin lifecycle | [`Hosting/PluginLifecycle.cs`](../src/Hosting/PluginLifecycle.cs) |
+| `PluginConfigRoots` | Resolves configuration root directories (XDG / Windows) | [`Hosting/PluginConfigRoots.cs`](../src/Hosting/PluginConfigRoots.cs) |
+
+See also: [Plugin Bridge](../docs/PLUGIN_BRIDGE.md), [Plugin Isolation](../docs/PLUGIN_ISOLATION.md),
+[Plugin Manifest](../docs/PLUGIN_MANIFEST.md).
+
+---
+
+## Observability & Diagnostics
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `WarnOnce` | Emits a log warning only once per key; suppresses duplicates | [`Diagnostics/WarnOnce.cs`](../src/Diagnostics/WarnOnce.cs) |
+| `HealthCheckHelper` | Runs provider health checks and formats `DiagnosticHealthResult` | [`Diagnostics/HealthCheckHelper.cs`](../src/Diagnostics/HealthCheckHelper.cs) |
+| `HttpExceptionClassifier` | Classifies HTTP exceptions into failure categories | [`Services/Diagnostics/HttpExceptionClassifier.cs`](../src/Services/Diagnostics/HttpExceptionClassifier.cs) |
+| `IMetricsRecorder` | Dimensional metrics interface with `NullMetricsRecorder` and `ObservableMetricsRecorder` | [`Observability/IMetricsRecorder.cs`](../src/Observability/IMetricsRecorder.cs) |
+| `Metrics` | Lightweight static counters for legacy callers | [`Observability/Metrics.cs`](../src/Observability/Metrics.cs) |
+| `PluginLogContext` | Scoped log context that enriches log entries with plugin metadata | [`Observability/PluginLogContext.cs`](../src/Observability/PluginLogContext.cs) |
+| `LogRedactor` | Source-generated redactor for sanitising log output | [`Observability/LogRedactor.cs`](../src/Observability/LogRedactor.cs) |
+| `Scrub` | Removes sensitive values (tokens, keys) from strings | [`Observability/Scrub.cs`](../src/Observability/Scrub.cs) |
+| `LoggerExtensions` / `EventIds` | Structured logging helpers and well-known event IDs | [`Observability/LoggerExtensions.cs`](../src/Observability/LoggerExtensions.cs) |
+| `LlmEventIds` / `LlmLoggerExtensions` | Event IDs and log helpers specific to LLM operations | [`Observability/LlmEventIds.cs`](../src/Observability/LlmEventIds.cs) |
+| `DownloadDiagnostics` | Helpers for emitting download-specific diagnostic events | [`Utilities/DownloadDiagnostics.cs`](../src/Utilities/DownloadDiagnostics.cs) |
+
+See also: [Telemetry (OpenTelemetry)](../docs/Telemetry.md),
+[Telemetry DI Contract](../docs/TELEMETRY_DI_CONTRACT.md),
+[Diagnostics Bundle Contract](../docs/DIAGNOSTICS_BUNDLE_CONTRACT.md).
+
+---
+
+## Validation & Guards
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `Guard` | Precondition checks (not-null, range, enum) | [`Utilities/Guard.cs`](../src/Utilities/Guard.cs) |
+| `PathValidation` | Validates paths are safe and within expected roots | [`Utilities/PathValidation.cs`](../src/Utilities/PathValidation.cs) |
+| `ValidationUtilities` | Common validation helpers for plugin inputs | [`Utilities/ValidationUtilities.cs`](../src/Utilities/ValidationUtilities.cs) |
+| `DataValidationService` | Validates streaming data (duplicates, track sequences, paths) | [`Services/Validation/DataValidationService.cs`](../src/Services/Validation/DataValidationService.cs) |
+| `DownloadPayloadValidator` | Validates downloaded payload integrity (size, magic bytes) | [`Utilities/DownloadPayloadValidator.cs`](../src/Utilities/DownloadPayloadValidator.cs) |
+| `PackageClosureValidator` | Validates that a download package contains all expected files | [`Utilities/PackageClosureValidator.cs`](../src/Utilities/PackageClosureValidator.cs) |
+| `AudioMagicBytesValidator` | Verifies downloaded files match expected audio format signatures | [`Utilities/AudioMagicBytesValidator.cs`](../src/Utilities/AudioMagicBytesValidator.cs) |
+
+---
+
+## Collections
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `BoundedConcurrentDictionary<K,V>` | Thread-safe dictionary that evicts excess entries when a capacity cap is hit | [`Collections/BoundedConcurrentDictionary.cs`](../src/Collections/BoundedConcurrentDictionary.cs) |
+| `CircularBuffer<T>` | Fixed-size ring buffer for sliding-window metrics | [`Services/Resilience/CircularBuffer.cs`](../src/Services/Resilience/CircularBuffer.cs) |
+
+---
+
+## Utilities
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `RetryUtilities` | Single source of truth for retry delay calculations | [`Utilities/RetryUtilities.cs`](../src/Utilities/RetryUtilities.cs) |
+| `ResiliencePolicy` | Lightweight resilience policy wrapper | [`Utilities/ResiliencePolicy.cs`](../src/Utilities/ResiliencePolicy.cs) |
+| `GenericResilienceExecutor` | Executes delegates with configurable retry and timeout | [`Utilities/GenericResilienceExecutor.cs`](../src/Utilities/GenericResilienceExecutor.cs) |
+| `HttpClientExtensions` | Extension methods for common HTTP patterns (download, read-as) | [`Utilities/HttpClientExtensions.cs`](../src/Utilities/HttpClientExtensions.cs) |
+| `FileSystemUtilities` | Safe file-system helpers (atomic write, temp paths) | [`Utilities/FileSystemUtilities.cs`](../src/Utilities/FileSystemUtilities.cs) |
+| `FileNameSanitizer` | Sanitises file names for cross-platform safety | [`Utilities/FileNameSanitizer.cs`](../src/Utilities/FileNameSanitizer.cs) |
+| `HashingUtility` | SHA/MD5 hashing helpers | [`Utilities/HashingUtility.cs`](../src/Utilities/HashingUtility.cs) |
+| `QueryCanonicalizer` | Normalises query strings for cache-key consistency | [`Utilities/QueryCanonicalizer.cs`](../src/Utilities/QueryCanonicalizer.cs) |
+| `SensitiveKeys` | Known key names that should be redacted from logs | [`Utilities/SensitiveKeys.cs`](../src/Utilities/SensitiveKeys.cs) |
+| `HostConcurrencyGate` | Limits concurrent operations per host | [`Utilities/HostConcurrencyGate.cs`](../src/Utilities/HostConcurrencyGate.cs) |
+| `DownloadTelemetryContext` | Async-local scope that tracks per-download telemetry counters | [`Utilities/DownloadTelemetryContext.cs`](../src/Utilities/DownloadTelemetryContext.cs) |
+| `PreviewDetectionUtility` | Detects preview/early-access content from metadata | [`Utilities/PreviewDetectionUtility.cs`](../src/Utilities/PreviewDetectionUtility.cs) |
+
+---
+
+## Intelligence & Metadata
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `LyricsEnricher` | Fetches and embeds synchronized lyrics via `ILyricsEnricher` | [`Services/Lyrics/LyricsEnricher.cs`](../src/Services/Lyrics/LyricsEnricher.cs) |
+| `LrclibClient` | Client for the LRCLIB lyrics API | [`Services/Lyrics/LrclibClient.cs`](../src/Services/Lyrics/LrclibClient.cs) |
+| `UnicodeNormalizer` | Normalises Unicode strings (NFC/NFD, script detection) | [`Services/Globalization/UnicodeNormalizer.cs`](../src/Services/Globalization/UnicodeNormalizer.cs) |
+| `MetadataFieldSanitizer` | Cleans metadata fields (whitespace, control chars) | [`Services/Intelligence/MetadataFieldSanitizer.cs`](../src/Services/Intelligence/MetadataFieldSanitizer.cs) |
+| `LiveAlbumNormalizer` | Detects and normalises live album metadata | [`Services/Intelligence/LiveAlbumNormalizer.cs`](../src/Services/Intelligence/LiveAlbumNormalizer.cs) |
+| `CompilationAlbumDetector` | Detects compilation albums from metadata patterns | [`Services/Intelligence/CompilationAlbumDetector.cs`](../src/Services/Intelligence/CompilationAlbumDetector.cs) |
+| `IQueryOptimizer` | Interface for search-query optimisation with feedback loops | [`Services/Intelligence/IQueryOptimizer.cs`](../src/Services/Intelligence/IQueryOptimizer.cs) |
+| `QualityMapper` | Maps streaming quality tiers to Lidarr quality profiles | [`Services/Quality/QualityMapper.cs`](../src/Services/Quality/QualityMapper.cs) |
+
+---
+
+## Performance & Rate Limiting
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `UniversalAdaptiveRateLimiter` | Self-tuning rate limiter that adapts to 429/backoff signals | [`Services/Performance/UniversalAdaptiveRateLimiter.cs`](../src/Services/Performance/UniversalAdaptiveRateLimiter.cs) |
+| `NamedServiceRateLimiter` | Per-service rate limiter base class for multi-service plugins | [`Services/Performance/NamedServiceRateLimiter.cs`](../src/Services/Performance/NamedServiceRateLimiter.cs) |
+| `AdaptiveConcurrencyManager` | Dynamically adjusts concurrency based on throughput and errors | [`Services/Performance/AdaptiveConcurrencyManager.cs`](../src/Services/Performance/AdaptiveConcurrencyManager.cs) |
+| `MemoryHealthMonitor` | Monitors GC memory pressure and advises on optimisation | [`Services/Performance/MemoryHealthMonitor.cs`](../src/Services/Performance/MemoryHealthMonitor.cs) |
+| `BatchMemoryManager` | Manages memory budgets for batch download operations | [`Services/Performance/BatchMemoryManager.cs`](../src/Services/Performance/BatchMemoryManager.cs) |
+| `PerformanceMonitor` | Tracks operation durations and throughput metrics | [`Services/Performance/PerformanceMonitor.cs`](../src/Services/Performance/PerformanceMonitor.cs) |
+
+---
+
+## Storage
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `JsonFileStore<K,V>` | Transactional JSON file store with typed keys and entry metadata | [`Services/Storage/JsonFileStore.cs`](../src/Services/Storage/JsonFileStore.cs) |
+| `FileConditionalRequestState` | Persists ETag/Last-Modified state for conditional HTTP requests | [`Services/Http/FileConditionalRequestState.cs`](../src/Services/Http/FileConditionalRequestState.cs) |
+
+---
+
+## DI Extensions
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `ServiceCollectionExtensions` | Registers Common's default services into the DI container | [`Extensions/ServiceCollectionExtensions.cs`](../src/Extensions/ServiceCollectionExtensions.cs) |
+| `BridgeServiceCollectionExtensions` | Registers bridge-specific services (auth gates, reporters) | [`Extensions/BridgeServiceCollectionExtensions.cs`](../src/Extensions/BridgeServiceCollectionExtensions.cs) |
+| `DownloadTelemetryServiceCollectionExtensions` | Registers download telemetry services | [`Extensions/DownloadTelemetryServiceCollectionExtensions.cs`](../src/Extensions/DownloadTelemetryServiceCollectionExtensions.cs) |
+
+---
+
+## Errors
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `LlmProviderException` | Base exception for LLM-provider errors | [`Errors/LlmProviderException.cs`](../src/Errors/LlmProviderException.cs) |
+| `RateLimitException` / `ProviderException` / `AuthenticationException` / `NetworkException` | Typed LLM error subclasses | [`Errors/`](../src/Errors/) |
+| `DownloadIntegrityException` | Thrown when a downloaded file fails integrity checks | [`Errors/DownloadIntegrityException.cs`](../src/Errors/DownloadIntegrityException.cs) |
+| `LlmErrorMapper` | Maps provider-specific error responses to `LlmErrorCode` | [`Errors/LlmErrorMapper.cs`](../src/Errors/LlmErrorMapper.cs) |
+| `StreamingException` | Base exception for streaming/SSE errors | [`Streaming/StreamingException.cs`](../src/Streaming/StreamingException.cs) |
+| `AuthGatedException` | Thrown when an `AuthFailureGate` is latched | [`Services/Bridge/AuthFailureGate.cs`](../src/Services/Bridge/AuthFailureGate.cs) |
+
+---
+
+## Base Classes (Inherit to Build a Plugin)
+
+| Class | Purpose | Source |
+|-------|---------|--------|
+| `BaseStreamingIndexer<T>` | Base class for streaming-service indexers | [`Base/BaseStreamingIndexer.cs`](../src/Base/BaseStreamingIndexer.cs) |
+| `BaseStreamingDownloadClient<T>` | Base class for streaming-service download clients | [`Base/BaseStreamingDownloadClient.cs`](../src/Base/BaseStreamingDownloadClient.cs) |
+| `BaseStreamingSettings` | Abstract settings POCO with common properties | [`Base/BaseStreamingSettings.cs`](../src/Base/BaseStreamingSettings.cs) |
+| `StreamingIndexerHelpers` / `StreamingConfigHelpers` | Static composition helpers used by base classes | [`Base/StreamingIndexerHelpers.cs`](../src/Base/StreamingIndexerHelpers.cs) |
+| `SafeOperationExecutor` | Executes lambdas with standard defensive patterns | [`Services/SafeOperationExecutor.cs`](../src/Services/SafeOperationExecutor.cs) |
+| `LidarrIntegrationHelpers` | Composition helpers for Lidarr host integration | [`Services/LidarrIntegrationHelpers.cs`](../src/Services/LidarrIntegrationHelpers.cs) |
+
+---
+
+## Testing Helpers
+
+| Helper | Purpose | Source |
+|--------|---------|--------|
+| `MockFactories` / `TestDataSets` | Factory methods and sample data sets for unit tests | [`Testing/MockFactories.cs`](../src/Testing/MockFactories.cs) |
+| `TestValidationBuilder` | Fluent builder for constructing test validation scenarios | [`Validation/TestValidationBuilder.cs`](../src/Validation/TestValidationBuilder.cs) |
+| `TestFailureFormatter` | Formats test failure messages for diagnostics | [`Utilities/TestFailureFormatter.cs`](../src/Utilities/TestFailureFormatter.cs) |
+
+See also: [Testing with the TestKit](../docs/TESTING_WITH_TESTKIT.md).
+
+---
+
+## Further Reading
+
+- [FAQ for Plugin Authors](../docs/FAQ_FOR_PLUGIN_AUTHORS.md)
+- [Upgrading Lidarr.Plugin.Common](../docs/UPGRADING.md)
+- [Settings Provider Bridge](../docs/SETTINGS_PROVIDER.md)
+- [Packaging Plugins](../docs/PACKAGING.md)
+- [Architecture Overview](Architecture-Overview.md)
+- [SDK and Extension Points](SDK-and-Extension-Points.md)

--- a/wiki/Testing-with-the-TestKit.md
+++ b/wiki/Testing-with-the-TestKit.md
@@ -1,0 +1,112 @@
+# Testing with the TestKit
+
+The TestKit (`Lidarr.Plugin.Common.TestKit` NuGet package) ships reusable test infrastructure so every plugin tests the same way.
+This page is a **catalog** of the fixtures, harnesses, HTTP handlers, builders, and assertion helpers it exposes — with source deep-links.
+
+For full usage instructions, see [TESTING_WITH_TESTKIT.md](../docs/TESTING_WITH_TESTKIT.md); this page does not restate it.
+
+## HTTP Handlers
+
+Simulate upstream API behaviour in unit tests by inserting these `HttpMessageHandler` / `DelegatingHandler` implementations into your `HttpClient` pipeline.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `AuthenticationTestHandler` | Simulates OAuth/token authentication flows. | [AuthenticationTestHandler.cs](../testkit/Http/AuthenticationTestHandler.cs) |
+| `AuthenticationTestOptions` | Configures `AuthenticationTestHandler` behaviour. | [AuthenticationTestHandler.cs](../testkit/Http/AuthenticationTestHandler.cs) |
+| `RateLimitTestHandler` | Simulates rate-limiting responses. | [AuthenticationTestHandler.cs](../testkit/Http/AuthenticationTestHandler.cs) |
+| `RateLimitTestOptions` | Configures `RateLimitTestHandler`. | [AuthenticationTestHandler.cs](../testkit/Http/AuthenticationTestHandler.cs) |
+| `ErrorSimulationHandler` | Simulates server errors with configurable patterns. | [AuthenticationTestHandler.cs](../testkit/Http/AuthenticationTestHandler.cs) |
+| `ErrorSimulationOptions` | Configures `ErrorSimulationHandler`. | [AuthenticationTestHandler.cs](../testkit/Http/AuthenticationTestHandler.cs) |
+| `SlowStreamHandler` | Simulates slow streaming responses. | [SlowStreamHandler.cs](../testkit/Http/SlowStreamHandler.cs) |
+| `PreviewStreamHandler` | Serves preview/partial stream responses. | [PreviewStreamHandler.cs](../testkit/Http/PreviewStreamHandler.cs) |
+| `RetriableFlakyHandler` | Simulates intermittent failures for retry testing. | [RetriableFlakyHandler.cs](../testkit/Http/RetriableFlakyHandler.cs) |
+| `PartialContentHandler` | Simulates HTTP 206 Partial Content responses. | [PartialContentHandler.cs](../testkit/Http/PartialContentHandler.cs) |
+| `GzipMislabeledHandler` | Simulates mislabeled gzip content-encoding. | [GzipMislabeledHandler.cs](../testkit/Http/GzipMislabeledHandler.cs) |
+| `JsonProblemHandler` | Simulates RFC 7807 problem-detail responses. | [JsonProblemHandler.cs](../testkit/Http/JsonProblemHandler.cs) |
+| `HttpResponseFactory` | Static factory for crafting test HTTP responses. | [HttpResponseFactory.cs](../testkit/Http/HttpResponseFactory.cs) |
+
+## Hosting and Container Fixtures
+
+Spin up a real Lidarr container or a lightweight in-memory plugin context.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `LidarrContainerFixture` | xUnit collection fixture that boots a real Lidarr container with a plugin DLL. | [LidarrContainerFixture.cs](../testkit/Hosting/LidarrContainerFixture.cs) |
+| `LidarrContainerOptions` | Record configuring which image, tag, and plugin to load. | [LidarrContainerOptions.cs](../testkit/Hosting/LidarrContainerOptions.cs) |
+| `LidarrContainerFixtureSmokeAssertions` | Static assertions for smoke-testing the running container. | [LidarrContainerFixtureSmokeAssertions.cs](../testkit/Hosting/LidarrContainerFixtureSmokeAssertions.cs) |
+| `PluginTestContext` | Minimal `IPluginContext` implementation for unit tests. | [PluginTestContext.cs](../testkit/Hosting/PluginTestContext.cs) |
+| `TestLogSink` | Captures log entries emitted during a test. | [PluginTestContext.cs](../testkit/Hosting/PluginTestContext.cs) |
+| `TestLogEntry` | Single structured log entry record. | [PluginTestContext.cs](../testkit/Hosting/PluginTestContext.cs) |
+| `TestLoggerFactory` | Injectable `ILoggerFactory` backed by the test sink. | [PluginTestContext.cs](../testkit/Hosting/PluginTestContext.cs) |
+
+## Compliance and Contract Bases
+
+Abstract base classes that enforce ecosystem-wide rules. Inherit them in your plugin's test project.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `PluginComplianceTestBase` | Abstract base for compliance tests every plugin must pass. | [PluginComplianceTestBase.cs](../testkit/Compliance/PluginComplianceTestBase.cs) |
+| `StreamingServiceComplianceTestBase` | Compliance tests specific to streaming services (extends `PluginComplianceTestBase`). | [StreamingServiceComplianceTestBase.cs](../testkit/Compliance/StreamingServiceComplianceTestBase.cs) |
+| `SecurityComplianceTestBase` | Security-focused compliance tests for all plugins. | [SecurityComplianceTestBase.cs](../testkit/Compliance/SecurityComplianceTestBase.cs) |
+| `EcosystemParityTestBase` | Abstract base for ecosystem parity tests (file/class naming, shared-type usage). | [EcosystemParityTestBase.cs](../testkit/Compliance/EcosystemParityTestBase.cs) |
+| `DiagnosticsAllowedValuesTestBase` | Validates that diagnostics expose only allowed values. | [DiagnosticsAllowedValuesTestBase.cs](../testkit/Compliance/DiagnosticsAllowedValuesTestBase.cs) |
+| `PluginVersionContract` | Static contract assertions for plugin versioning. | [PluginVersionContract.cs](../testkit/Compliance/PluginVersionContract.cs) |
+| `PublishedReleaseInstallabilityContract` | Static contract for release installability. | [PublishedReleaseInstallabilityContract.cs](../testkit/Compliance/PublishedReleaseInstallabilityContract.cs) |
+| `PluginPackagingContract` | Static contract for packaging compliance; references `PluginPackagePolicy`. | [PluginPackagingContract.cs](../testkit/Compliance/PluginPackagingContract.cs) |
+
+## Isolation and ALC Harness
+
+Verify that your plugin loads correctly inside a dedicated AssemblyLoadContext.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `PluginIsolationTestBase` | Abstract base for ALC isolation tests. | [PluginIsolationTestBase.cs](../testkit/LibraryLinking/PluginIsolationTestBase.cs) |
+| `StreamingPluginIsolationTestBase` | ALC tests specific to streaming plugins (extends `PluginIsolationTestBase`). | [PluginIsolationTestBase.cs](../testkit/LibraryLinking/PluginIsolationTestBase.cs) |
+| `PluginIsolationAssertions` | Static assertions for isolation and manifest consistency. | [PluginIsolationAssertions.cs](../testkit/LibraryLinking/PluginIsolationAssertions.cs) |
+| `PluginSandbox` | Isolated sandbox that loads a plugin assembly in a separate ALC (`IAsyncDisposable`). | [PluginSandbox.cs](../testkit/Fixtures/PluginSandbox.cs) |
+| `SandboxLoaderMode` | Controls how `PluginSandbox` loads the plugin assembly. | [PluginSandbox.cs](../testkit/Fixtures/PluginSandbox.cs) |
+| `PluginSandboxOptions` | Configures sandbox behaviour. | [PluginSandbox.cs](../testkit/Fixtures/PluginSandbox.cs) |
+| `BridgeComplianceFixture` | Fixture verifying bridge compliance (`IDisposable`). | [BridgeComplianceFixture.cs](../testkit/Fixtures/BridgeComplianceFixture.cs) |
+
+## Builders
+
+Fluent builders for constructing streaming model instances in tests.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `StreamingArtistBuilder` | Fluent builder for `StreamingArtist` instances. | [StreamingModelBuilders.cs](../testkit/Builders/StreamingModelBuilders.cs) |
+| `StreamingAlbumBuilder` | Fluent builder for `StreamingAlbum` instances. | [StreamingModelBuilders.cs](../testkit/Builders/StreamingModelBuilders.cs) |
+| `StreamingTrackBuilder` | Fluent builder for `StreamingTrack` instances. | [StreamingModelBuilders.cs](../testkit/Builders/StreamingModelBuilders.cs) |
+| `StreamingQualityBuilder` | Fluent builder for `StreamingQuality` instances. | [StreamingModelBuilders.cs](../testkit/Builders/StreamingModelBuilders.cs) |
+| `StreamingSearchResultBuilder` | Fluent builder for `StreamingSearchResult` instances. | [StreamingModelBuilders.cs](../testkit/Builders/StreamingModelBuilders.cs) |
+
+## Assertions
+
+One-shot static helpers for validating plugin contracts in tests.
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `FileNameAssertions` | Validates file naming contracts across streaming plugins. | [FileNameAssertions.cs](../testkit/Assertions/FileNameAssertions.cs) |
+| `PluginAssertions` | General plugin assertion helpers. | [PluginAssertions.cs](../testkit/Assertions/PluginAssertions.cs) |
+| `LogAssertions` | Assertion helpers for verifying log output. | [LogAssertions.cs](../testkit/Assertions/LogAssertions.cs) |
+
+## Helpers, Fakes, and Utilities
+
+| Type | Purpose | Source |
+|------|---------|--------|
+| `FakeTimeProvider` | Deterministic `TimeProvider` for time-dependent tests. | [FakeTimeProvider.cs](../testkit/Testing/FakeTimeProvider.cs) |
+| `NullUniversalAdaptiveRateLimiter` | No-op `IUniversalAdaptiveRateLimiter` for tests. | [NullUniversalAdaptiveRateLimiter.cs](../testkit/Fakes/NullUniversalAdaptiveRateLimiter.cs) |
+| `NLogTestLogger` | NLog-based logger for test output. | [NLogTestLogger.cs](../testkit/Helpers/NLogTestLogger.cs) |
+| `EmbeddedJson` | Reads embedded JSON resource files as test data. | [EmbeddedJson.cs](../testkit/Data/EmbeddedJson.cs) |
+| `ModelValidationHelpers` | Static helpers for validating `StreamingModel` objects. | [ModelValidationHelpers.cs](../testkit/Validation/ModelValidationHelpers.cs) |
+| `MockFactories` | Factory methods for mock streaming service data. | [MockFactories.cs](../src/Testing/MockFactories.cs) |
+| `TestDataSets` | Common test data sets for streaming scenarios. | [MockFactories.cs](../src/Testing/MockFactories.cs) |
+| `PackagingTestPaths` | Resolves paths used by packaging integration tests. | [PackagingTestPaths.cs](../testkit/Packaging/PackagingTestPaths.cs) |
+| `PackagingFactAttribute` | Base attribute for packaging test facts. | [PackagingFactAttribute.cs](../testkit/Packaging/PackagingFactAttribute.cs) |
+
+## Related Docs
+
+- [TESTING_WITH_TESTKIT.md](../docs/TESTING_WITH_TESTKIT.md) — full usage guide for fixtures, HTTP handlers, and manifest helpers.
+- [TEST_PLUGIN.md](../docs/how-to/TEST_PLUGIN.md) — step-by-step: how to test a plugin end-to-end.
+- [PERSISTENT_E2E_TESTING.md](../docs/PERSISTENT_E2E_TESTING.md) — long-running end-to-end test environment.
+- [MULTI_PLUGIN_SMOKE_TEST.md](../docs/MULTI_PLUGIN_SMOKE_TEST.md) — multi-plugin smoke test infrastructure.

--- a/wiki/Versioning-and-Submodule-Pinning.md
+++ b/wiki/Versioning-and-Submodule-Pinning.md
@@ -1,0 +1,36 @@
+# Versioning and Submodule Pinning
+
+How Common releases are versioned, how plugin repos pin the submodule, and how the ecosystem stays in lockstep.
+
+## Common version contract
+
+Every plugin's `plugin.json` declares a `commonVersion` field that must match the `<Version>` in [src/Lidarr.Plugin.Common.csproj](../src/Lidarr.Plugin.Common.csproj). A parity-lint spec ([scripts/parity-spec.json](../scripts/parity-spec.json)) encodes the invariants, and `ecosystem-parity-lint.ps1` enforces them in CI.
+
+Full details → [Ecosystem Version Contract](../docs/ECOSYSTEM_VERSION_CONTRACT.md).
+
+## Submodule pin and sentinel file
+
+Plugin repos consume Common as a git submodule under `ext/`. Alongside the submodule pointer, each plugin keeps an `ext-common-sha.txt` sentinel file whose content must match the submodule's checked-out SHA. CI drift detection reads this file and fails if it diverges.
+
+The two scripts that automate repinning:
+
+- [scripts/repin-common-submodule.ps1](../scripts/repin-common-submodule.ps1) — PowerShell (update SHA, sentinel, optionally stage).
+- [scripts/repin-common-submodule.sh](../scripts/repin-common-submodule.sh) — Bash equivalent for CI workflows.
+
+## Host-version upgrade flow
+
+When the Lidarr host target changes, a structured playbook coordinates the bump across Common and every plugin repo.
+
+See → [Host Version Upgrade Playbook](../docs/HOST_VERSION_UPGRADE_PLAYBOOK.md).
+
+## Compatibility matrix
+
+Supported host/abstractions/Common version combinations and target-framework policy.
+
+See → [Compatibility](../docs/COMPATIBILITY.md).
+
+## Upgrading Common in your plugin
+
+Step-by-step checklist to follow after each tagged release.
+
+See → [Upgrading](../docs/UPGRADING.md).


### PR DESCRIPTION
## Summary
Adds an 8-page **wiki/** for Lidarr.Plugin.Common, aimed at plugin authors. It's a **navigation/orientation layer** that deep-links into the existing `docs/` and source — **it does not duplicate** their content.

Pages: Home · Architecture-Overview · SDK-and-Extension-Points · Shared-Helpers-Catalog · Ecosystem-Parity-and-Guards · Versioning-and-Submodule-Pinning · Testing-with-the-TestKit · CI-and-Packaging.

## Quality
- Every linked doc/source path verified to resolve; every named type (`StreamingPlugin<TModule,TSettings>`, `IIndexer`, `BaseStreamingDownloadClient`, `AuthenticationTestHandler`, …) confirmed to have a real definition in the repo.
- markdownlint **0 errors**; cspell clean (legit British/technical terms added to dictionary).
- No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)