### PR TITLE
test(parity): guard download clients use Common's DownloadPayloadValidator

### DIFF
--- a/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
+++ b/testkit/Compliance/EcosystemParityTestBase.BehaviorContracts.cs
@@ -621,6 +621,69 @@ public abstract partial class EcosystemParityTestBase
 
     #endregion
 
+    #region Check_DownloadClientUsesCommonPayloadValidator
+
+    /// <summary>
+    /// Audio-payload validation — is a downloaded blob real audio vs an HTML/JSON error page or the
+    /// wrong container? — is consolidated in Common's canonical <c>DownloadPayloadValidator</c>, a strict
+    /// superset of the legacy <c>AudioMagicBytesValidator</c> (it adds MP4/M4A ftyp recognition,
+    /// text/HTML/JSON/XML rejection, and file + span overloads). A plugin that ships a download client
+    /// must not (a) use the legacy <c>AudioMagicBytesValidator</c>, nor (b) declare its own
+    /// <c>*PayloadValidator</c> fork — the historical tidalarr <c>TidalDownloadPayloadValidator</c> +
+    /// qobuz m4a-workaround divergence this guard exists to prevent regressing. Applicable only to
+    /// download-client plugins (import-list plugins such as brainarr → N/A); source-scan based and
+    /// conservative (no source root → skip). Note: inline MP4-box integrity checks on decrypted DASH
+    /// segments (moov/mdat) are a DISTINCT concern (segment integrity, not file-level audio validation)
+    /// and are intentionally NOT flagged — this targets file-level audio-payload validation only.
+    /// </summary>
+    public virtual ComplianceResult Check_DownloadClientUsesCommonPayloadValidator()
+    {
+        var assembly = PluginAssembly;
+        if (assembly == null) return Skipped();
+        if (!PluginDeclaresHostDownloadClient(assembly)) return ComplianceResult.Success; // N/A (no download client)
+        if (!Directory.Exists(PluginSourceRoot)) return Skipped();
+
+        var excluded = new[]
+        {
+            $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}ext{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}.worktrees{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}tests{Path.DirectorySeparatorChar}",
+            $"{Path.DirectorySeparatorChar}Tests{Path.DirectorySeparatorChar}",
+            ".Tests" + Path.DirectorySeparatorChar,
+            $"{Path.DirectorySeparatorChar}examples{Path.DirectorySeparatorChar}",
+        };
+        // (a) legacy weak validator usage; (b) a plugin-local *PayloadValidator fork declaration.
+        var legacyUse = new System.Text.RegularExpressions.Regex(
+            @"\bAudioMagicBytesValidator\b", System.Text.RegularExpressions.RegexOptions.Compiled);
+        var forkClass = new System.Text.RegularExpressions.Regex(
+            @"\bclass\s+[A-Za-z0-9_]*PayloadValidator\b", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(PluginSourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            if (excluded.Any(x => file.Contains(x, StringComparison.Ordinal))) continue;
+            string text;
+            try { text = File.ReadAllText(file); }
+            catch { continue; }
+            var rel = Path.GetRelativePath(RepoRootPath, file);
+            if (legacyUse.IsMatch(text))
+                offenders.Add($"{rel}: uses the legacy AudioMagicBytesValidator");
+            if (forkClass.IsMatch(text))
+                offenders.Add($"{rel}: declares a plugin-local *PayloadValidator fork");
+        }
+
+        return offenders.Count == 0
+            ? ComplianceResult.Success
+            : ComplianceResult.Failure(
+                "Audio-payload validation must use Lidarr.Plugin.Common.Utilities.DownloadPayloadValidator " +
+                $"(the canonical superset), not the legacy AudioMagicBytesValidator or a plugin-local fork: {string.Join("; ", offenders)}");
+    }
+
+    #endregion
+
     #region Check_FileClassNameParity
 
     /// <summary>
@@ -939,6 +1002,7 @@ public abstract partial class EcosystemParityTestBase
             [nameof(Check_UsesCommonDownloadTelemetrySink)] = Check_UsesCommonDownloadTelemetrySink(),
             [nameof(Check_DownloadClientUsesPathTraversalGuard)] = Check_DownloadClientUsesPathTraversalGuard(),
             [nameof(Check_DownloadClientStampsRegisteredClientId)] = Check_DownloadClientStampsRegisteredClientId(),
+            [nameof(Check_DownloadClientUsesCommonPayloadValidator)] = Check_DownloadClientUsesCommonPayloadValidator(),
             [nameof(Check_FileClassNameParity)] = Check_FileClassNameParity(),
             [nameof(Check_ClaudeMdDocumentsCommonHelpers)] = Check_ClaudeMdDocumentsCommonHelpers(),
         };

--- a/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
+++ b/tests/Compliance/EcosystemParityTestBaseExtensionTests.cs
@@ -72,6 +72,7 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         public ComplianceResult RunFileClassNameParity() => Check_FileClassNameParity();
         public ComplianceResult RunClaudeMdHelpers() => Check_ClaudeMdDocumentsCommonHelpers();
         public ComplianceResult RunDownloadClientIdStamp() => Check_DownloadClientStampsRegisteredClientId();
+        public ComplianceResult RunPayloadValidator() => Check_DownloadClientUsesCommonPayloadValidator();
     }
 
     /// <summary>A plugin-local re-declaration of the lyrics enricher (forbidden — must use common's).</summary>
@@ -728,6 +729,85 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
         Assert.Contains(r.Errors, e => e.Contains("IgnDownloadClient"));
     }
 
+    // --- Check_DownloadClientUsesCommonPayloadValidator ---
+    //
+    // Audio-payload validation is consolidated on Common's DownloadPayloadValidator; a download-client
+    // plugin must not use the legacy AudioMagicBytesValidator nor declare its own *PayloadValidator fork.
+
+    [Fact]
+    public void PayloadValidator_NoAssembly_ReturnsSkipped()
+    {
+        var h = new Harness(_tempRepo) { AssemblyValue = null };
+        Assert.True(h.RunPayloadValidator().Passed);
+    }
+
+    [Fact]
+    public void PayloadValidator_NoDownloadClient_NotApplicable_Passes()
+    {
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FileTokenStore<string>) },
+        };
+        Assert.True(h.RunPayloadValidator().Passed);
+    }
+
+    [Fact]
+    public void PayloadValidator_UsesCommonValidator_Passes()
+    {
+        var src = Path.Combine(_tempRepo, "pv-clean");
+        WriteSrcFile(src, "FooDownloadClient.cs",
+            "namespace P;\npublic class FooDownloadClient : DownloadClientBase<FooSettings>\n{\n" +
+            "    void Validate(System.ReadOnlySpan<byte> b) => DownloadPayloadValidator.ValidateOrThrow(b, \".flac\", null);\n}\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunPayloadValidator();
+        Assert.True(r.Passed, string.Join("; ", r.Errors));
+    }
+
+    [Fact]
+    public void PayloadValidator_UsesLegacyAudioMagicBytesValidator_Fails()
+    {
+        var src = Path.Combine(_tempRepo, "pv-legacy");
+        WriteSrcFile(src, "FooDownloadClient.cs",
+            "namespace P;\npublic class FooDownloadClient : DownloadClientBase<FooSettings>\n{\n" +
+            "    bool Validate(byte[] b) => AudioMagicBytesValidator.IsValidAudioMagicBytes(b.AsSpan());\n}\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunPayloadValidator();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("AudioMagicBytesValidator"));
+    }
+
+    [Fact]
+    public void PayloadValidator_DeclaresLocalForkClass_Fails()
+    {
+        var src = Path.Combine(_tempRepo, "pv-fork");
+        WriteSrcFile(src, "RogueDownloadPayloadValidator.cs",
+            "namespace P;\ninternal static class RogueDownloadPayloadValidator\n{\n" +
+            "    public static void ValidateOrThrow(System.ReadOnlySpan<byte> s, string? e, string? m) { }\n}\n");
+        // The download client itself lives in another file so the gate is satisfied.
+        WriteSrcFile(src, "FooDownloadClient.cs",
+            "namespace P;\npublic class FooDownloadClient : DownloadClientBase<FooSettings> { }\n");
+        var h = new Harness(_tempRepo)
+        {
+            AssemblyValue = typeof(EcosystemParityTestBaseExtensionTests).Assembly,
+            TypesValue = new[] { typeof(FakeDownloadClient) },
+            SourceRootValue = src,
+        };
+        var r = h.RunPayloadValidator();
+        Assert.False(r.Passed);
+        Assert.Contains(r.Errors, e => e.Contains("PayloadValidator fork"));
+    }
+
     // --- Check_FileClassNameParity ---
 
     private string WriteSrcFile(string srcDir, string fileName, string content)
@@ -941,8 +1021,8 @@ public class EcosystemParityTestBaseExtensionTests : IDisposable
     {
         var h = new Harness(_tempRepo) { AssemblyValue = null };
         var report = h.RunBehaviorContractChecks();
-        Assert.Equal(14, report.TotalCount);
-        // No assembly + no CLAUDE.md => the other 13 skip (Pass); Check_EnforcesAlbumCompletionPolicy
+        Assert.Equal(15, report.TotalCount);
+        // No assembly + no CLAUDE.md => the other 14 skip (Pass); Check_EnforcesAlbumCompletionPolicy
         // runs unconditionally (it asserts the shared rule directly, no assembly needed) and passes.
         Assert.True(report.AllPassed);
     }


### PR DESCRIPTION
## What
Adds `Check_DownloadClientUsesCommonPayloadValidator` to `EcosystemParityTestBase` — locks the audio-payload-validation consolidation just landed in tidalarr #323 + qobuzarr #302.

## Contract
Audio-payload validation (real audio vs HTML/JSON error page or wrong container) is consolidated on Common's canonical `DownloadPayloadValidator` — a strict superset of the legacy `AudioMagicBytesValidator` (adds MP4/M4A `ftyp`, text/HTML/JSON/XML rejection, file+span overloads). A download-client plugin **fails** the guard if it:
- (a) uses the legacy `AudioMagicBytesValidator`, or
- (b) declares its own `*PayloadValidator` fork (the historical `TidalDownloadPayloadValidator` + qobuz m4a-workaround divergence).

## Scope & precision
- Source-scan based; gated on the plugin shipping a host-contract download client (import-list plugins like brainarr → N/A).
- **Intentionally does NOT flag** inline MP4-box integrity checks on decrypted DASH segments (`moov`/`mdat`) — that's a distinct segment-integrity concern, not file-level audio validation (e.g. amazon's Widevine decryptor).
- Verified against each plugin's `origin/main`: **tidal/qobuz/apple PASS**; **amazon FAILs** (its `AmazonmusicarrManifestService` still uses the legacy validator — a deferred follow-up, amazon is mid-CI-rework).

## Verification (TDD)
5 behavior tests (N/A, clean, legacy-usage→fail, local-fork→fail). Red confirmed by neutering the guard (the two detection tests fail); green with it active. Aggregator count 14→15. Full Compliance extension class green (65 tests).

Consumers wire the one-line `[Fact]` on their next Common bump (tidal/qobuz/apple pass; amazon after it migrates its one remaining site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)