### PR TITLE
harden(packaging): serialize MSBuild in New-PluginPackage (-m:1) to fix deps.json race

### DIFF
--- a/tools/PluginPack.psm1
+++ b/tools/PluginPack.psm1
@@ -23,7 +23,11 @@ function Get-PluginOutput {
 
     # Use `dotnet build` instead of `dotnet publish` so projects using PluginPackaging.targets
     # (ILRepack) produce the same merged output that is used in real plugin deployment.
-    $buildArgs = @($projectPath, '-c', $Configuration, '-f', $Framework, '-o', $publishDirectory,
+    # `-m:1` serializes MSBuild project builds. ILRepack-merged plugin projects reference the same
+    # Abstractions/Common projects; parallel builds can run GenerateDepsFile for one project twice at
+    # once and collide on `*.deps.json` ("being used by another process"), an intermittent packaging
+    # failure. Serializing removes the race at negligible cost for these small project graphs.
+    $buildArgs = @($projectPath, '-c', $Configuration, '-f', $Framework, '-o', $publishDirectory, '-m:1',
         '/p:CopyLocalLockFileAssemblies=true', '/p:ContinuousIntegrationBuild=true')
     if ($ExtraBuildArgs) { $buildArgs += $ExtraBuildArgs }
     # Capture build output so failures are diagnosable. Previously piped to Out-Null,


### PR DESCRIPTION
## Problem
Plugin `packaging-gates` intermittently fails with:
> `error MSB4018: GenerateDepsFile … System.IO.IOException: cannot access '…Abstractions.deps.json' because it is being used by another process` (preceded by *"same project built more than once in parallel"*).

`tools/PluginPack.psm1` (shared by every plugin's packaging) ran `dotnet build` with **default parallelism**, so the same Abstractions/Common project's `GenerateDepsFile` could run twice concurrently and collide.

## Fix
Add `-m:1` to the build args (serialize MSBuild project builds) — matches what Common's own `ci.yml` build steps already use. Negligible cost for these small graphs; removes the race. No output/behavior change.

## Verification
- Module parses + imports cleanly; `New-PluginPackage` exported.
- `-m:1` is already a proven flag in Common CI and local builds.
- Parity-to-Common: one fix hardens packaging for all 4 plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)