### PR TITLE
refactor(http): consolidate AdaptiveRateLimitingHandler onto RateLimitHeaderUtilities

### DIFF
--- a/src/Services/Http/AdaptiveRateLimitingHandler.cs
+++ b/src/Services/Http/AdaptiveRateLimitingHandler.cs
@@ -77,7 +77,7 @@ namespace Lidarr.Plugin.Common.Services.Http
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            string endpointKey = BuildEndpointKey(request);
+            string endpointKey = RateLimitHeaderUtilities.BuildHostFirstSegmentKey(request);
 
             // Pre-send: wait for the limiter to permit this request.
             try
@@ -102,7 +102,7 @@ namespace Lidarr.Plugin.Common.Services.Http
             if (response.StatusCode == HttpStatusCode.TooManyRequests
                 && response.Headers.RetryAfter is { } retryAfter)
             {
-                TimeSpan delay = ResolveRetryAfter(retryAfter);
+                TimeSpan delay = RateLimitHeaderUtilities.ResolveRetryAfter(retryAfter);
                 // Clamp: a far-future Retry-After Date (or an enormous Delta) yields a delay beyond
                 // Task.Delay's ~49.7-day limit, which throws ArgumentOutOfRangeException — and that
                 // escapes the OperationCanceledException-only catch below, turning a 429 into a hard
@@ -125,38 +125,6 @@ namespace Lidarr.Plugin.Common.Services.Http
             }
 
             return response;
-        }
-
-        /// <summary>
-        /// Derives a stable endpoint key from the request URI.
-        /// Uses <c>host:firstPathSegment</c> to balance specificity vs. cardinality:
-        /// <list type="bullet">
-        /// <item><description><c>api.tidal.com/v1/search</c> → <c>api.tidal.com:v1</c></description></item>
-        /// <item><description><c>sp-ap-eu.audio.tidal.com/.../seg.mp4</c> → <c>sp-ap-eu.audio.tidal.com:</c></description></item>
-        /// </list>
-        /// </summary>
-        private static string BuildEndpointKey(HttpRequestMessage request)
-        {
-            Uri? uri = request.RequestUri;
-            if (uri is null) return "unknown";
-            string host = uri.Host;
-            string firstSeg = uri.Segments.Length > 1 ? uri.Segments[1].TrimEnd('/') : string.Empty;
-            return $"{host}:{firstSeg}";
-        }
-
-        /// <summary>
-        /// Resolves the effective delay from a <c>Retry-After</c> header value.
-        /// Precedence: Delta → Date → Zero.
-        /// </summary>
-        private static TimeSpan ResolveRetryAfter(System.Net.Http.Headers.RetryConditionHeaderValue retryAfter)
-        {
-            if (retryAfter.Delta is { } delta) return delta;
-            if (retryAfter.Date is { } date)
-            {
-                TimeSpan untilDate = date - DateTimeOffset.UtcNow;
-                return untilDate > TimeSpan.Zero ? untilDate : TimeSpan.Zero;
-            }
-            return TimeSpan.Zero;
         }
     }
 }


### PR DESCRIPTION
## What

`AdaptiveRateLimitingHandler` carried private copies of two helpers that already exist canonically in `RateLimitHeaderUtilities`:

- **`BuildEndpointKey(request)`** — functionally identical to `BuildHostFirstSegmentKey(request)` (host + first-path-segment keying). Pure duplicate → replaced + deleted.
- **`ResolveRetryAfter(retryAfter)`** — same `Delta→Date→Zero` precedence as the utility, **but dropped the utility's negative-delta guard** (`delta > Zero ? delta : Zero`), returning a negative `Delta` verbatim. **Latent only** — the call site clamps with `if (delay > TimeSpan.Zero)` before `Task.Delay`, so a negative never reached it — but the divergence is precisely how a future refactor introduces a real bug. Replaced with the guarded canonical; private copy deleted.

## Why

De-dup a shared handler (~25 lines of divergent copy-paste removed) and eliminate a latent correctness divergence by routing through the single guarded implementation. The request overload also throws an explicit `ArgumentNullException` instead of the private copy's potential NRE.

## Safety

Behaviour-preserving — the only difference (restored negative-delta guard) was already masked by the downstream clamp. **134 rate-limit tests pass.** Full Common suite otherwise green; the unrelated failures are pre-existing/environmental (`MultiPluginAlc`, `PackageClosure(qobuzarr)` need sibling repos absent from a worktree) plus one timing-flaky `CliRunner` stress test that passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)