### PR TITLE
docs(readme): correct docs.yml gate description (Vale + snippets non-blocking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Orientation pages that map what exists and where to find it — full details liv
   dotnet run --project tools/DocTools/SnippetVerifier
   ```
 
-- GitHub Actions `docs.yml` enforces markdownlint, Vale, cspell, link checking, and snippet compilation on every documentation PR.
+- GitHub Actions `docs.yml` enforces markdownlint, cspell, and link checking on every documentation PR; Vale prose-linting and snippet compilation also run but are non-blocking (`continue-on-error`).
 
 ## Repository layout
 


### PR DESCRIPTION
## Summary

The README said `docs.yml` "enforces markdownlint, Vale, cspell, link checking, and snippet compilation." But in `.github/workflows/docs.yml`, **Vale (`:48`) and the Snippet verifier (`:64`) run with `continue-on-error: true`** — they're non-blocking. Reworded so only markdownlint + cspell + link-check are described as enforced (blocking), with Vale/snippets noted as non-blocking. One-line docs fix; verified against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)