### PR TITLE
test(parity): guard download clients report DownloadClientInfo.Id == Definition.Id

### DIFF
--- a/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
@@ -607,27 +607,7 @@ public abstract partial class EcosystemParityTestBase
     {
         var assembly = PluginAssembly;
         if (assembly == null) return Skipped();
-
-        const string dcIface = "Lidarr.Plugin.Abstractions.Contracts.IDownloadClient";
-        var hasDownloadClient = SafeGetTypes(assembly).Any(t =>
-        {
-            if (t == null) return false;
-            try
-            {
-                if (t.IsInterface || t.IsAbstract) return false;
-                if (t.GetInterfaces().Any(i => i.FullName == dcIface)) return true;
-                // Host-contract download clients subclass DownloadClientBase<T>.
-                var b = t.BaseType;
-                while (b != null)
-                {
-                    if ((b.Name ?? string.Empty).StartsWith("DownloadClientBase", StringComparison.Ordinal)) return true;
-                    b = b.BaseType;
-                }
-                return false;
-            }
-            catch { return false; }
-        });
-        if (!hasDownloadClient) return ComplianceResult.Success; // not applicable
+        if (!PluginDeclaresHostDownloadClient(assembly)) return ComplianceResult.Success; // not applicable
 
         string text;
         try { text = System.Text.Encoding.UTF8.GetString(File.ReadAllBytes(assembly.Location)); }
@@ -731,6 +711,181 @@ public abstract partial class EcosystemParityTestBase
 
     #endregion
 
+    #region Check_DownloadClientStampsRegisteredClientId
+
+    /// <summary>
+    /// A plugin's download client must stamp every reported <c>DownloadClientItem</c> with the
+    /// registered client id — <c>DownloadClientInfo.Id == this client's Definition.Id</c> — never a
+    /// literal <c>0</c>. Lidarr's <c>DownloadMonitoringService</c> → <c>CompletedDownloadService</c> →
+    /// <c>DownloadClientProvider.Get(DownloadClientInfo.Id)</c> resolves the owning client by that id;
+    /// a wrong/zero id makes its <c>.Single(...)</c> throw "Sequence contains no matching element", so
+    /// every completed download wedges at "Couldn't process tracked download" and never imports. (Live
+    /// qobuz regression, 2026-05-31: <c>GetItems()</c> passed <c>0</c> → every download stuck.)
+    /// <para>
+    /// Canonical shape (tidal/apple/amazon): <c>DownloadClientItemClientInfo.FromDownloadClient(this, …)</c>,
+    /// the host helper that always reads <c>this.Definition.Id/Name</c>. qobuz derives the id explicitly
+    /// from <c>Definition?.Id</c>. The guard accepts either; it fails a <c>GetItems()</c> that neither
+    /// uses <c>FromDownloadClient(this, …)</c> nor references <c>Definition.Id/Name</c>, or that passes a
+    /// literal <c>0</c> to a <c>ToDownloadClientItem(...)</c> converter.
+    /// </para>
+    /// <para>
+    /// Applicable only to plugins that ship a host-contract download client (import-list plugins such as
+    /// brainarr → N/A). Source-scan based (like <see cref="Check_NoFluentValidation_ErrorsApi_Drift"/>):
+    /// it isolates each download client's <c>GetItems()</c> body and is conservative — if no body can be
+    /// located it passes rather than false-fail.
+    /// </para>
+    /// </summary>
+    public virtual ComplianceResult Check_DownloadClientStampsRegisteredClientId()
+    {
+        var assembly = PluginAssembly;
+        if (assembly == null) return Skipped();
+        if (!PluginDeclaresHostDownloadClient(assembly)) return ComplianceResult.Success; // N/A (no download client)
+        if (!Directory.Exists(PluginSourceRoot)) return Skipped();
+
+        var excluded = new[]
+        {
+            $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}ext{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}.worktrees{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}tests{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}Tests{Path.DirectorySeparatorChar}",
+            ".Tests" + Path.DirectorySeparatorChar,
+            $"{Path.DirectorySeparatorChar}examples{Path.DirectorySeparatorChar}",
+        };
+
+        // Host-contract download clients subclass DownloadClientBase<TSettings> and override GetItems().
+        var clientBasePattern = new System.Text.RegularExpressions.Regex(
+            @":\s*DownloadClientBase\s*<", System.Text.RegularExpressions.RegexOptions.Compiled);
+        var derivesFromDefinition = new System.Text.RegularExpressions.Regex(
+            @"FromDownloadClient\s*\(\s*this\b|Definition\s*\??\s*\.\s*(Id|Name)",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+        var stampsLiteralZero = new System.Text.RegularExpressions.Regex(
+            @"ToDownloadClientItem\s*\(\s*0\b", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var offenders = new List<string>();
+        var scannedAny = false;
+        foreach (var file in Directory.EnumerateFiles(PluginSourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            if (excluded.Any(x => file.Contains(x, StringComparison.Ordinal))) continue;
+            string text;
+            try { text = File.ReadAllText(file); }
+            catch { continue; }
+            if (!clientBasePattern.IsMatch(text)) continue;
+            if (!text.Contains("GetItems", StringComparison.Ordinal)) continue;
+
+            var body = ExtractMethodBody(text, "GetItems");
+            if (body == null) continue; // couldn't isolate the body — don't false-fail
+            scannedAny = true;
+
+            var derives = derivesFromDefinition.IsMatch(body);
+            var stampsZero = stampsLiteralZero.IsMatch(body);
+            if (!derives || stampsZero)
+            {
+                offenders.Add(
+                    $"{Path.GetRelativePath(RepoRootPath, file)}: GetItems() must stamp DownloadClientInfo.Id " +
+                    "from this client's Definition (use DownloadClientItemClientInfo.FromDownloadClient(this, …) " +
+                    "or pass Definition.Id) — a literal 0 makes Lidarr's CompletedDownloadService fail to resolve " +
+                    "the owning client and wedges every completed download.");
+            }
+        }
+
+        // No locatable download-client GetItems() body to assert against — treat as N/A rather than fail.
+        if (!scannedAny) return ComplianceResult.Success;
+
+        return offenders.Count == 0
+            ? ComplianceResult.Success
+            : ComplianceResult.Failure(
+                $"Download client(s) must report DownloadClientInfo.Id == Definition.Id (download-client-id contract): {string.Join("; ", offenders)}");
+    }
+
+    /// <summary>
+    /// True if the plugin assembly declares a host-contract download client — a concrete type
+    /// implementing the abstractions <c>IDownloadClient</c> or subclassing Lidarr's
+    /// <c>DownloadClientBase&lt;T&gt;</c>. Import-list plugins (e.g. brainarr) declare neither.
+    /// </summary>
+    private bool PluginDeclaresHostDownloadClient(Assembly assembly)
+    {
+        const string dcIface = "Lidarr.Plugin.Abstractions.Contracts.IDownloadClient";
+        return SafeGetTypes(assembly).Any(t =>
+        {
+            if (t == null) return false;
+            try
+            {
+                if (t.IsInterface || t.IsAbstract) return false;
+                if (t.GetInterfaces().Any(i => i.FullName == dcIface)) return true;
+                var b = t.BaseType;
+                while (b != null)
+                {
+                    if ((b.Name ?? string.Empty).StartsWith("DownloadClientBase", StringComparison.Ordinal)) return true;
+                    b = b.BaseType;
+                }
+                return false;
+            }
+            catch { return false; }
+        });
+    }
+
+    /// <summary>
+    /// Extracts the body text (the enclosing <c>{ … }</c>, or the <c>=&gt; … ;</c> for an expression
+    /// body) of the first method named <paramref name="methodName"/> in <paramref name="source"/>.
+    /// Returns null if the method or a balanced body can't be located (callers treat null as "skip").
+    /// Brace-matching tolerates balanced interpolation braces (<c>$"{x}"</c>); a stray unbalanced brace
+    /// inside a string/comment yields null (safe — the caller skips rather than false-fails).
+    /// </summary>
+    private static string? ExtractMethodBody(string source, string methodName)
+    {
+        var searchFrom = 0;
+        while (true)
+        {
+            var nameIdx = source.IndexOf(methodName, searchFrom, StringComparison.Ordinal);
+            if (nameIdx < 0) return null;
+            var afterName = nameIdx + methodName.Length;
+            // Require a left word boundary so "GetItems" doesn't match inside "FooGetItems".
+            if (nameIdx > 0)
+            {
+                var prev = source[nameIdx - 1];
+                if (char.IsLetterOrDigit(prev) || prev == '_') { searchFrom = afterName; continue; }
+            }
+            // Next non-space char must open a parameter list.
+            var p = afterName;
+            while (p < source.Length && char.IsWhiteSpace(source[p])) p++;
+            if (p >= source.Length || source[p] != '(') { searchFrom = afterName; continue; }
+            // Match the parameter-list parens.
+            var parenDepth = 0;
+            var q = p;
+            for (; q < source.Length; q++)
+            {
+                if (source[q] == '(') parenDepth++;
+                else if (source[q] == ')') { parenDepth--; if (parenDepth == 0) { q++; break; } }
+            }
+            if (q >= source.Length) return null;
+            var r = q;
+            while (r < source.Length && char.IsWhiteSpace(source[r])) r++;
+            if (r >= source.Length) return null;
+            if (source[r] == '{')
+            {
+                var depth = 0;
+                for (var i = r; i < source.Length; i++)
+                {
+                    if (source[i] == '{') depth++;
+                    else if (source[i] == '}') { depth--; if (depth == 0) return source.Substring(r, i - r + 1); }
+                }
+                return null; // unbalanced
+            }
+            if (source[r] == '=' && r + 1 < source.Length && source[r + 1] == '>')
+            {
+                var semi = source.IndexOf(';', r);
+                return semi < 0 ? null : source.Substring(r, semi - r + 1);
+            }
+            // Declaration without an inline body (interface/abstract) or a generic constraint — keep looking.
+            searchFrom = afterName;
+        }
+    }
+
+    #endregion
+
     #region Aggregator
 
     #region Check_EnforcesAlbumCompletionPolicy
@@ -783,6 +938,7 @@ public abstract partial class EcosystemParityTestBase
             [nameof(Check_UsesCommonDiagnosticTypes)] = Check_UsesCommonDiagnosticTypes(),
             [nameof(Check_UsesCommonDownloadTelemetrySink)] = Check_UsesCommonDownloadTelemetrySink(),
             [nameof(Check_DownloadClientUsesPathTraversalGuard)] = Check_DownloadClientUsesPathTraversalGuard(),
+            [nameof(Check_DownloadClientStampsRegisteredClientId)] = Check_DownloadClientStampsRegisteredClientId(),
             [nameof(Check_FileClassNameParity)] = Check_FileClassNameParity(),
             [nameof(Check_ClaudeMdDocumentsCommonHelpers)] = Check_ClaudeMdDocumentsCommonHelpers(),
         };

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -71,6 +71,7 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         public ComplianceResult RunPathTraversalGuard() => Check_DownloadClientUsesPathTraversalGuard();
         public ComplianceResult RunFileClassNameParity() => Check_FileClassNameParity();
         public ComplianceResult RunClaudeMdHelpers() => Check_ClaudeMdDocumentsCommonHelpers();
+        public ComplianceResult RunDownloadClientIdStamp() => Check_DownloadClientStampsRegisteredClientId();
     }
 
     /// <summary>A plugin-local re-declaration of the lyrics enricher (forbidden — must use common's).</summary>
@@ -584,6 +585,149 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         Assert.True(h.RunPathTraversalGuard().Passed);
     }
 
+    // --- Check_DownloadClientStampsRegisteredClientId ---
+    //
+    // Contract (live qobuz regression, 2026-05-31): a download client's GetItems() must stamp every
+    // reported DownloadClientItem with DownloadClientInfo.Id == this client's Definition.Id (never a
+    // literal 0). Lidarr resolves the owning client by that id; a 0/wrong id makes CompletedDownloadService
+    // throw "Sequence contains no matching element" and wedges every completed download before import.
+    // Canonical shape (tidal/apple/amazon): DownloadClientItemClientInfo.FromDownloadClient(this, …);
+    // qobuz derives the id explicitly from Definition?.Id. Both satisfy the guard.
+
+    private const string DlClientHeader =
+        "namespace P;\nusing System.Collections.Generic;\nusing System.Linq;\n";
+
+    [Fact]
+    public void DownloadClientIdStamp_NoAssembly_ReturnsSkipped()
+    {
+        var h = new Harness(_tempRepo) { AssemblyValue = null };
+        Assert.True(h.RunDownloadClientIdStamp().Passed);
+    }
+
+    [Fact]
+    public void DownloadClientIdStamp_NoDownloadClient_NotApplicable_Passes()
+    {
+        // Import-list plugins (e.g. brainarr) ship no download client → N/A.
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FileTokenStore<string>) },
+        };
+        Assert.True(h.RunDownloadClientIdStamp().Passed);
+    }
+
+    [Fact]
+    public void DownloadClientIdStamp_HasClientButNoSourceFile_Passes()
+    {
+        // Ships a download client but no download-client source file is found under the source root
+        // (relocated/examples-only source) → don't false-fail; the GetItems() body can't be located.
+        var src = Path.Combine(_tempRepo, "empty-src");
+        Directory.CreateDirectory(src);
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        Assert.True(h.RunDownloadClientIdStamp().Passed);
+    }
+
+    [Fact]
+    public void DownloadClientIdStamp_CanonicalFromDownloadClient_Passes()
+    {
+        // tidal/apple/amazon shape — the host helper always reads this.Definition.Id/Name.
+        // The interpolated Title exercises the brace-matcher against balanced interpolation braces.
+        var src = Path.Combine(_tempRepo, "src-canonical");
+        WriteSrcFile(src, "FooDownloadClient.cs",
+            DlClientHeader +
+            "public class FooDownloadClient : DownloadClientBase<FooSettings>\n{\n" +
+            "    public override IEnumerable<DownloadClientItem> GetItems()\n    {\n" +
+            "        var result = new List<DownloadClientItem>();\n" +
+            "        foreach (var item in Tracker.GetSnapshot())\n        {\n" +
+            "            result.Add(new DownloadClientItem\n            {\n" +
+            "                DownloadId = item.Id,\n" +
+            "                Title = $\"{item.Artist} - {item.Title}\",\n" +
+            "                DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, false)\n" +
+            "            });\n        }\n        return result;\n    }\n}\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunDownloadClientIdStamp();
+        Assert.True(r.Passed, string.Join("; ", r.Errors));
+    }
+
+    [Fact]
+    public void DownloadClientIdStamp_DerivesIdFromDefinition_Passes()
+    {
+        // qobuz shape — hand-rolled converter, but the client id is derived from Definition?.Id.
+        var src = Path.Combine(_tempRepo, "src-definition");
+        WriteSrcFile(src, "BarDownloadClient.cs",
+            DlClientHeader +
+            "public class BarDownloadClient : DownloadClientBase<BarSettings>\n{\n" +
+            "    public override IEnumerable<DownloadClientItem> GetItems()\n    {\n" +
+            "        var clientId = Definition?.Id ?? 0;\n" +
+            "        var clientName = Definition?.Name ?? Name;\n" +
+            "        return Tracker.GetSnapshot().Select(i => i.ToDownloadClientItem(clientId, clientName)).ToList();\n" +
+            "    }\n}\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunDownloadClientIdStamp();
+        Assert.True(r.Passed, string.Join("; ", r.Errors));
+    }
+
+    [Fact]
+    public void DownloadClientIdStamp_StampsLiteralZero_Fails()
+    {
+        // The exact historical regression: passing literal 0 as the client id, no Definition derivation.
+        var src = Path.Combine(_tempRepo, "src-zero");
+        WriteSrcFile(src, "BadDownloadClient.cs",
+            DlClientHeader +
+            "public class BadDownloadClient : DownloadClientBase<BadSettings>\n{\n" +
+            "    public override IEnumerable<DownloadClientItem> GetItems()\n    {\n" +
+            "        return Tracker.GetSnapshot().Select(i => i.ToDownloadClientItem(0, Name)).ToList();\n" +
+            "    }\n}\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunDownloadClientIdStamp();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("BadDownloadClient"));
+    }
+
+    [Fact]
+    public void DownloadClientIdStamp_GetItemsIgnoresDefinition_Fails()
+    {
+        // GetItems builds client-info without deriving the id from Definition nor FromDownloadClient(this).
+        var src = Path.Combine(_tempRepo, "src-ignore");
+        WriteSrcFile(src, "IgnDownloadClient.cs",
+            DlClientHeader +
+            "public class IgnDownloadClient : DownloadClientBase<IgnSettings>\n{\n" +
+            "    public override IEnumerable<DownloadClientItem> GetItems()\n    {\n" +
+            "        var result = new List<DownloadClientItem>();\n" +
+            "        result.Add(new DownloadClientItem { DownloadId = \"x\", DownloadClientInfo = new DownloadClientItemClientInfo { Name = \"Foo\" } });\n" +
+            "        return result;\n" +
+            "    }\n}\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunDownloadClientIdStamp();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("IgnDownloadClient"));
+    }
+
     // --- Check_FileClassNameParity ---
 
     private string WriteSrcFile(string srcDir, string fileName, string content)
@@ -797,8 +941,8 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
     {
         var h = new Harness(_tempRepo) { AssemblyValue = null };
         var report = h.RunBehaviorContractChecks();
-        Assert.Equal(13, report.TotalCount);
-        // No assembly + no CLAUDE.md => the other 12 skip (Pass); Check_EnforcesAlbumCompletionPolicy
+        Assert.Equal(14, report.TotalCount);
+        // No assembly + no CLAUDE.md => the other 13 skip (Pass); Check_EnforcesAlbumCompletionPolicy
         // runs unconditionally (it asserts the shared rule directly, no assembly needed) and passes.
         Assert.True(report.AllPassed);
     }


### PR DESCRIPTION
## What

Adds `Check_DownloadClientStampsRegisteredClientId` to `EcosystemParityTestBase` (behavior contracts). A plugin's download client `GetItems()` must stamp every reported `DownloadClientItem` with the registered client id — `DownloadClientInfo.Id == this client's Definition.Id` — **never a literal `0`**.

## Why

Lidarr's `DownloadMonitoringService` → `CompletedDownloadService` → `DownloadClientProvider.Get(DownloadClientInfo.Id)` resolves the owning client by that id; a `0`/wrong id makes its `.Single(...)` throw *"Sequence contains no matching element"*, so **every completed download wedges** at "Couldn't process tracked download" and never imports.

This was a **live qobuz regression (2026-05-31)**: `GetItems()` passed `0` and every completed download stuck. The fix was pinned only by a qobuz-local test (`GetItems_ReturnsItemsCarryingRegisteredClientId_NotZero`). This lifts the contract into the shared parity base so the whole ecosystem inherits the guard — the explicit TODO from the program mission ("add a cross-plugin guard that download clients report `DownloadClientInfo.Id == Definition.Id`").

## How it works

- **Canonical shape** (tidal/apple/amazon): `DownloadClientItemClientInfo.FromDownloadClient(this, …)` — the host helper that always reads `this.Definition.Id/Name`.
- **qobuz** derives the id explicitly from `Definition?.Id`.
- The guard accepts either; it **fails** a `GetItems()` that derives from neither, or that passes a literal `0` to a `ToDownloadClientItem(...)` converter.
- Source-scan based (like `Check_NoFluentValidation_ErrorsApi_Drift`); isolates each download client's `GetItems()` body via brace-matching (tolerates balanced `$"{…}"` interpolation).
- Applicable only to plugins that ship a host-contract download client; **import-list plugins (brainarr) → N/A**. Conservative: passes when no body can be located (never false-fails).
- Also consolidates the download-client detection shared with `Check_DownloadClientUsesPathTraversalGuard` into one `PluginDeclaresHostDownloadClient` helper.

## Verification

- TDD: 7 new behavior tests (red→green) covering canonical/Definition-derived (pass), literal-zero + no-derivation (fail), N/A, and no-source-file cases. Aggregator count 13→14.
- **Verified green against all four plugins' real download clients** (qobuz/tidal/apple/amazon) — ships green, zero regression on next bump.
- Full Compliance suite: 111/111 green.

## Follow-up (not in this PR)

Consumers inherit the method on their next Common bump; each adds a one-line `[Fact] Check_DownloadClientStampsRegisteredClientId_Test()` to its `*EcosystemParityTests` to run it in CI (all 4 already opt in via `PluginAssembly`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)