### PR TITLE
fix(ci): serialize MSBuild in quarantine-review build (-m:1) to fix deps.json race

### DIFF
--- a/.github/workflows/quarantine-review-reusable.yml
+++ b/.github/workflows/quarantine-review-reusable.yml
@@ -97,7 +97,9 @@ jobs:
 
       - name: Build
         shell: bash
-        run: dotnet build -c Release -v minimal
+        # -m:1 serializes MSBuild project builds to avoid the GenerateDepsFile race
+        # (parallel nodes writing the same Abstractions/Common deps.json -> MSB4018). Matches PR #582.
+        run: dotnet build -c Release -v minimal -m:1
 
       - name: Run Quarantined Tests
         id: run_quarantined

--- a/.github/workflows/quarantine-review.yml
+++ b/.github/workflows/quarantine-review.yml
@@ -59,8 +59,12 @@ jobs:
 
       - name: Build Test Projects
         shell: bash
+        # -m:1 serializes MSBuild project builds to avoid the GenerateDepsFile race:
+        # the solution graph has several projects that depend on Abstractions/Common, and
+        # with default parallelism two build nodes can write the same project's deps.json
+        # concurrently -> "MSB4018 ... deps.json ... used by another process". Matches PR #582.
         run: |
-          dotnet build -c Release -v minimal
+          dotnet build -c Release -v minimal -m:1
 
       - name: Run Quarantined Tests
         id: run_quarantined


### PR DESCRIPTION
## Problem
The scheduled **Weekly Quarantine Review** workflow fails at its **Build Test Projects** step with:

> `error MSB4018: The "GenerateDepsFile" task failed unexpectedly. System.IO.IOException: The process cannot access the file '.../src/Abstractions/bin/Release/net8.0/Lidarr.Plugin.Abstractions.deps.json' because it is being used by another process` (also on `src/.../Lidarr.Plugin.Common.deps.json`).

Root cause: a **parallel-build race**. The step runs `dotnet build -c Release -v minimal` on the whole `lidarr.plugin.common.sln`. That solution graph has several projects (`Lidarr.Plugin.Common`, `…Common.Tests`, `…Common.TestKit`, `IsolationHostSample`) that all depend on `Abstractions`, so with default MSBuild parallelism two build nodes run `GenerateDepsFile` for the same Abstractions/Common project concurrently and collide writing its `deps.json`. Confirmed on the failing scheduled run (26755580182, Linux runner).

This is the same race class that **PR #582** fixed in `New-PluginPackage` via `-m:1`, and that `ci.yml`/`nightly.yml`/`taglib-private-weekly.yml` already guard against.

## Fix
Add `-m:1` (serialize MSBuild project builds) to the build invocation in:
- `.github/workflows/quarantine-review.yml` — "Build Test Projects" step
- `.github/workflows/quarantine-review-reusable.yml` — "Build" step (called by downstream plugins)

No output/behavior change; negligible cost for this small graph; removes the race.

## Audit (consistency)
Audited the sibling Common workflows that build test projects in parallel:
- `nightly.yml` — already `-maxcpucount:1` ✓
- `taglib-private-weekly.yml` — already `-m:1` ✓
- `ci.yml`, `codeql.yml`, `codeql-reusable.yml`, `pr-validation.yml`, `release.yml` — already `-m:1` ✓
- `e2e-nightly-live.yml` — delegates to `multi-plugin-smoke-test.yml`, which builds *downstream-plugin* graphs via `build.ps1`/`New-PluginPackage` (already #582-hardened), not Common's own solution — out of scope.
- The two quarantine-review workflows were the only unguarded spots that build Common's own multi-project solution. Both fixed here.

## Verification
Dispatched the **Weekly Quarantine Review** workflow on this branch multiple times to confirm the intermittent race is gone (see PR checks / run links in the thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)