### PR TITLE
docs: polish to ~99 (accuracy, dedup, completeness, cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,7 +453,7 @@ Template to copy when drafting a release:
 - Request deduplication cancels in-flight tasks on dispose with TrySet* guards
 - README Maintainer Checklist references Lidarr setup script
 
-[Full diff](https://github.com/RicherTunes/Lidarr.Plugin.Common/compare/v1.1.6...v1.7)
+[Full diff](https://github.com/RicherTunes/Lidarr.Plugin.Common/compare/v1.1.6...v1.1.7)
 
 ## [1.1.6] - 2025-10-10
 **Upgrade note:** Diagnostics and concurrency improvements.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Shared utilities, resilience policies, and packaging helpers for Lidarr streamin
 
 ## Key capabilities
 
-- **ALC isolation** — each plugin loads Common in a private `AssemblyLoadContext`; the host owns only `Lidarr.Plugin.Abstractions`. → [Plugin Isolation](docs/PLUGIN_ISOLATION.md)
+- **ALC isolation** — each plugin loads Common in a private `AssemblyLoadContext`; the host shares `Lidarr.Plugin.Abstractions` and two `Microsoft.Extensions` abstractions. → [Plugin Isolation](docs/PLUGIN_ISOLATION.md)
 - **Streaming plugin bridge** — `StreamingPlugin<TModule, TSettings>` base class wires DI, settings, lifecycle, and the host bridge. → [Plugin Bridge](docs/PLUGIN_BRIDGE.md)
 - **Resilient HTTP pipeline** — builder → options → executor → cache flow with retries, deadlines, concurrency caps, and request deduplication. → [HTTP Flow](docs/Flow.md) · [Key Services](docs/reference/KEY_SERVICES.md)
 - **Security helpers** — `PathTraversalGuard`, `SecureMemory`, `TokenProtectorFactory`, LLM prompt sanitization. → [Shared Helpers Catalog](wiki/Shared-Helpers-Catalog.md)

--- a/cspell.json
+++ b/cspell.json
@@ -170,7 +170,20 @@
     "sanitises",
     "serialisation",
     "reloadable",
-    "retriable"
+    "retriable",
+    "Anson",
+    "HOSTBRIDGE",
+    "Standardisation",
+    "Standardise",
+    "anchore",
+    "bitrates",
+    "danielpalme",
+    "lycheeverse",
+    "ossf",
+    "reviewdog",
+    "sarif",
+    "sigstore",
+    "softprops"
   ],
   "ignorePaths": [
     "**/bin",

--- a/cspell.json
+++ b/cspell.json
@@ -183,7 +183,9 @@
     "reviewdog",
     "sarif",
     "sigstore",
-    "softprops"
+    "softprops",
+    "unsha'd",
+    "unsha"
   ],
   "ignorePaths": [
     "**/bin",

--- a/docs/CI_REUSABLE_WORKFLOWS.md
+++ b/docs/CI_REUSABLE_WORKFLOWS.md
@@ -1,7 +1,7 @@
 # Reusable Workflow Proposals
 
-**Generated**: 2026-05-23  
-**Agent**: ci-cd-agent (Phase 1.5)  
+**Generated**: 2026-05-23
+**Agent**: ci-cd-agent (Phase 1.5)
 **Status**: PROPOSAL ONLY — do not implement without design review
 
 ---
@@ -17,7 +17,7 @@ eliminate drift, centralise version bumps, and reduce per-repo CI YAML by ~40%.
 
 ## Candidate 1: `setup-plugin-dotnet.yml`
 
-**Occurrences**: 42+ identical blocks across 5 repos  
+**Occurrences**: 42+ identical blocks across 5 repos
 **Pattern identified in**: every CI, test-and-coverage, and nightly workflow
 
 ### Current duplicated block (verbatim example from qobuzarr/ci.yml):
@@ -66,7 +66,7 @@ on:
 
 ## Candidate 2: `init-common-submodule.yml`
 
-**Occurrences**: 42+ across all plugin repos  
+**Occurrences**: 42+ across all plugin repos
 **Pattern identified in**: every CI, packaging-gates caller, nightly workflows
 
 ### Current duplicated block (verbatim example from tidalarr/ci.yml):
@@ -113,7 +113,7 @@ action). This pattern should be **promoted to Common** so all repos share it.
 
 ## Candidate 3: `parity-lint-job.yml`
 
-**Occurrences**: 5 repos, each with an identical `parity-lint` job  
+**Occurrences**: 5 repos, each with an identical `parity-lint` job
 **Pattern identified in**: brainarr/ci.yml, qobuzarr/ci.yml, tidalarr/ci.yml,
 applemusicarr/ci.yml, lidarr.plugin.common/ci.yml
 
@@ -166,7 +166,7 @@ on:
 
 ## Candidate 4: `extract-lidarr-assemblies-job.yml`
 
-**Occurrences**: 40+ in brainarr alone, 15+ in applemusicarr, 8+ in qobuzarr  
+**Occurrences**: 40+ in brainarr alone, 15+ in applemusicarr, 8+ in qobuzarr
 **Pattern identified in**: ci.yml, docker-e2e.yml, nightly.yml, test-and-coverage.yml
 
 ### Current pattern (brainarr ci.yml, `prepare-lidarr` job):

--- a/docs/CI_SHA_PINS.md
+++ b/docs/CI_SHA_PINS.md
@@ -1,7 +1,7 @@
 # CI SHA Pins Inventory
 
-**Generated**: 2026-05-23  
-**Agent**: ci-cd-agent (Phase 1.5)  
+**Generated**: 2026-05-23
+**Agent**: ci-cd-agent (Phase 1.5)
 **Scope**: All 5 ecosystem repos — brainarr, qobuzarr, tidalarr, applemusicarr, lidarr.plugin.common
 
 ---

--- a/docs/E2E_SECRETS_CHECKLIST.md
+++ b/docs/E2E_SECRETS_CHECKLIST.md
@@ -125,7 +125,7 @@ For organization-level secrets:
 ### "CROSS_REPO_PAT secret is missing or empty"
 
 The workflow skips when this secret is not configured. Solution:
-1. Create PAT at https://github.com/settings/tokens
+1. Create PAT at [GitHub Settings → Tokens](https://github.com/settings/tokens)
 2. Grant `repo` scope (classic) or fine-grained read access
 3. Add to repository secrets as `CROSS_REPO_PAT`
 

--- a/docs/EVIDENCE_TEMPLATE.md
+++ b/docs/EVIDENCE_TEMPLATE.md
@@ -112,7 +112,7 @@ Redaction Check:
 Phase: 17 — Tech Debt Burn-Down
 Status: In Progress (7-day flake window closes Feb 23)
 Date completed: pending
-PR(s): https://github.com/RicherTunes/Brainarr/pull/502
+PR(s): [Brainarr #502](https://github.com/RicherTunes/Brainarr/pull/502)
 
 Exit Criteria:
   1. [x] EnhancedRecommendationCache registered in DI

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -63,6 +63,44 @@ Secret key paired with App ID. Should be kept confidential.
 
 ## Plugin Architecture Terms
 
+### HostBridge
+Subsystem of helpers lifted from identical implementations across streaming plugins. Provides download orchestration, runtime caching, size estimation, path safety, and placeholder URI round-tripping. → [HOSTBRIDGE.md](HOSTBRIDGE.md)
+
+### StreamingPlugin
+Base class (`StreamingPlugin<TModule, TSettings>`) that wires DI, settings lifecycle, manifest loading, and the host bridge for a streaming-service plugin. → [Plugin Bridge](PLUGIN_BRIDGE.md)
+
+### StreamingPluginModule
+Base class for streaming-service plugin modules. Handles DI registration and service wiring.
+
+### PluginPack
+PowerShell module (`tools/PluginPack.psm1`) that standardizes build, manifest validation, and ZIP packaging for Lidarr plugins. → [PACKAGING.md](PACKAGING.md)
+
+### AuthFailureGate
+A per-endpoint circuit that tracks authentication failures and trips when a threshold is reached. Used with `IAuthFailureHandler` implementations (e.g., `SlidingWindowAuthFailureHandler`).
+
+### PluginCapability
+Attribute/tag system that declares which capabilities a plugin provides (Indexer, DownloadClient, ImportList).
+
+### TestKit
+Reusable test infrastructure for Lidarr plugins: HTTP handler fakes, ALC harnesses, fixture caching, and ecosystem-parity guard tests. → [Testing with the TestKit](TESTING_WITH_TESTKIT.md)
+
+### Parity Lint
+Automated lint that enforces API and behavioural consistency across the streaming-plugin family (Tidalarr, Qobuzarr, AppleMusicarr, Brainarr).
+
+### Runtime Cache
+`HostBridgeRuntimeCache<TRuntime, TSettings>` — per-plugin singleton cache keyed on settings instance, for storing runtime state that survives client re-instantiation.
+
+### PluginManifest
+`plugin.json` metadata file describing the plugin: name, version, capabilities, and assembly references. → [MANIFEST.md](reference/MANIFEST.md)
+
+### Bridge Defaults
+Convention-based default settings and service registrations that the streaming plugin bridge applies automatically when no override is provided.
+
+### SettingDefinition
+Describes a single plugin setting: key, display name, type, required/sensitive flags, and default value. Used by `ISettingsProvider.Describe()`.
+
+## Plugin Architecture Terms (legacy)
+
 ### Indexer
 Component that searches the streaming service for content. Returns search results to Lidarr.
 

--- a/docs/HOSTBRIDGE.md
+++ b/docs/HOSTBRIDGE.md
@@ -1,0 +1,40 @@
+# HostBridge Subsystem
+
+Helpers for the host-side bridge plugins (`brainarr` ImportList, `qobuzarr`/`tidalarr`/`applemusicarr` Indexer + DownloadClient). Each helper was lifted out of identical implementations duplicated across the plugin family in the May 2026 unification pass.
+
+Full source-adjacent documentation: [`src/HostBridge/README.md`](../src/HostBridge/README.md).
+
+## Core types
+
+| Type | Purpose |
+|------|---------|
+| `HostBridgeDownloadOrchestrator` | Centralizes fire-and-forget download enqueue pattern for streaming plugins. Snapshots settings before enqueue to avoid mutation races. |
+| `HostBridgeRuntimeCache<TRuntime, TSettings>` | Generic singleton-runtime cache for Lidarr-native bridge plugins. Stores per-plugin runtime state keyed by settings instance. |
+| `HostBridgeDownloadTrackerStore<TItem>` | Thread-safe `ConcurrentDictionary`-backed download tracker with retention sweep. Use one static instance per process. |
+| `AlbumSizeEstimator` | Estimates on-disk byte size of a streaming album/track from duration and bitrate. Formula: `bytes = durationSeconds × (bitrate ÷ 8)` with a 3-rung fallback ladder (album duration → summed tracks → count × average). |
+| `MultiQualityReleaseBuilder` | Builds multi-quality release variants — one `ReleaseInfo` per quality tier so the host can pick the best match. |
+| `AlbumReleaseInfoBuilder` | Builds the three `ReleaseInfo` string fields (`Guid`, `DownloadUrl`, `Title`) for streaming-service plugins. Supports edition, explicit, and live marker brackets. |
+| `AlbumDownloadUri` | Build and parse `{scheme}://album/{id}[?quality={q}]` placeholder URIs for streaming download round-trip. |
+
+## Path safety
+
+| Type | Purpose |
+|------|---------|
+| `PathTraversalGuard` | `SanitizeSegment` + `IsPathWithinRoot` for defense-in-depth path containment. Performs lexical canonicalization only — does not resolve symlinks/junctions. |
+
+## URI helpers
+
+| Type | Purpose |
+|------|---------|
+| `PlaceholderSearchUri` | Build and parse `{scheme}://search?query={encoded}` placeholder URIs for indexer search round-trip. |
+| `PrefixedReleaseGuidParser` | Parse album IDs from `ReleaseInfo.Guid`/`InfoUrl` shapes shared by streaming plugins. |
+
+## Quick start
+
+See the canonical adoption pattern in [`src/HostBridge/README.md`](../src/HostBridge/README.md) — a complete `DownloadClientBase<T>` + `HttpIndexerBase<T>` example using the tracker, path guard, and placeholder URI helpers.
+
+## Related docs
+
+- [Key Services](reference/KEY_SERVICES.md)
+- [Plugin Bridge](PLUGIN_BRIDGE.md)
+- [Changelog — HostBridge lift wave](../CHANGELOG.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Pick the guide that matches what you need to do.
 
 - [Create a plugin project](how-to/CREATE_PLUGIN.md)
 - [Test a plugin with the isolation loader](how-to/TEST_PLUGIN.md)
-- [Leverage the Common TestKit](how-to/TEST_WITH_TESTKIT.md)
+- [Leverage the Common TestKit](TESTING_WITH_TESTKIT.md)
 - [Implement an indexer](how-to/IMPLEMENT_INDEXER.md)
 - [Use the shared download orchestrator](how-to/USE_DOWNLOAD_ORCHESTRATOR.md)
 - [Authenticate with OAuth](how-to/AUTHENTICATE_OAUTH.md)
@@ -60,6 +60,32 @@ Pick the guide that matches what you need to do.
 - [Multi-plugin smoke test](MULTI_PLUGIN_SMOKE_TEST.md)
 - [Documentation style guide](dev-guide/STYLE_GUIDE.md)
 - [Doc testing & snippet verification](dev-guide/TESTING_DOCS.md)
+
+### Infrastructure & operations
+
+- [CI lane strategy](CI_LANE_STRATEGY.md)
+- [CI reusable workflows](CI_REUSABLE_WORKFLOWS.md)
+- [CI SHA pins](CI_SHA_PINS.md)
+- [Security hardening overview](SECURITY_HARDENING_OVERVIEW.md)
+- [Security hardening backlog](SECURITY_HARDENING_BACKLOG.md)
+- [E2E error codes](E2E_ERROR_CODES.md)
+- [Quarantine process](QUARANTINE_PROCESS.md)
+
+### Architecture decisions (ADRs)
+
+- [ADR-001: Streaming architecture](decisions/ADR-001-streaming-architecture.md)
+- [ADR-002: Subscription auth research](decisions/ADR-002-subscription-auth-research.md)
+
+### Planning & roadmap
+
+- [Tech debt register](TECH_DEBT.md)
+- [6-month takeover roadmap](TAKEOVER_6M_ROADMAP.md)
+- [H2 2026 roadmap](TAKEOVER_H2_2026.md)
+
+### Observability
+
+- [OpenTelemetry quickstart](observability/OTEL-QUICKSTART.md)
+- [Observability proposal](observability/PROPOSAL.md)
 
 ## Plugins using this library
 

--- a/docs/dev-guide/E2E_HARDENING_ROADMAP.md
+++ b/docs/dev-guide/E2E_HARDENING_ROADMAP.md
@@ -142,7 +142,7 @@ Mapping rules (minimal):
 - [x] Reduce/disable fuzzy fallback in `Select-ConfiguredComponent` (flag-gated), and add explicit tests for “no accidental selection”.
 
 ### P2 (concurrency + usability)
-- [x] Add state-write lock backoff tuning via env var (still best-effort).      
+- [x] Add state-write lock backoff tuning via env var (still best-effort).
 - [x] Add `E2E_INSTANCE_KEY` override for power users (explicit key beats heuristics).
 
 ## References

--- a/docs/dev-guide/ECOSYSTEM_HANDOFF.md
+++ b/docs/dev-guide/ECOSYSTEM_HANDOFF.md
@@ -132,5 +132,5 @@ The Lidarr host has an AssemblyLoadContext lifecycle bug that affects multi-plug
 
 ## Contact
 
-- Repository: https://github.com/RicherTunes/Lidarr.Plugin.Common
-- Issues: https://github.com/RicherTunes/Lidarr.Plugin.Common/issues
+- Repository: [Lidarr.Plugin.Common](https://github.com/RicherTunes/Lidarr.Plugin.Common)
+- Issues: [Lidarr.Plugin.Common Issues](https://github.com/RicherTunes/Lidarr.Plugin.Common/issues)

--- a/docs/how-to/TOKEN_MANAGER.md
+++ b/docs/how-to/TOKEN_MANAGER.md
@@ -98,8 +98,8 @@ By default, the manager only refreshes tokens on-demand (when `GetValidSessionAs
 var options = new StreamingTokenManagerOptions<MySession>
 {
     DefaultSessionLifetime = TimeSpan.FromHours(1),
-    RefreshBuffer = TimeSpan.FromMinutes(5),  // Refresh 5 min before expiry   
-    RefreshCheckInterval = TimeSpan.FromMinutes(1),  // Check every minute     
+    RefreshBuffer = TimeSpan.FromMinutes(5),  // Refresh 5 min before expiry
+    RefreshCheckInterval = TimeSpan.FromMinutes(1),  // Check every minute
     GetSessionExpiry = s => s.ExpiresAt,
 
     // Enable proactive refresh by providing a credentials factory

--- a/docs/migration/BREAKING_CHANGES.md
+++ b/docs/migration/BREAKING_CHANGES.md
@@ -1,11 +1,20 @@
 # Breaking Changes
 
-Track ABI-breaking updates here so plugin authors can plan migrations. Each entry should link to the relevant release notes and documentation updates.
+Track ABI-breaking updates here so plugin authors can plan migrations. Each entry links to the relevant release notes and documentation updates.
 
 | Version | Component | Breaking? | Description | Migration steps | Docs |
 |---------|-----------|-----------|-------------|-----------------|------|
 | 1.0.0 | E2E Sanitization | Yes | Centralized `e2e-sanitize.psm1` module replaces duplicate pattern definitions | Import new module; deprecated patterns in `e2e-diagnostics.psm1` will be removed in next major version | [e2e-sanitize.psm1](../../scripts/lib/e2e-sanitize.psm1) |
 | 1.0.0 | E2E Manifest | No | Added `fullSha` field to `sources.*` block for reproducibility | Optional additive field; existing consumers unaffected (schema allows additionalProperties) | [e2e-json-output.psm1](../../scripts/lib/e2e-json-output.psm1) |
+| 1.1.7 | Redirect Semantics | Yes | 301/302 auto-follow only for safe methods (GET/HEAD); 307/308 preserve method and body. Previous behaviour followed all redirects uniformly. | If your plugin issues POST/PUT to endpoints that return 301/302, you must handle the redirect explicitly or switch to a safe method. | [CHANGELOG v1.1.7](../../CHANGELOG.md) |
+| 1.8.0 | ALC Isolation | Yes | Each plugin loads Common in a private `AssemblyLoadContext`; host shares only `Lidarr.Plugin.Abstractions` and two `Microsoft.Extensions` abstractions. | Plugins must not assume they can cast Common types to host-side types across the ALC boundary. Use the abstraction interfaces instead. | [Plugin Isolation](../PLUGIN_ISOLATION.md) |
+| 1.8.0 | Abstractions Merge | Yes | `Lidarr.Plugin.Abstractions` merged into the plugin DLL (cross-ALC fix). | No action required if consuming via NuGet; if referencing Abstractions directly, switch to the Common package. | [CHANGELOG v1.8.0](../../CHANGELOG.md) |
+| 1.9.0 | Sync-over-async | Yes | Removed `Task.Delay(...).Wait()` inside lock pattern; replaced with `SemaphoreSlim + await Task.Delay`. | If you called `ApplyRateLimitAsync` synchronously via `.Wait()` or `.Result`, switch to `await`. | [CHANGELOG v1.9.0](../../CHANGELOG.md) |
+| 1.12.0 | Builder Seal | Yes | `StreamingApiRequestBuilder` seals after `Build()` to prevent query bleed. Calling `Build()` twice or mutating after build now throws. | Create a new builder instance for each request instead of reusing a built one. | [CHANGELOG v1.12.0](../../CHANGELOG.md) |
+| 1.13.0 | Scrub.Url | Yes | `Scrub.Url` delegates recognition to `LogRedactor`. Custom URL-scrubbing logic that relied on the old standalone behaviour may produce different output. | Verify that your logged URLs still redact correctly; update any custom scrubbers to align with `LogRedactor`. | [CHANGELOG v1.13.0](../../CHANGELOG.md) |
+| 1.14.0 | AdaptiveRateLimiter | Yes | Removed deprecated `AdaptiveRateLimiter` family (`AdaptiveRateLimiter`, `IAdaptiveRateLimiter`, `UniversalAdaptiveRateLimiter`, `IUniversalAdaptiveRateLimiter`). | Use `UniversalAdaptiveRateLimiter` is also removed — switch to per-service rate-limiting via `ResiliencePolicy` and the built-in executor pipeline. | [CHANGELOG v1.14.0](../../CHANGELOG.md) |
+| 1.14.0 | WithExecutor | Yes | Removed `WithExecutor` method (Wave 17K). | Use `HttpClientExtensions.ExecuteWithResilienceAsync` or the builder → executor pipeline instead. | [CHANGELOG v1.14.0](../../CHANGELOG.md) |
+| Unreleased | IAuthFailureGateRegistry | Deprecation | `IAuthFailureGateRegistry` / `AuthFailureGateRegistry` deprecated in favour of a direct `ConcurrentDictionary<string, AuthFailureGate>` per-plugin. Marked `[Obsolete(error: false)]`; will be removed in v2.0.0. | Replace registry usage with a local `ConcurrentDictionary<string, AuthFailureGate>` and pair each gate with a custom `IAuthFailureHandler`. | [CHANGELOG Unreleased](../../CHANGELOG.md) |
 
 Guidelines:
 

--- a/docs/reference/KEY_SERVICES.md
+++ b/docs/reference/KEY_SERVICES.md
@@ -147,3 +147,42 @@ Source: [`src/Abstractions/Results/PluginErrorCode.cs`](../../src/Abstractions/R
 - `SafeOperationExecutor` — defensive wrappers: timeouts, try-execute patterns, and IO retry for transient sharing violations.
 - `FileNameSanitizer`/`Sanitize` — filesystem-safe names and URL-safe components.
 - `RequestSigning`/`IRequestSigner` — MD5/HMAC helpers for signature schemes.
+
+## Streaming Plugin Base Classes
+
+- `StreamingPlugin<TModule, TSettings>` — main plugin entry point. Wires DI, settings lifecycle, manifest loading, and the host bridge. Inherit from this to create a streaming-service plugin. → [Plugin Bridge](../PLUGIN_BRIDGE.md)
+- `StreamingPluginModule` — base class for streaming-service plugin modules (DI registration, service wiring).
+- `BaseStreamingIndexer<T>` — base class for streaming-service indexers. Provides search, rate-limit integration, and release cleanup.
+- `BaseStreamingDownloadClient<T>` — base class for streaming-service download clients. Provides tracked download lifecycle and path safety.
+
+## HTTP Execution
+
+- `CachingHttpExecutor` — HTTP executor that integrates caching with the resilience pipeline. Use when you need automatic GET caching alongside retries and dedup.
+
+## Resilience & Circuit Breaking
+
+- `AdvancedCircuitBreaker` — circuit breaker with dual-trip logic: trips on consecutive failures **or** failure-rate threshold within a sampling window. Configurable half-open probe interval.
+- `NetworkResilienceService` — coordinates resilience for batch operations and non-HTTP workflows (bulk lookups, metadata enrichment). Wraps `AdvancedCircuitBreaker` with per-endpoint tracking.
+
+## Authentication Failure Handling
+
+- `SlidingWindowAuthFailureHandler` — `IAuthFailureHandler` with K-of-N-in-W sliding-window failure threshold semantics. Trips when K failures occur within window W; auto-resets after cooldown. → [CHANGELOG v1.7.0](../../CHANGELOG.md)
+
+## HostBridge Subsystem
+
+- `HostBridgeDownloadOrchestrator` — centralizes fire-and-forget download enqueue pattern for streaming plugins.
+- `HostBridgeRuntimeCache<TRuntime, TSettings>` — generic singleton-runtime cache for per-plugin state keyed by settings instance.
+- `AlbumSizeEstimator` — estimates album byte size from duration × bitrate with fallback ladder.
+- `MultiQualityReleaseBuilder` — builds one `ReleaseInfo` per quality tier.
+- `AlbumReleaseInfoBuilder` — builds `Guid`, `DownloadUrl`, and `Title` fields with edition/explicit/live markers.
+
+→ Full HostBridge documentation: [HOSTBRIDGE.md](../HOSTBRIDGE.md)
+
+## Lyrics
+
+- `LyricsEnricher` — canonical synced-lyrics enricher shared across plugins. Orchestrates LRCLIB fallback with native-source lookup.
+- `LrclibClient` — minimal client for the LRCLIB public lyrics API.
+
+## Storage
+
+- `JsonFileStore` — JSON file persistence for plugin state (tokens, session data, user preferences). Handles atomic write, read, and schema migration.

--- a/docs/reference/SETTINGS.md
+++ b/docs/reference/SETTINGS.md
@@ -88,6 +88,34 @@ The bridge:
 
 > Prefer flat settings objects. Nested objects are currently unsupported and require custom logic.
 
+## BaseStreamingSettings properties
+
+`BaseStreamingSettings` (namespace `Lidarr.Plugin.Common.Base`) is the recommended base class for streaming-service plugin settings. It provides common configuration with sensible defaults.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `BaseUrl` | `string` | — | Base URL for the streaming service API |
+| `Email` | `string` | — | User email for authentication |
+| `Password` | `string` | — | User password for authentication (mark as sensitive) |
+| `AuthToken` | `string` | — | Authentication token for token-based auth services |
+| `UserId` | `string` | — | User ID for services that require it |
+| `CountryCode` | `string` | `"US"` | ISO 3166-1 alpha-2 country code for content availability |
+| `Locale` | `string` | `"en-US"` | BCP 47 locale tag |
+| `SearchLimit` | `int` | `100` | Max search results per query (1–1000) |
+| `IncludeSingles` | `bool` | `false` | Include singles and EPs in results |
+| `IncludeCompilations` | `bool` | `false` | Include compilation albums in results |
+| `ApiRateLimit` | `int` | `60` | Max API requests per minute (1–1000) |
+| `SearchCacheDuration` | `int` | `5` | Cache TTL in minutes (0–1440) |
+| `ConnectionTimeout` | `int` | `30` | Connection timeout in seconds (5–300) |
+| `OrganizeByArtist` | `bool` | `true` | Organize downloads by artist/album folder structure |
+| `EarlyReleaseDayLimit` | `int` | `0` | Include albums up to N days before official release (0–90) |
+
+Computed accessors: `CacheDuration` (`TimeSpan`), `RequestTimeout` (`TimeSpan`), `RateLimitWindow` (`TimeSpan` = 1 min).
+
+Override `IsValid(out string errorMessage)` in derived classes to add service-specific validation.
+
+Source: [`src/Base/BaseStreamingSettings.cs`](../../src/Base/BaseStreamingSettings.cs).
+
 ## Recommended keys
 
 | Key | Type | Required | Notes |

--- a/wiki/Shared-Helpers-Catalog.md
+++ b/wiki/Shared-Helpers-Catalog.md
@@ -6,6 +6,8 @@ Each entry is a one-line purpose and a link to its source; full details live in 
 For architecture context, see [Architecture Overview](Architecture-Overview.md) and the
 [doc hub](../docs/README.md).
 
+**See also:** [Key Services Reference](../docs/reference/KEY_SERVICES.md) — code-example–rich canonical page covering overlapping services.
+
 ---
 
 ## Security


### PR DESCRIPTION
Applies the verified path-to-99 checklist from the adversarial doc-quality review: stale version/metric/framework fixes, changelog + wiki de-duplication, remaining settings/env-vars documented, TODO(docval)/phantom-block cleanup, dead-link fixes. Surgical doc edits, verified vs source, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)