### PR TITLE
feat(streaming): add HLS manifest parser to Common's manifest-parser seam

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -136,5 +136,9 @@ Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser
 Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.DashManifestParser() -> void
 Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.CanParse(string! mimeTypeOrContent) -> bool
 Lidarr.Plugin.Common.Services.Streaming.Manifests.DashManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
+Lidarr.Plugin.Common.Services.Streaming.Manifests.HlsManifestParser
+Lidarr.Plugin.Common.Services.Streaming.Manifests.HlsManifestParser.HlsManifestParser() -> void
+Lidarr.Plugin.Common.Services.Streaming.Manifests.HlsManifestParser.CanParse(string! mimeTypeOrContent) -> bool
+Lidarr.Plugin.Common.Services.Streaming.Manifests.HlsManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
 Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector
 static Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector.SelectByBandwidthCeiling(System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>! variants, int ceilingBps) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant?

--- a/src/Services/Streaming/Manifests/HlsManifestParser.cs
+++ b/src/Services/Streaming/Manifests/HlsManifestParser.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Lidarr.Plugin.Common.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Spec-correct HLS (RFC 8216 / <c>.m3u8</c>) playlist parser, shared across plugins whose service
+    /// delivers HLS (Apple Music's per-track <c>.m3u8</c>). Slots in alongside
+    /// <see cref="DashManifestParser"/> behind the <see cref="IStreamManifestParser"/> seam so callers
+    /// parse HLS through one shared code path instead of an inline per-plugin walk.
+    ///
+    /// <para>
+    /// <b>Parse-only (see <see cref="IStreamManifestParser"/>):</b> this turns the playlist index into a
+    /// variant list (for a master playlist) or an ordered segment list (for a media playlist), and
+    /// surfaces any <c>#EXT-X-KEY</c> as <b>opaque data</b> (<see cref="StreamManifest.IsEncrypted"/> /
+    /// <see cref="StreamManifest.KeyId"/>). It contains no decrypt, key-derivation, or key-fetch logic;
+    /// the <c>#EXT-X-KEY URI</c> is deliberately NOT followed.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Master vs media:</b> a playlist that carries any <c>#EXT-X-STREAM-INF</c> line is a master
+    /// playlist; <see cref="Parse"/> returns its renditions in <see cref="StreamManifest.Variants"/> with
+    /// an empty <see cref="StreamManifest.Segments"/>. The caller selects a variant (e.g. via
+    /// <see cref="QualitySelector"/>) and re-parses that variant's playlist to obtain the segment list —
+    /// mirroring how <see cref="DashManifestParser"/> exposes <c>Representation</c>s and how Apple's
+    /// downloader follows the chosen variant.
+    /// </para>
+    /// </summary>
+    public sealed class HlsManifestParser : IStreamManifestParser
+    {
+        // CODECS="a,b" attribute on #EXT-X-STREAM-INF (quoted, comma-separated list).
+        private static readonly Regex CodecsAttr =
+            new("CODECS=\"(?<v>[^\"]*)\"", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // BANDWIDTH=<int> attribute on #EXT-X-STREAM-INF (unquoted decimal).
+        private static readonly Regex BandwidthAttr =
+            new(@"BANDWIDTH=(?<v>\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <inheritdoc />
+        public bool CanParse(string mimeTypeOrContent)
+        {
+            if (string.IsNullOrWhiteSpace(mimeTypeOrContent))
+            {
+                return false;
+            }
+
+            string s = mimeTypeOrContent;
+
+            // MIME types Apple/HLS services advertise for playlists.
+            if (s.IndexOf("mpegurl", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+
+            // A URL/filename ending in the playlist extension (allow a query string after it).
+            if (s.IndexOf(".m3u8", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+
+            // Sniff content: an HLS playlist's first line is the #EXTM3U tag.
+            return s.TrimStart().StartsWith("#EXTM3U", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <inheritdoc />
+        public StreamManifest Parse(string manifestContent, string baseUrl)
+        {
+            if (string.IsNullOrWhiteSpace(manifestContent))
+            {
+                throw new ArgumentException("Manifest content is empty.", nameof(manifestContent));
+            }
+
+            // Split on both \n and \r so CRLF playlists don't leave a trailing \r on every line.
+            string[] lines = manifestContent
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace('\r', '\n')
+                .Split('\n');
+
+            bool isMaster = lines.Any(l =>
+                l.TrimStart().StartsWith("#EXT-X-STREAM-INF", StringComparison.OrdinalIgnoreCase));
+
+            return isMaster
+                ? ParseMaster(lines, baseUrl)
+                : ParseMedia(lines, baseUrl);
+        }
+
+        /// <summary>
+        /// Parses a master playlist into the variant list. Each <c>#EXT-X-STREAM-INF</c> tag (carrying
+        /// <c>BANDWIDTH</c>/<c>CODECS</c>) is paired with the immediately following non-comment line (the
+        /// variant playlist URI, resolved against <paramref name="baseUrl"/>). Segments are empty: the
+        /// caller selects a variant and re-parses it. The manifest-level <see cref="StreamManifest.Codec"/>
+        /// reflects the highest-bandwidth variant.
+        /// </summary>
+        private static StreamManifest ParseMaster(IReadOnlyList<string> lines, string baseUrl)
+        {
+            var variants = new List<StreamVariant>();
+            int pendingBandwidth = -1;
+            string? pendingCodec = null;
+            bool pending = false;
+
+            foreach (string raw in lines)
+            {
+                string line = raw.Trim();
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                if (line.StartsWith("#EXT-X-STREAM-INF", StringComparison.OrdinalIgnoreCase))
+                {
+                    pending = true;
+                    pendingBandwidth = ParseBandwidth(line);
+                    pendingCodec = ParseCodec(line);
+                    continue;
+                }
+
+                // Other tags between the stream-inf and its URI (rare) are ignored, not the URI.
+                if (line.StartsWith('#'))
+                {
+                    continue;
+                }
+
+                if (pending)
+                {
+                    string url = ResolveUrl(baseUrl, line);
+                    variants.Add(new StreamVariant(pendingBandwidth < 0 ? 0 : pendingBandwidth, url, pendingCodec));
+                    pending = false;
+                    pendingBandwidth = -1;
+                    pendingCodec = null;
+                }
+            }
+
+            // Manifest-level codec/extension reflect the highest-bandwidth rendition (the canonical pick).
+            StreamVariant? top = variants
+                .OrderByDescending(v => v.BandwidthBps)
+                .FirstOrDefault();
+            string codec = top?.Codec ?? string.Empty;
+            string fileExtension = DetermineFileExtension(codec, Array.Empty<StreamSegment>());
+
+            // A master playlist itself declares no segments and no content protection.
+            return new StreamManifest(variants, Array.Empty<StreamSegment>(), codec, fileExtension, false, null, null);
+        }
+
+        /// <summary>
+        /// Parses a media (variant) playlist into the ordered segment list. <c>#EXTINF:&lt;dur&gt;,&lt;title&gt;</c>
+        /// supplies each segment's duration; the following non-comment line is the segment URI (resolved
+        /// against <paramref name="baseUrl"/>). An <c>#EXT-X-KEY</c> with a <c>METHOD</c> other than
+        /// <c>NONE</c> flags <see cref="StreamManifest.IsEncrypted"/> and surfaces its <c>KEYID</c> (when
+        /// present) as opaque <see cref="StreamManifest.KeyId"/> — no key is fetched or applied.
+        /// </summary>
+        private static StreamManifest ParseMedia(IReadOnlyList<string> lines, string baseUrl)
+        {
+            var segments = new List<StreamSegment>();
+            double? pendingDuration = null;
+            int index = 0;
+
+            bool isEncrypted = false;
+            string? keyId = null;
+
+            foreach (string raw in lines)
+            {
+                string line = raw.Trim();
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                if (line.StartsWith('#'))
+                {
+                    if (line.StartsWith("#EXTINF", StringComparison.OrdinalIgnoreCase))
+                    {
+                        pendingDuration = ParseExtInfDuration(line);
+                    }
+                    else if (line.StartsWith("#EXT-X-KEY", StringComparison.OrdinalIgnoreCase))
+                    {
+                        ApplyKeyTag(line, ref isEncrypted, ref keyId);
+                    }
+
+                    continue;
+                }
+
+                // A non-comment line is a media segment URI.
+                string url = ResolveUrl(baseUrl, line);
+                segments.Add(new StreamSegment(index++, url, pendingDuration));
+                pendingDuration = null;
+            }
+
+            string codec = string.Empty;
+            string fileExtension = DetermineFileExtension(codec, segments);
+
+            // A media playlist exposes segments, not selectable variants. HLS carries no PSSH (that is a
+            // DASH/CENC construct), so KeyId is the only content-protection datum.
+            return new StreamManifest(Array.Empty<StreamVariant>(), segments, codec, fileExtension, isEncrypted, keyId, null);
+        }
+
+        /// <summary>
+        /// Reads an <c>#EXT-X-KEY</c> tag. Sets <paramref name="isEncrypted"/> when <c>METHOD</c> is present
+        /// and not <c>NONE</c>, and captures <c>KEYID</c> (hex KID, opaque) when present. The key <c>URI</c>
+        /// is intentionally ignored — this parser never fetches or applies keys.
+        /// </summary>
+        private static void ApplyKeyTag(string line, ref bool isEncrypted, ref string? keyId)
+        {
+            string? method = ParseAttribute(line, "METHOD");
+
+            // METHOD=NONE explicitly means "no encryption" and clears any prior key (per RFC 8216).
+            if (string.Equals(method, "NONE", StringComparison.OrdinalIgnoreCase))
+            {
+                isEncrypted = false;
+                keyId = null;
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(method))
+            {
+                isEncrypted = true;
+            }
+
+            string? kid = ParseAttribute(line, "KEYID");
+            if (!string.IsNullOrWhiteSpace(kid))
+            {
+                keyId = kid;
+            }
+        }
+
+        private static int ParseBandwidth(string streamInfLine)
+        {
+            Match m = BandwidthAttr.Match(streamInfLine);
+            return m.Success && int.TryParse(m.Groups["v"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int bw)
+                ? bw
+                : -1;
+        }
+
+        private static string? ParseCodec(string streamInfLine)
+        {
+            Match m = CodecsAttr.Match(streamInfLine);
+            if (!m.Success)
+            {
+                return null;
+            }
+
+            // CODECS may list several (audio,video); the first entry is the primary codec.
+            string list = m.Groups["v"].Value.Trim();
+            if (list.Length == 0)
+            {
+                return null;
+            }
+
+            string first = list.Split(',')[0].Trim();
+            return first.Length == 0 ? null : first;
+        }
+
+        /// <summary>Parses the duration from <c>#EXTINF:&lt;seconds&gt;,&lt;optional title&gt;</c>.</summary>
+        private static double? ParseExtInfDuration(string extInfLine)
+        {
+            int colon = extInfLine.IndexOf(':');
+            if (colon < 0 || colon + 1 >= extInfLine.Length)
+            {
+                return null;
+            }
+
+            string value = extInfLine.Substring(colon + 1);
+            int comma = value.IndexOf(',');
+            string number = comma >= 0 ? value.Substring(0, comma) : value;
+            number = number.Trim();
+
+            return double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds)
+                ? seconds
+                : (double?)null;
+        }
+
+        /// <summary>
+        /// Extracts a comma-separated HLS attribute (e.g. <c>METHOD</c>, <c>KEYID</c>) from a tag line.
+        /// Handles both quoted (<c>URI="..."</c>) and unquoted (<c>METHOD=AES-128</c>) values, and ignores
+        /// matches inside an earlier quoted value.
+        /// </summary>
+        private static string? ParseAttribute(string line, string name)
+        {
+            // Strip the leading "#TAG:" so the attribute scan starts at the attribute list.
+            int colon = line.IndexOf(':');
+            string attrs = colon >= 0 && colon + 1 < line.Length ? line.Substring(colon + 1) : line;
+
+            int i = 0;
+            int n = attrs.Length;
+            while (i < n)
+            {
+                // Read an attribute name up to '='.
+                int eq = attrs.IndexOf('=', i);
+                if (eq < 0)
+                {
+                    break;
+                }
+
+                string key = attrs.Substring(i, eq - i).Trim();
+                int valStart = eq + 1;
+                string value;
+                int next;
+
+                if (valStart < n && attrs[valStart] == '"')
+                {
+                    // Quoted value: read to the closing quote.
+                    int close = attrs.IndexOf('"', valStart + 1);
+                    if (close < 0)
+                    {
+                        value = attrs.Substring(valStart + 1);
+                        next = n;
+                    }
+                    else
+                    {
+                        value = attrs.Substring(valStart + 1, close - valStart - 1);
+                        // Skip past the closing quote and the following comma, if any.
+                        next = close + 1;
+                        int afterComma = attrs.IndexOf(',', next);
+                        next = afterComma < 0 ? n : afterComma + 1;
+                    }
+                }
+                else
+                {
+                    // Unquoted value: read to the next comma.
+                    int comma = attrs.IndexOf(',', valStart);
+                    if (comma < 0)
+                    {
+                        value = attrs.Substring(valStart);
+                        next = n;
+                    }
+                    else
+                    {
+                        value = attrs.Substring(valStart, comma - valStart);
+                        next = comma + 1;
+                    }
+                }
+
+                if (key.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return value.Trim();
+                }
+
+                i = next;
+            }
+
+            return null;
+        }
+
+        private static string DetermineFileExtension(string codec, IReadOnlyList<StreamSegment> segments)
+        {
+            // Prefer a concrete extension sniffed from a segment URL when present.
+            foreach (StreamSegment seg in segments)
+            {
+                string u = seg.Url;
+                if (u.IndexOf(".m4a", StringComparison.OrdinalIgnoreCase) >= 0
+                    || u.IndexOf(".m4s", StringComparison.OrdinalIgnoreCase) >= 0
+                    || u.IndexOf(".mp4", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return ".m4a";
+                }
+
+                if (u.IndexOf(".aac", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return ".aac";
+                }
+
+                if (u.IndexOf(".ts", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return ".ts";
+                }
+            }
+
+            // AAC-LC (mp4a.40.2) and ALAC (alac) are delivered fragmented-MP4 by Apple Music.
+            if (!string.IsNullOrEmpty(codec)
+                && (codec.IndexOf("mp4a", StringComparison.OrdinalIgnoreCase) >= 0
+                    || codec.IndexOf("alac", StringComparison.OrdinalIgnoreCase) >= 0))
+            {
+                return ".m4a";
+            }
+
+            return ".m4a";
+        }
+
+        /// <summary>
+        /// Resolves <paramref name="reference"/> against <paramref name="baseUrl"/>. Absolute references
+        /// are returned as-is; scheme-relative (<c>//host/path</c>) references take the base's scheme; when
+        /// no usable base is available the reference is returned unchanged.
+        /// </summary>
+        private static string ResolveUrl(string baseUrl, string reference)
+        {
+            if (string.IsNullOrEmpty(reference))
+            {
+                return baseUrl ?? string.Empty;
+            }
+
+            if (Uri.TryCreate(reference, UriKind.Absolute, out Uri? abs)
+                && (abs.Scheme == Uri.UriSchemeHttp || abs.Scheme == Uri.UriSchemeHttps))
+            {
+                return abs.ToString();
+            }
+
+            if (string.IsNullOrEmpty(baseUrl)
+                || !Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri? baseUri))
+            {
+                return reference;
+            }
+
+            // Scheme-relative (//host/path): .NET won't resolve these via the (base, relative) overload,
+            // so prepend the base scheme explicitly.
+            if (reference.StartsWith("//", StringComparison.Ordinal)
+                && Uri.TryCreate(baseUri.Scheme + ":" + reference, UriKind.Absolute, out Uri? schemeRelative))
+            {
+                return schemeRelative.ToString();
+            }
+
+            return Uri.TryCreate(baseUri, reference, out Uri? combined)
+                ? combined.ToString()
+                : reference;
+        }
+    }
+}

--- a/tests/Lidarr.Plugin.Common.Tests.csproj
+++ b/tests/Lidarr.Plugin.Common.Tests.csproj
@@ -32,6 +32,8 @@
     <None Include="fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
     <!-- DASH manifest golden fixtures for DashManifestParser tests -->
     <None Include="fixtures\**\*.mpd" CopyToOutputDirectory="PreserveNewest" />
+    <!-- HLS manifest golden fixtures for HlsManifestParser tests -->
+    <None Include="fixtures\**\*.m3u8" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Services/Streaming/Manifests/HlsManifestParserTests.cs
+++ b/tests/Services/Streaming/Manifests/HlsManifestParserTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.IO;
+using System.Linq;
+using Lidarr.Plugin.Common.Services.Streaming.Manifests;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.Services.Streaming.Manifests
+{
+    /// <summary>
+    /// Golden-file tests for <see cref="HlsManifestParser"/>. They assert EXACT variant extraction from a
+    /// master <c>.m3u8</c> (bandwidth/codec/URL, in file order) and EXACT segment extraction from a media
+    /// <c>.m3u8</c> (ordered URLs, <c>#EXTINF</c> durations, relative + absolute URL resolution), plus the
+    /// <c>#EXT-X-KEY</c> encryption flag and opaque <c>KEYID</c>. They are the regression guard for the
+    /// inline HLS walk that applemusicarr will migrate onto this shared parser.
+    /// </summary>
+    public sealed class HlsManifestParserTests
+    {
+        private readonly HlsManifestParser _parser = new();
+
+        private static string LoadFixture(string name)
+        {
+            string path = Path.Combine(AppContext.BaseDirectory, "fixtures", "manifests", name);
+            return File.ReadAllText(path);
+        }
+
+        [Theory]
+        [InlineData("application/vnd.apple.mpegurl")]
+        [InlineData("application/x-mpegurl")]
+        [InlineData("#EXTM3U")]
+        [InlineData("#EXTM3U\n#EXT-X-VERSION:6")]
+        [InlineData("https://cdn.example.com/track/master.m3u8")]
+        [InlineData("https://cdn.example.com/track/master.m3u8?token=abc")]
+        public void CanParse_RecognizesHlsByMimeContentOrExtension(string input)
+        {
+            Assert.True(_parser.CanParse(input));
+        }
+
+        [Theory]
+        [InlineData("application/dash+xml")]
+        [InlineData("<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\">")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CanParse_RejectsNonHls(string? input)
+        {
+            Assert.False(_parser.CanParse(input!));
+        }
+
+        // --- Fixture 1: master playlist with multiple #EXT-X-STREAM-INF variants ---
+
+        [Fact]
+        public void Master_ProducesVariantPerStreamInf_InFileOrder_WithBandwidthAndCodec()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_master.m3u8"),
+                "https://cdn.example.com/audio/track-7/master.m3u8");
+
+            Assert.Equal(3, manifest.Variants.Count);
+
+            // Bandwidths preserved in file order (NOT sorted).
+            Assert.Equal(new[] { 64000, 256000, 1411000 }, manifest.Variants.Select(v => v.BandwidthBps).ToArray());
+
+            // CODECS is a quoted list; the FIRST entry is the primary codec ("alac" for the lossless rendition).
+            Assert.Equal(new[] { "mp4a.40.2", "mp4a.40.2", "alac" }, manifest.Variants.Select(v => v.Codec).ToArray());
+        }
+
+        [Fact]
+        public void Master_ResolvesRelativeVariantUrls_AgainstBaseUrl()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_master.m3u8"),
+                "https://cdn.example.com/audio/track-7/master.m3u8");
+
+            Assert.Equal(
+                new[]
+                {
+                    "https://cdn.example.com/audio/track-7/aac-lc/64/prog_index.m3u8",
+                    "https://cdn.example.com/audio/track-7/aac-lc/256/prog_index.m3u8",
+                    "https://cdn.example.com/audio/track-7/alac/1411/prog_index.m3u8",
+                },
+                manifest.Variants.Select(v => v.Url).ToArray());
+        }
+
+        [Fact]
+        public void Master_HasNoSegments_AndIsNotEncrypted()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_master.m3u8"),
+                "https://cdn.example.com/audio/track-7/master.m3u8");
+
+            // A master playlist exposes variants only; the caller selects one and re-parses it.
+            Assert.Empty(manifest.Segments);
+            Assert.False(manifest.IsEncrypted);
+            Assert.Null(manifest.KeyId);
+            Assert.Null(manifest.Pssh);
+
+            // Manifest-level codec reflects the highest-bandwidth rendition (alac).
+            Assert.Equal("alac", manifest.Codec);
+            Assert.Equal(".m4a", manifest.FileExtension);
+        }
+
+        [Fact]
+        public void Master_VariantsAreSelectableByQualitySelector()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_master.m3u8"),
+                "https://cdn.example.com/audio/track-7/master.m3u8");
+
+            // The caller flow: parse master -> select a variant -> re-parse that variant.
+            StreamVariant? chosen = QualitySelector.SelectByBandwidthCeiling(manifest.Variants, 300000);
+            Assert.NotNull(chosen);
+            Assert.Equal(256000, chosen!.BandwidthBps);
+            Assert.Equal("https://cdn.example.com/audio/track-7/aac-lc/256/prog_index.m3u8", chosen.Url);
+        }
+
+        // --- Fixture 2: media (variant) playlist with #EXTINF segments + #EXT-X-KEY ---
+
+        [Fact]
+        public void Media_ExtractsOrderedSegments_WithExtInfDurations()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_variant_encrypted.m3u8"),
+                "https://cdn.example.com/audio/track-7/alac/1411/prog_index.m3u8");
+
+            // Three #EXTINF segments; #EXT-X-MAP / #EXT-X-KEY are NOT segments.
+            Assert.Equal(3, manifest.Segments.Count);
+
+            // Indices contiguous from 0, in file order.
+            Assert.Equal(new[] { 0, 1, 2 }, manifest.Segments.Select(s => s.Index).ToArray());
+
+            // Durations from #EXTINF:<seconds>,<title>.
+            Assert.Equal(new double?[] { 6.0, 6.0, 4.25 }, manifest.Segments.Select(s => s.DurationSeconds).ToArray());
+        }
+
+        [Fact]
+        public void Media_ResolvesRelativeAndAbsoluteSegmentUrls()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_variant_encrypted.m3u8"),
+                "https://cdn.example.com/audio/track-7/alac/1411/prog_index.m3u8");
+
+            Assert.Equal(
+                new[]
+                {
+                    // Relative URIs resolved against the variant playlist URL's directory.
+                    "https://cdn.example.com/audio/track-7/alac/1411/seg-0.m4s",
+                    "https://cdn.example.com/audio/track-7/alac/1411/seg-1.m4s",
+                    // Already-absolute URI passed through unchanged.
+                    "https://cdn.example.com/audio/track-7/alac/1411/seg-2.m4s",
+                },
+                manifest.Segments.Select(s => s.Url).ToArray());
+        }
+
+        [Fact]
+        public void Media_ExtKey_FlagsEncrypted_AndSurfacesKeyIdAsOpaqueData()
+        {
+            StreamManifest manifest = _parser.Parse(
+                LoadFixture("apple_variant_encrypted.m3u8"),
+                "https://cdn.example.com/audio/track-7/alac/1411/prog_index.m3u8");
+
+            Assert.True(manifest.IsEncrypted);
+
+            // KEYID is surfaced verbatim as opaque data (no parsing/decoding of the hex KID).
+            Assert.Equal("0x9eb4050de44b4802932e27d75083e266", manifest.KeyId);
+
+            // HLS carries no PSSH (that is a DASH/CENC construct).
+            Assert.Null(manifest.Pssh);
+
+            // Apple audio segments are fragmented MP4 -> .m4a.
+            Assert.Equal(".m4a", manifest.FileExtension);
+        }
+
+        [Fact]
+        public void Media_ExtKeyMethodNone_IsNotEncrypted()
+        {
+            const string playlist =
+                "#EXTM3U\n" +
+                "#EXT-X-VERSION:3\n" +
+                "#EXT-X-KEY:METHOD=NONE\n" +
+                "#EXTINF:6.0,\n" +
+                "seg-0.aac\n" +
+                "#EXT-X-ENDLIST\n";
+
+            StreamManifest manifest = _parser.Parse(playlist, "https://cdn.example.com/a/index.m3u8");
+
+            Assert.False(manifest.IsEncrypted);
+            Assert.Null(manifest.KeyId);
+            Assert.Single(manifest.Segments);
+
+            // .aac segment URL drives the extension sniff.
+            Assert.Equal(".aac", manifest.FileExtension);
+            Assert.Equal("https://cdn.example.com/a/seg-0.aac", manifest.Segments[0].Url);
+        }
+
+        [Fact]
+        public void Parse_EmptyContent_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => _parser.Parse("", "https://x/y.m3u8"));
+        }
+    }
+}

--- a/tests/fixtures/manifests/apple_master.m3u8
+++ b/tests/fixtures/manifests/apple_master.m3u8
@@ -1,0 +1,12 @@
+#EXTM3U
+#EXT-X-VERSION:6
+# Golden fixture: HLS MASTER playlist with three #EXT-X-STREAM-INF renditions.
+# Pins: BANDWIDTH parsing, CODECS (first entry of a quoted list) parsing, relative variant-URL
+# resolution against the base URL, and that a master exposes Variants (in file order) with NO
+# segments. Shape mirrors Apple Music's per-track master .m3u8 (AAC-LC + ALAC ladders).
+#EXT-X-STREAM-INF:BANDWIDTH=64000,CODECS="mp4a.40.2",AUDIO="aud"
+aac-lc/64/prog_index.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=256000,CODECS="mp4a.40.2",AUDIO="aud"
+aac-lc/256/prog_index.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1411000,CODECS="alac,mp4a.40.2",AUDIO="aud"
+alac/1411/prog_index.m3u8

--- a/tests/fixtures/manifests/apple_variant_encrypted.m3u8
+++ b/tests/fixtures/manifests/apple_variant_encrypted.m3u8
@@ -1,0 +1,19 @@
+#EXTM3U
+#EXT-X-VERSION:6
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PLAYLIST-TYPE:VOD
+# Golden fixture: HLS MEDIA (variant) playlist with #EXTINF segments and an #EXT-X-KEY.
+# Pins: ordered segment extraction (index 0..N in file order), #EXTINF duration parsing
+# (<seconds>,<title> form), relative + absolute segment-URL resolution against the base URL,
+# and that #EXT-X-KEY (METHOD!=NONE) flags IsEncrypted and surfaces KEYID as opaque KeyId.
+# The key URI is present but is intentionally NOT followed (parse-only seam).
+#EXT-X-KEY:METHOD=SAMPLE-AES,URI="skd://itunes.apple.com/key/abc",KEYFORMAT="com.apple.streamingkeydelivery",KEYFORMATVERSIONS="1",KEYID=0x9eb4050de44b4802932e27d75083e266
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.000,
+seg-0.m4s
+#EXTINF:6.000,
+seg-1.m4s
+#EXTINF:4.250,
+https://cdn.example.com/audio/track-7/alac/1411/seg-2.m4s
+#EXT-X-ENDLIST


### PR DESCRIPTION
## What

Adds `HlsManifestParser : IStreamManifestParser` to `src/Services/Streaming/Manifests/`, alongside the `DashManifestParser` lifted this cycle (#576). This gives HLS a home behind the shared `IStreamManifestParser` seam so **applemusicarr** (and future HLS plugins) can migrate off their inline `.m3u8` walk onto one shared, tested parser.

This PR is **parser-only**. It does **not** migrate apple (separate task) and adds **no** decrypt/key logic.

## Behavior

- **`CanParse`** — recognizes HLS by MIME (`application/vnd.apple.mpegurl`, `application/x-mpegurl`, any `*mpegurl`), by `.m3u8` extension (query string tolerated), or by an `#EXTM3U` content sniff. Rejects DASH (`application/dash+xml`, `<MPD ...>`), empty, and null.
- **`Parse(content, baseUrl)`**
  - A playlist carrying any `#EXT-X-STREAM-INF` is treated as a **master**: returns its renditions in `Variants` (`BANDWIDTH` -> `BandwidthBps`, first entry of the `CODECS` list -> `Codec`, variant URI resolved vs `baseUrl`), **in file order**, with empty `Segments`. The caller selects a variant (e.g. `QualitySelector.SelectByBandwidthCeiling`) and re-parses that variant's playlist — mirroring how `DashManifestParser` exposes `Representation`s and how Apple's downloader follows the chosen variant.
  - A **media** playlist returns ordered `StreamSegment`s with `#EXTINF:<seconds>` durations and relative / scheme-relative (`//host/...`) / absolute URL resolution vs `baseUrl`.
  - `#EXT-X-KEY` with `METHOD` != `NONE` sets `IsEncrypted` and surfaces `KEYID` as **opaque** `KeyId`; `METHOD=NONE` clears it. The key `URI` is intentionally **not** followed. `Pssh` stays `null` (PSSH is a DASH/CENC construct, absent from HLS).

## Tests (golden-file)

`tests/Services/Streaming/Manifests/HlsManifestParserTests.cs` against two fixtures in `tests/fixtures/manifests/`:
- `apple_master.m3u8` — three `#EXT-X-STREAM-INF` renditions (AAC-LC 64k/256k + ALAC 1411k). Asserts exact bandwidths/codecs in file order, relative variant-URL resolution, empty segments, not-encrypted, and `QualitySelector` round-trip.
- `apple_variant_encrypted.m3u8` — `#EXTINF` segments + `#EXT-X-KEY` (SAMPLE-AES) + `#EXT-X-MAP`. Asserts exact ordered segment URLs (relative + absolute), `#EXTINF` durations, `IsEncrypted`/opaque `KeyId`, and that `#EXT-X-MAP`/`#EXT-X-KEY` are not miscounted as segments.

The tests csproj now copies `fixtures/**/*.m3u8` to the test output dir.

## API / build

- `src/PublicAPI/net8.0/PublicAPI.Unshipped.txt` updated for the new surface (class + ctor + `CanParse`/`Parse`). No `net6.0` PublicAPI dir exists on `main` (single `net8.0` TFM), so none added.
- `dotnet build` **clean** (Debug). Built with analyzers forced on (`-p:RunAnalyzersDuringBuild=true -p:EnableNETAnalyzers=true`): **no RS0016/RS0017** for the new surface. (Pre-existing, unrelated CA1416/RS0025 warnings only.)
- All 37 `Streaming.Manifests` tests pass (19 new HLS + existing DASH/QualitySelector) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)