### PR TITLE
feat(hostbridge): lift AlbumSizeEstimator + MultiQualityReleaseBuilder into Common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Template to copy when drafting a release:
 
 ## [Unreleased]
 
+### Added
+- **`AlbumSizeEstimator`** (`Lidarr.Plugin.Common.HostBridge`) — shared release-size estimator: `bytes = durationSeconds × (bitrate ÷ 8)` with an optional floor, plus a duration-fallback ladder (album duration → summed track durations → count × average). Lifts the duplicated `EstimateAlbumSize` (tidalarr) / `QualitySizeCalculator` (qobuzarr) logic into one place. Bitrate is bits-per-second as a `double` so non-round per-quality bitrates (e.g. Qobuz FLAC ≈ 1 411 200 bps) aren't truncated, and double arithmetic avoids the `int × int` overflow a kbps integer formula hits on long hi-res albums.
+- **`MultiQualityReleaseBuilder` / `MultiQualityRelease`** (`Lidarr.Plugin.Common.HostBridge`) — emits one release per available quality for an album by composing `AlbumReleaseInfoBuilder` (per-tier GUID/URL/title) and `AlbumSizeEstimator` (per-tier size). Consolidates the "offer all quality tiers" indexer pattern (tidalarr `ConvertToReleaseInfosStatic`, qobuzarr's per-quality parser loop). Common cannot reference the host `ReleaseInfo` type, so `Build()` returns neutral `MultiQualityRelease` rows the plugin maps onto its own release object.
+
 ### Deprecations
 - **`IAuthFailureGateRegistry` / `AuthFailureGateRegistry`** — deprecated in favour of a direct `ConcurrentDictionary<string, AuthFailureGate>` per-plugin. A Wave-26 adversarial audit found zero non-test plugin consumers across all four ecosystem repos; every real call-site builds its own gate map so it can pair a custom `IAuthFailureHandler` (e.g. `SlidingWindowAuthFailureHandler`) with each gate — something the registry cannot do because it hard-wires `DefaultAuthFailureHandler` internally. Both the interface and the concrete class are marked `[Obsolete(error: false)]`. They will be removed in v2.0.0.
 

--- a/src/HostBridge/AlbumSizeEstimator.cs
+++ b/src/HostBridge/AlbumSizeEstimator.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+
+namespace Lidarr.Plugin.Common.HostBridge;
+
+/// <summary>
+/// Estimates the on-disk byte size of a streaming album/track from its duration and bitrate.
+/// Every RicherTunes streaming-service plugin computes a <c>ReleaseInfo.Size</c> the same way
+/// — <c>bytes = durationSeconds × (bitrate ÷ 8)</c>, optionally floored — but each rolled its
+/// own copy (tidalarr's <c>EstimateAlbumSize</c>, qobuzarr's <c>QualitySizeCalculator</c>).
+///
+/// <para><strong>Unit convention:</strong> bitrate is expressed in <em>bits per second</em> as a
+/// <see cref="double"/>. This is deliberate — Qobuz's per-quality bitrates are not round kbps
+/// (e.g. FLAC ≈ 1 411 200 bps = 1411.2 kbps), so an <c>int kbps</c> parameter would truncate and
+/// shift the computed size. Callers holding kbps pass <c>kbps × 1000</c>.</para>
+///
+/// <para>The arithmetic is done in <see cref="double"/> and cast once at the end, which also
+/// sidesteps the latent <c>int × int × int</c> overflow a kbps-based integer formula hits on long
+/// hi-res albums (e.g. a 2-hour 24-bit/96 kHz album exceeds <see cref="int.MaxValue"/>).</para>
+/// </summary>
+public static class AlbumSizeEstimator
+{
+    /// <summary>
+    /// Conventional 1 MB floor. Lidarr can mishandle a zero/near-zero release size, so plugins
+    /// that want a non-zero guarantee pass this (or their own value) as <c>minimumBytes</c>.
+    /// </summary>
+    public const long DefaultMinimumSizeBytes = 1024L * 1024L;
+
+    /// <summary>
+    /// Estimate the byte size of audio of the given duration at the given bitrate.
+    /// </summary>
+    /// <param name="durationSeconds">Total playback duration in seconds.</param>
+    /// <param name="bitsPerSecond">Encoded bitrate in bits per second (not kbps).</param>
+    /// <param name="minimumBytes">
+    /// Lower bound on the returned size. When the computed size is below this (including the
+    /// degenerate case of a non-positive duration or bitrate), <paramref name="minimumBytes"/> is
+    /// returned instead. Defaults to 0 (no floor). Negative values are treated as 0.
+    /// </param>
+    /// <returns>Estimated size in bytes, never less than <paramref name="minimumBytes"/>.</returns>
+    public static long EstimateBytesFromBitrate(double durationSeconds, double bitsPerSecond, long minimumBytes = 0)
+    {
+        if (minimumBytes < 0)
+        {
+            minimumBytes = 0;
+        }
+
+        if (durationSeconds <= 0 || bitsPerSecond <= 0)
+        {
+            return minimumBytes;
+        }
+
+        var bytes = (long)(durationSeconds * (bitsPerSecond / 8.0));
+        return Math.Max(bytes, minimumBytes);
+    }
+
+    /// <summary>
+    /// Resolve the most reliable album duration from the data a plugin has, using the shared
+    /// fallback ladder: (1) an explicit album duration, else (2) the sum of per-track durations,
+    /// else (3) a count × per-track-average estimate — never below <paramref name="minimumSeconds"/>.
+    /// </summary>
+    /// <param name="albumDurationSeconds">Album-level duration if known; ignored when ≤ 0.</param>
+    /// <param name="trackDurationsSeconds">
+    /// Per-track durations in seconds. Non-positive entries are ignored. When the collection is
+    /// null/empty or every entry is non-positive, the ladder falls through to the count estimate.
+    /// </param>
+    /// <param name="fallbackTrackCount">Track count used by the count estimate; coerced to ≥ 1.</param>
+    /// <param name="averageTrackSeconds">Assumed average track length for the count estimate.</param>
+    /// <param name="minimumSeconds">Floor for the count estimate (e.g. 30s). Ignored when ≤ 0.</param>
+    public static double EstimateDurationSeconds(
+        double albumDurationSeconds,
+        IReadOnlyCollection<double>? trackDurationsSeconds,
+        int fallbackTrackCount,
+        double averageTrackSeconds,
+        double minimumSeconds = 0)
+    {
+        if (albumDurationSeconds > 0)
+        {
+            return albumDurationSeconds;
+        }
+
+        if (trackDurationsSeconds is { Count: > 0 })
+        {
+            double sum = 0;
+            foreach (var d in trackDurationsSeconds)
+            {
+                if (d > 0)
+                {
+                    sum += d;
+                }
+            }
+
+            if (sum > 0)
+            {
+                return sum;
+            }
+        }
+
+        var count = fallbackTrackCount > 0 ? fallbackTrackCount : 1;
+        var avg = averageTrackSeconds > 0 ? averageTrackSeconds : 0;
+        var estimate = count * avg;
+        return minimumSeconds > 0 ? Math.Max(estimate, minimumSeconds) : estimate;
+    }
+}

--- a/src/HostBridge/MultiQualityReleaseBuilder.cs
+++ b/src/HostBridge/MultiQualityReleaseBuilder.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+
+namespace Lidarr.Plugin.Common.HostBridge;
+
+/// <summary>
+/// One quality variant produced by <see cref="MultiQualityReleaseBuilder"/>: the neutral
+/// <c>ReleaseInfo</c> string fields plus the estimated size. Common cannot reference the host
+/// <c>NzbDrone.Core.Indexers.ReleaseInfo</c> type, so the plugin maps each row onto its own
+/// release object (setting <c>Guid</c>, <c>DownloadUrl</c>, <c>Title</c>, <c>Size</c>).
+/// </summary>
+/// <param name="QualityHint">The quality token that disambiguates this release (e.g. "Lossless", "FLAC").</param>
+/// <param name="Guid">Stable per-quality GUID from <see cref="AlbumReleaseInfoBuilder"/>.</param>
+/// <param name="DownloadUrl">Per-quality download URL from <see cref="AlbumReleaseInfoBuilder"/>.</param>
+/// <param name="Title">Release title from <see cref="AlbumReleaseInfoBuilder"/>.</param>
+/// <param name="SizeBytes">Estimated size from <see cref="AlbumSizeEstimator"/>.</param>
+public sealed record MultiQualityRelease(
+    string QualityHint,
+    string Guid,
+    string DownloadUrl,
+    string Title,
+    long SizeBytes);
+
+/// <summary>
+/// Builds one release per available quality for a single album — the pattern every streaming
+/// plugin's indexer emits so Lidarr shows the user all quality options (tidalarr's
+/// <c>ConvertToReleaseInfosStatic</c>, qobuzarr's per-quality parser loop). It composes the
+/// existing <see cref="AlbumReleaseInfoBuilder"/> (called once per tier, with the album-level
+/// fields held constant and the per-tier format/extra/quality tokens varied) and
+/// <see cref="AlbumSizeEstimator"/> (one size per tier), so the only thing a plugin supplies is
+/// its own list of quality specs via <see cref="AddQuality"/>.
+///
+/// <para>Album-level markers (edition / explicit / live) are set once and applied to every tier.
+/// Tidal leaves them unset; qobuz pre-computes them from its metadata and sets them here.</para>
+/// </summary>
+public sealed class MultiQualityReleaseBuilder
+{
+    private readonly List<QualitySpec> _qualities = new();
+
+    private string? _artist;
+    private string? _album;
+    private int? _year;
+    private string? _scheme;
+    private string? _albumId;
+    private string? _releaseGroup;
+    private string? _editionMarker;
+    private bool _explicitMarker;
+    private bool _liveMarker;
+    private double _durationSeconds;
+    private long _minimumSizeBytes;
+
+    private readonly record struct QualitySpec(string QualityHint, string? FormatMarker, string? ExtraMarker, double BitsPerSecond);
+
+    /// <summary>Artist display name. Required.</summary>
+    public MultiQualityReleaseBuilder WithArtist(string artist)
+    {
+        _artist = artist;
+        return this;
+    }
+
+    /// <summary>Album title. Required.</summary>
+    public MultiQualityReleaseBuilder WithAlbum(string album)
+    {
+        _album = album;
+        return this;
+    }
+
+    /// <summary>Release year. When null or ≤ 0 the year parentheses are omitted from titles.</summary>
+    public MultiQualityReleaseBuilder WithYear(int? year)
+    {
+        _year = year;
+        return this;
+    }
+
+    /// <summary>Plugin scheme literal (<c>tidal</c>, <c>qobuz</c>, …). Required — GUID prefix + URL scheme.</summary>
+    public MultiQualityReleaseBuilder WithScheme(string scheme)
+    {
+        _scheme = scheme;
+        return this;
+    }
+
+    /// <summary>Service-specific album identifier. Required.</summary>
+    public MultiQualityReleaseBuilder WithAlbumId(string albumId)
+    {
+        _albumId = albumId;
+        return this;
+    }
+
+    /// <summary>Release-group tag (last title bracket). When unset, <see cref="AlbumReleaseInfoBuilder"/>'s default (<c>WEB</c>) is used.</summary>
+    public MultiQualityReleaseBuilder WithReleaseGroup(string group)
+    {
+        _releaseGroup = group;
+        return this;
+    }
+
+    /// <summary>Optional edition bracket applied to every tier (e.g. <c>Deluxe</c>, <c>Remastered</c>).</summary>
+    public MultiQualityReleaseBuilder WithEditionMarker(string? edition)
+    {
+        _editionMarker = edition;
+        return this;
+    }
+
+    /// <summary>When true, an <c>[Explicit]</c> bracket is applied to every tier.</summary>
+    public MultiQualityReleaseBuilder WithExplicitMarker(bool isExplicit)
+    {
+        _explicitMarker = isExplicit;
+        return this;
+    }
+
+    /// <summary>When true, a <c>[LIVE]</c> bracket is applied to every tier.</summary>
+    public MultiQualityReleaseBuilder WithLiveMarker(bool isLive)
+    {
+        _liveMarker = isLive;
+        return this;
+    }
+
+    /// <summary>
+    /// Album playback duration in seconds, used by <see cref="AlbumSizeEstimator"/> for every tier.
+    /// When ≤ 0, sizes fall back to <see cref="WithMinimumSizeBytes"/> (or 0).
+    /// </summary>
+    public MultiQualityReleaseBuilder WithDurationSeconds(double durationSeconds)
+    {
+        _durationSeconds = durationSeconds;
+        return this;
+    }
+
+    /// <summary>Lower bound applied to every tier's estimated size (e.g. <see cref="AlbumSizeEstimator.DefaultMinimumSizeBytes"/>).</summary>
+    public MultiQualityReleaseBuilder WithMinimumSizeBytes(long minimumBytes)
+    {
+        _minimumSizeBytes = minimumBytes;
+        return this;
+    }
+
+    /// <summary>
+    /// Add one quality tier. Call once per quality the album is offered in.
+    /// </summary>
+    /// <param name="qualityHint">
+    /// Quality token appended to the GUID/URL so each tier has a distinct, stable identifier
+    /// (e.g. "Lossless", "HiRes", "FLAC"). Required.
+    /// </param>
+    /// <param name="formatMarker">Title format bracket (e.g. <c>FLAC</c>, <c>AAC</c>, <c>MP3 320kbps</c>). Optional.</param>
+    /// <param name="extraMarker">Second title bracket (e.g. <c>HIRES</c>, <c>320</c>). Optional.</param>
+    /// <param name="bitsPerSecond">Encoded bitrate in bits per second for size estimation (see <see cref="AlbumSizeEstimator"/>).</param>
+    public MultiQualityReleaseBuilder AddQuality(string qualityHint, string? formatMarker, string? extraMarker, double bitsPerSecond)
+    {
+        if (string.IsNullOrWhiteSpace(qualityHint))
+        {
+            throw new ArgumentException("Quality hint must be non-empty.", nameof(qualityHint));
+        }
+
+        _qualities.Add(new QualitySpec(qualityHint, formatMarker, extraMarker, bitsPerSecond));
+        return this;
+    }
+
+    /// <summary>
+    /// Produce one <see cref="MultiQualityRelease"/> per added quality, in insertion order.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no qualities were added. Required album fields are validated by the underlying
+    /// <see cref="AlbumReleaseInfoBuilder"/>.
+    /// </exception>
+    public IReadOnlyList<MultiQualityRelease> Build()
+    {
+        if (_qualities.Count == 0)
+        {
+            throw new InvalidOperationException("At least one quality must be added via AddQuality().");
+        }
+
+        var results = new List<MultiQualityRelease>(_qualities.Count);
+        foreach (var q in _qualities)
+        {
+            var builder = new AlbumReleaseInfoBuilder()
+                .WithArtist(_artist!)
+                .WithAlbum(_album!)
+                .WithYear(_year)
+                .WithEditionMarker(_editionMarker)
+                .WithExplicitMarker(_explicitMarker)
+                .WithLiveMarker(_liveMarker)
+                .WithFormatMarker(q.FormatMarker)
+                .WithExtraMarker(q.ExtraMarker)
+                .WithScheme(_scheme!)
+                .WithAlbumId(_albumId!)
+                .WithQualityHint(q.QualityHint);
+
+            if (!string.IsNullOrWhiteSpace(_releaseGroup))
+            {
+                builder.WithReleaseGroup(_releaseGroup!);
+            }
+
+            var (guid, downloadUrl, title) = builder.Build();
+            var size = AlbumSizeEstimator.EstimateBytesFromBitrate(_durationSeconds, q.BitsPerSecond, _minimumSizeBytes);
+
+            results.Add(new MultiQualityRelease(q.QualityHint, guid, downloadUrl, title, size));
+        }
+
+        return results;
+    }
+}

--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -142,3 +142,34 @@ Lidarr.Plugin.Common.Services.Streaming.Manifests.HlsManifestParser.CanParse(str
 Lidarr.Plugin.Common.Services.Streaming.Manifests.HlsManifestParser.Parse(string! manifestContent, string! baseUrl) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamManifest!
 Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector
 static Lidarr.Plugin.Common.Services.Streaming.Manifests.QualitySelector.SelectByBandwidthCeiling(System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant!>! variants, int ceilingBps) -> Lidarr.Plugin.Common.Services.Streaming.Manifests.StreamVariant?
+Lidarr.Plugin.Common.HostBridge.AlbumSizeEstimator
+const Lidarr.Plugin.Common.HostBridge.AlbumSizeEstimator.DefaultMinimumSizeBytes = 1048576 -> long
+static Lidarr.Plugin.Common.HostBridge.AlbumSizeEstimator.EstimateBytesFromBitrate(double durationSeconds, double bitsPerSecond, long minimumBytes = 0) -> long
+static Lidarr.Plugin.Common.HostBridge.AlbumSizeEstimator.EstimateDurationSeconds(double albumDurationSeconds, System.Collections.Generic.IReadOnlyCollection<double>? trackDurationsSeconds, int fallbackTrackCount, double averageTrackSeconds, double minimumSeconds = 0) -> double
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.MultiQualityRelease(string! QualityHint, string! Guid, string! DownloadUrl, string! Title, long SizeBytes) -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.QualityHint.get -> string!
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.QualityHint.init -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.Guid.get -> string!
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.Guid.init -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.DownloadUrl.get -> string!
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.DownloadUrl.init -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.Title.get -> string!
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.Title.init -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.SizeBytes.get -> long
+Lidarr.Plugin.Common.HostBridge.MultiQualityRelease.SizeBytes.init -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.MultiQualityReleaseBuilder() -> void
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.AddQuality(string! qualityHint, string? formatMarker, string? extraMarker, double bitsPerSecond) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.Build() -> System.Collections.Generic.IReadOnlyList<Lidarr.Plugin.Common.HostBridge.MultiQualityRelease!>!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithAlbum(string! album) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithAlbumId(string! albumId) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithArtist(string! artist) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithDurationSeconds(double durationSeconds) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithEditionMarker(string? edition) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithExplicitMarker(bool isExplicit) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithLiveMarker(bool isLive) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithMinimumSizeBytes(long minimumBytes) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithReleaseGroup(string! group) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithScheme(string! scheme) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithYear(int? year) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!

--- a/tests/HostBridge/AlbumSizeEstimatorTests.cs
+++ b/tests/HostBridge/AlbumSizeEstimatorTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using Lidarr.Plugin.Common.HostBridge;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.HostBridge;
+
+/// <summary>
+/// TDD pins for <see cref="AlbumSizeEstimator"/> — the shared duration×bitrate→bytes kernel
+/// that tidalarr (<c>EstimateAlbumSize</c>) and qobuzarr (<c>QualitySizeCalculator</c>) each
+/// hand-rolled. The equivalence tests assert the lifted helper reproduces both plugins' formulas
+/// byte-for-byte so adoption is provably behavior-preserving.
+/// </summary>
+public class AlbumSizeEstimatorTests
+{
+    [Fact]
+    public void EstimateBytesFromBitrate_BasicCase_MultipliesDurationByBytesPerSecond()
+    {
+        // 200s @ 1,411,200 bps → 200 * (1411200/8) = 200 * 176400 = 35,280,000
+        Assert.Equal(35_280_000L, AlbumSizeEstimator.EstimateBytesFromBitrate(200, 1_411_200));
+    }
+
+    [Fact]
+    public void EstimateBytesFromBitrate_MatchesTidalIntegerFormula_ForRepresentativeAlbum()
+    {
+        // tidal: totalDurationSeconds * bitrateKbps * 125  (kbps×125 = kbps×1000/8 = bytes/sec)
+        // here 2400s @ 3000 kbps → 2400 * 3000 * 125 = 900,000,000
+        const long tidalFormula = 2400L * 3000L * 125L;
+        Assert.Equal(tidalFormula, AlbumSizeEstimator.EstimateBytesFromBitrate(2400, 3_000 * 1000.0));
+    }
+
+    [Fact]
+    public void EstimateBytesFromBitrate_MatchesQobuzDoubleFormula_ForFlacLossless()
+    {
+        // qobuz: (long)(durationSeconds * (bitrate / 8.0)) with bitrate = 1,411,200 bps
+        const double duration = 3600;
+        const double bits = 1_411_200;
+        var qobuzFormula = (long)(duration * (bits / 8.0));
+        Assert.Equal(qobuzFormula, AlbumSizeEstimator.EstimateBytesFromBitrate(duration, bits));
+    }
+
+    [Theory]
+    [InlineData(0, 1_000_000)]      // zero duration
+    [InlineData(-5, 1_000_000)]     // negative duration
+    public void EstimateBytesFromBitrate_NonPositiveDuration_ReturnsFloor(double duration, double bits)
+    {
+        Assert.Equal(500L, AlbumSizeEstimator.EstimateBytesFromBitrate(duration, bits, minimumBytes: 500));
+    }
+
+    [Fact]
+    public void EstimateBytesFromBitrate_NonPositiveBitrate_ReturnsFloor()
+    {
+        Assert.Equal(500L, AlbumSizeEstimator.EstimateBytesFromBitrate(100, 0, minimumBytes: 500));
+    }
+
+    [Fact]
+    public void EstimateBytesFromBitrate_ComputedBelowFloor_ReturnsFloor()
+    {
+        // 1s @ 8 bps → 1 byte, below 1 MB floor
+        Assert.Equal(AlbumSizeEstimator.DefaultMinimumSizeBytes,
+            AlbumSizeEstimator.EstimateBytesFromBitrate(1, 8, AlbumSizeEstimator.DefaultMinimumSizeBytes));
+    }
+
+    [Fact]
+    public void EstimateBytesFromBitrate_NoFloorByDefault_ReturnsRawEstimate()
+    {
+        Assert.Equal(100L, AlbumSizeEstimator.EstimateBytesFromBitrate(1, 800));
+    }
+
+    [Fact]
+    public void EstimateBytesFromBitrate_NegativeFloor_TreatedAsZero()
+    {
+        Assert.Equal(10_000L, AlbumSizeEstimator.EstimateBytesFromBitrate(100, 800, minimumBytes: -10));
+    }
+
+    [Fact]
+    public void EstimateDurationSeconds_PrefersExplicitAlbumDuration()
+    {
+        var result = AlbumSizeEstimator.EstimateDurationSeconds(1800, new[] { 100.0, 200.0 }, 12, 240, 30);
+        Assert.Equal(1800, result);
+    }
+
+    [Fact]
+    public void EstimateDurationSeconds_SumsTrackDurations_IgnoringNonPositive()
+    {
+        var result = AlbumSizeEstimator.EstimateDurationSeconds(0, new[] { 100.0, 200.0, 0.0, -5.0 }, 12, 240, 30);
+        Assert.Equal(300, result);
+    }
+
+    [Fact]
+    public void EstimateDurationSeconds_FallsBackToCountTimesAverage()
+    {
+        var result = AlbumSizeEstimator.EstimateDurationSeconds(0, null, 10, 240, 30);
+        Assert.Equal(2400, result);
+    }
+
+    [Fact]
+    public void EstimateDurationSeconds_AllTracksZero_FallsBackToCountEstimate()
+    {
+        var result = AlbumSizeEstimator.EstimateDurationSeconds(0, new[] { 0.0, 0.0 }, 5, 60, 30);
+        Assert.Equal(300, result);
+    }
+
+    [Fact]
+    public void EstimateDurationSeconds_AppliesMinimumFloor()
+    {
+        // count coerced to 1, average 0 → 0, floored to 30
+        var result = AlbumSizeEstimator.EstimateDurationSeconds(0, null, 0, 0, 30);
+        Assert.Equal(30, result);
+    }
+}

--- a/tests/HostBridge/MultiQualityReleaseBuilderTests.cs
+++ b/tests/HostBridge/MultiQualityReleaseBuilderTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Linq;
+using Lidarr.Plugin.Common.HostBridge;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests.HostBridge;
+
+/// <summary>
+/// TDD pins for <see cref="MultiQualityReleaseBuilder"/> — the "one release per available quality"
+/// pattern emitted by tidalarr's <c>ConvertToReleaseInfosStatic</c> and qobuzarr's per-quality
+/// parser loop. Verifies it composes <see cref="AlbumReleaseInfoBuilder"/> (distinct per-tier GUID
+/// + title markers) and <see cref="AlbumSizeEstimator"/> (per-tier size) correctly.
+/// </summary>
+public class MultiQualityReleaseBuilderTests
+{
+    private static MultiQualityReleaseBuilder BaseBuilder() =>
+        new MultiQualityReleaseBuilder()
+            .WithArtist("Miles Davis")
+            .WithAlbum("Kind of Blue")
+            .WithYear(1959)
+            .WithScheme("tidal")
+            .WithAlbumId("12345")
+            .WithDurationSeconds(2400);
+
+    [Fact]
+    public void Build_EmitsOneReleasePerQuality_InInsertionOrder()
+    {
+        var releases = BaseBuilder()
+            .AddQuality("Lossless", "FLAC", null, 1_000 * 1000.0)
+            .AddQuality("HiRes", "FLAC", "HIRES", 3_000 * 1000.0)
+            .Build();
+
+        Assert.Equal(2, releases.Count);
+        Assert.Equal("Lossless", releases[0].QualityHint);
+        Assert.Equal("HiRes", releases[1].QualityHint);
+    }
+
+    [Fact]
+    public void Build_ProducesDistinctPerQualityGuidsAndUrls()
+    {
+        var releases = BaseBuilder()
+            .AddQuality("Lossless", "FLAC", null, 1_000 * 1000.0)
+            .AddQuality("HiRes", "FLAC", "HIRES", 3_000 * 1000.0)
+            .Build();
+
+        Assert.Equal("tidal:album:12345:Lossless", releases[0].Guid);
+        Assert.Equal("tidal:album:12345:HiRes", releases[1].Guid);
+        Assert.Equal("tidal://album/12345?quality=Lossless", releases[0].DownloadUrl);
+        Assert.Equal("tidal://album/12345?quality=HiRes", releases[1].DownloadUrl);
+        Assert.Equal(2, releases.Select(r => r.Guid).Distinct().Count());
+    }
+
+    [Fact]
+    public void Build_ComposesTitleMarkersPerTier()
+    {
+        var releases = BaseBuilder()
+            .AddQuality("Lossless", "FLAC", null, 1_000 * 1000.0)
+            .AddQuality("HiRes", "FLAC", "HIRES", 3_000 * 1000.0)
+            .Build();
+
+        Assert.Equal("Miles Davis - Kind of Blue (1959) [FLAC] [WEB]", releases[0].Title);
+        Assert.Equal("Miles Davis - Kind of Blue (1959) [FLAC] [HIRES] [WEB]", releases[1].Title);
+    }
+
+    [Fact]
+    public void Build_EstimatesSizePerTier_FromDurationAndBitrate()
+    {
+        var releases = BaseBuilder()
+            .AddQuality("Lossless", "FLAC", null, 1_000 * 1000.0)
+            .AddQuality("HiRes", "FLAC", "HIRES", 3_000 * 1000.0)
+            .Build();
+
+        Assert.Equal(2400L * 1000 * 125, releases[0].SizeBytes); // 1000 kbps
+        Assert.Equal(2400L * 3000 * 125, releases[1].SizeBytes); // 3000 kbps
+    }
+
+    [Fact]
+    public void Build_AppliesAlbumLevelMarkersToEveryTier()
+    {
+        var releases = BaseBuilder()
+            .WithEditionMarker("Deluxe")
+            .WithExplicitMarker(true)
+            .WithLiveMarker(true)
+            .AddQuality("Lossless", "FLAC", null, 1_000 * 1000.0)
+            .Build();
+
+        Assert.Equal("Miles Davis - Kind of Blue (1959) [Deluxe] [Explicit] [LIVE] [FLAC] [WEB]", releases[0].Title);
+    }
+
+    [Fact]
+    public void Build_HonorsCustomReleaseGroup()
+    {
+        var releases = BaseBuilder()
+            .WithReleaseGroup("WEB-DL")
+            .AddQuality("Lossless", "FLAC", null, 1_000 * 1000.0)
+            .Build();
+
+        Assert.EndsWith("[FLAC] [WEB-DL]", releases[0].Title);
+    }
+
+    [Fact]
+    public void Build_AppliesMinimumSizeFloorPerTier()
+    {
+        var releases = new MultiQualityReleaseBuilder()
+            .WithArtist("A").WithAlbum("B").WithScheme("qobuz").WithAlbumId("9")
+            .WithDurationSeconds(0) // unknown duration → size falls to floor
+            .WithMinimumSizeBytes(AlbumSizeEstimator.DefaultMinimumSizeBytes)
+            .AddQuality("FLAC", "FLAC", null, 1_411_200)
+            .Build();
+
+        Assert.Equal(AlbumSizeEstimator.DefaultMinimumSizeBytes, releases[0].SizeBytes);
+    }
+
+    [Fact]
+    public void Build_WithNoQualities_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => BaseBuilder().Build());
+    }
+
+    [Fact]
+    public void Build_WithMissingRequiredAlbumField_Throws()
+    {
+        // No artist set → AlbumReleaseInfoBuilder rejects it.
+        var builder = new MultiQualityReleaseBuilder()
+            .WithAlbum("B").WithScheme("qobuz").WithAlbumId("9")
+            .AddQuality("FLAC", "FLAC", null, 1_411_200);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void AddQuality_WithBlankHint_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => BaseBuilder().AddQuality("  ", "FLAC", null, 1_000_000));
+    }
+}


### PR DESCRIPTION
Both **tidalarr** and **qobuzarr** independently hand-roll two indexer-side concerns. This lifts the shared kernels into Common (additive — no existing API changed) so the existing plugins converge and future ones (amazonmusicarr) get them for free.

## `AlbumSizeEstimator` (`Lidarr.Plugin.Common.HostBridge`)
`bytes = durationSeconds × (bitrate ÷ 8)` with an optional floor, plus a duration-fallback ladder (album duration → summed track durations → count × average). Replaces:
- tidalarr `EstimateAlbumSize` (`TidalLidarrIndexer.cs`)
- qobuzarr `QualitySizeCalculator` (`Indexers/Parsing/QualitySizeCalculator.cs`)

**Design notes (verified against both call sites):**
- Bitrate is **bits-per-second as `double`** — Qobuz's per-quality bitrates aren't round kbps (FLAC = `1 411 200` bps = 1411.2 kbps), so an `int kbps` param would truncate and shift the byte output.
- Double arithmetic also fixes a **latent `int × int × 125` overflow** in tidal's integer formula (a ~2-hour 24-bit/96 kHz album exceeds `int.MaxValue`).
- Tests assert **byte-for-byte equivalence with both plugins' existing formulas**, so adoption is provably behavior-preserving.

## `MultiQualityReleaseBuilder` / `MultiQualityRelease` (`Lidarr.Plugin.Common.HostBridge`)
Emits one release per available quality for an album by composing the existing `AlbumReleaseInfoBuilder` (per-tier GUID/URL/title) and `AlbumSizeEstimator` (per-tier size). Consolidates the "offer all quality tiers" indexer pattern:
- tidalarr `ConvertToReleaseInfosStatic` (fixed 4-tier loop)
- qobuzarr `QobuzParser` per-quality loop (`foreach quality in qualityList`)

Common cannot reference the host `NzbDrone.Core.Indexers.ReleaseInfo` type (same reason `AlbumReleaseInfoBuilder` returns strings), so `Build()` returns neutral `MultiQualityRelease` rows `(QualityHint, Guid, DownloadUrl, Title, SizeBytes)` the plugin maps onto its own release object. Album-level markers (edition/explicit/live) are set once and applied to every tier (tidal leaves them unset; qobuz pre-computes them).

## Verification
- 24 new tests; full `HostBridge` test namespace green (**182** total — existing `AlbumReleaseInfoBuilder`/`PathTraversalGuard` suites unaffected).
- `dotnet build -c Release` clean (0 warn / 0 err).
- `PublicAPI/net8.0/PublicAPI.Unshipped.txt` updated.

## Follow-up (separate PRs, after this merges + pins advance)
- tidalarr: replace `EstimateAlbumSize` + `ConvertToReleaseInfosStatic` with the Common helpers.
- qobuzarr: replace `QualitySizeCalculator` + the per-quality parser loop.

(Does not touch the in-flight DASH/HLS parser-migration branches.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)