### PR TITLE
feat(utilities): SettingsSnapshot.Copy<T> — reflection settings snapshot (no dropped fields)

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -179,3 +179,5 @@ Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithMinimumSizeBytes(
 Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithReleaseGroup(string! group) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
 Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithScheme(string! scheme) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
 Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder.WithYear(int? year) -> Lidarr.Plugin.Common.HostBridge.MultiQualityReleaseBuilder!
+Lidarr.Plugin.Common.Utilities.SettingsSnapshot
+static Lidarr.Plugin.Common.Utilities.SettingsSnapshot.Copy<T>(T source) -> T

--- a/src/Utilities/SettingsSnapshot.cs
+++ b/src/Utilities/SettingsSnapshot.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Reflection;
+
+namespace Lidarr.Plugin.Common.Utilities
+{
+    /// <summary>
+    /// Creates a defensive snapshot of a settings object by reflection-copying <b>every</b> read-write
+    /// property into a fresh instance.
+    ///
+    /// <para>
+    /// Download clients snapshot their settings synchronously, before the background download's first
+    /// <c>await</c>, so the deferred work sees a stable view even if the host repoints the live settings
+    /// mid-download. Hand-written field-by-field copies are fragile: across several plugins a copy silently
+    /// dropped a field (amazon's <c>EnableDrm</c>, tidal's <c>SaveSyncedLyrics</c>/<c>UseLRCLIB</c>), so a
+    /// feature the user enabled was ignored in the background download. Copying by reflection makes the
+    /// snapshot structurally unable to drop a field — a newly-added setting is captured automatically.
+    /// </para>
+    ///
+    /// <para>
+    /// Call with the concrete settings type, e.g. <c>SettingsSnapshot.Copy(this)</c>. A snapshot wants ALL
+    /// settings captured, so copy-everything is exactly the right semantic here. Only public read-write
+    /// instance properties are copied (computed/get-only properties are skipped); reference-typed values are
+    /// copied by reference, which is correct for the immutable strings/primitives settings use.
+    /// </para>
+    /// </summary>
+    public static class SettingsSnapshot
+    {
+        /// <summary>
+        /// Returns a new <typeparamref name="T"/> with every public read-write instance property copied from
+        /// <paramref name="source"/>. <typeparamref name="T"/> should be the concrete settings type.
+        /// </summary>
+        public static T Copy<T>(T source)
+            where T : new()
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var copy = new T();
+            foreach (var property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (property.CanRead && property.CanWrite && property.GetIndexParameters().Length == 0)
+                {
+                    property.SetValue(copy, property.GetValue(source));
+                }
+            }
+
+            return copy;
+        }
+    }
+}

--- a/tests/SettingsSnapshotTests.cs
+++ b/tests/SettingsSnapshotTests.cs
@@ -1,0 +1,75 @@
+using System;
+using Lidarr.Plugin.Common.Utilities;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// SettingsSnapshot.Copy reflection-copies every read-write property — the structural fix for the
+    /// cross-plugin "snapshot silently dropped a field" bug class (amazon EnableDrm, tidal SaveSyncedLyrics /
+    /// UseLRCLIB). A newly-added property is captured automatically; get-only properties are skipped.
+    /// </summary>
+    public sealed class SettingsSnapshotTests
+    {
+        private sealed class SampleSettings
+        {
+            public string? ConfigPath { get; set; }
+            public int MaxConcurrent { get; set; }
+            public bool EnableFeature { get; set; }
+            public SampleQuality Quality { get; set; }
+
+            // Get-only / computed — must NOT be touched by the copy.
+            public string Computed => $"{ConfigPath}:{MaxConcurrent}";
+        }
+
+        private enum SampleQuality { Sd, Hd, UltraHd }
+
+        [Fact]
+        public void Copy_CopiesEveryReadWriteProperty()
+        {
+            var source = new SampleSettings
+            {
+                ConfigPath = "/cfg",
+                MaxConcurrent = 7,
+                EnableFeature = true,
+                Quality = SampleQuality.UltraHd,
+            };
+
+            var copy = SettingsSnapshot.Copy(source);
+
+            Assert.NotSame(source, copy);
+            Assert.Equal("/cfg", copy.ConfigPath);
+            Assert.Equal(7, copy.MaxConcurrent);
+            Assert.True(copy.EnableFeature);
+            Assert.Equal(SampleQuality.UltraHd, copy.Quality);
+        }
+
+        [Fact]
+        public void Copy_IsIndependentOfSource()
+        {
+            var source = new SampleSettings { ConfigPath = "/a", MaxConcurrent = 1 };
+            var copy = SettingsSnapshot.Copy(source);
+
+            source.ConfigPath = "/changed";
+            source.MaxConcurrent = 99;
+
+            Assert.Equal("/a", copy.ConfigPath);
+            Assert.Equal(1, copy.MaxConcurrent);
+        }
+
+        [Fact]
+        public void Copy_IgnoresGetOnlyProperties_DoesNotThrow()
+        {
+            var copy = SettingsSnapshot.Copy(new SampleSettings { ConfigPath = "/x", MaxConcurrent = 2 });
+
+            // Computed has no setter; it is derived from the copied fields, never assigned.
+            Assert.Equal("/x:2", copy.Computed);
+        }
+
+        [Fact]
+        public void Copy_Null_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => SettingsSnapshot.Copy<SampleSettings>(null!));
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds `SettingsSnapshot.Copy<T>(this)` — reflection-copies every read-write property of a settings object into a fresh instance for the download-client pre-await snapshot.

## Why
Hand-written field-by-field snapshot copies silently dropped fields across plugins, disabling features in **background** downloads (which read the snapshot, not the live settings):
- **amazonmusicarr**: dropped `EnableDrm` → native Widevine CDM never activated in real downloads.
- **tidalarr**: dropped `SaveSyncedLyrics` + `UseLRCLIB` → background ignored the user's lyric settings.

The host-shape settings classes are hard to unit-test, so the drops went unnoticed. Copying by reflection makes the snapshot **structurally unable** to drop a field — a newly-added setting is captured automatically. Get-only/computed properties are skipped.

## Adoption
Lets all five plugins replace their bespoke snapshot copies with one shared, tested helper (find-once → fix-once-in-Common → all adopt). Plugins re-pin to this Common SHA and call `SettingsSnapshot.Copy(this)` in their download-client snapshotter once merged.

## Tests
4 unit tests: copies-all / independent-of-source / ignores-get-only / null-throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)