### PR TITLE
fix(http): parse HTTP-date Retry-After with InvariantCulture (locale-safe)

### DIFF
--- a/src/Services/Http/HttpResponseHelpers.cs
+++ b/src/Services/Http/HttpResponseHelpers.cs
@@ -53,10 +53,13 @@ namespace Lidarr.Plugin.Common.Services.Http
                         return TimeSpan.FromSeconds(Math.Max(0, seconds));
                     }
 
-                    // HTTP-date — RFC 7231 (e.g. "Wed, 21 Oct 2025 07:28:00 GMT").
+                    // HTTP-date — RFC 7231 IMF-fixdate (e.g. "Wed, 21 Oct 2025 07:28:00 GMT"). Always English
+                    // day/month names on a Gregorian calendar, so parse with InvariantCulture: the host's
+                    // CurrentCulture (esp. non-Gregorian, e.g. Thai Buddhist) fails to recognize "Oct"/"Wed"
+                    // and would silently drop the Retry-After header.
                     if (DateTimeOffset.TryParse(
                             raw,
-                            null,
+                            CultureInfo.InvariantCulture,
                             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
                             out var when))
                     {

--- a/tests/HttpResponseHelpersRetryAfterCultureTests.cs
+++ b/tests/HttpResponseHelpersRetryAfterCultureTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Lidarr.Plugin.Common.Services.Http;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// HTTP-date Retry-After values are RFC 7231 IMF-fixdate ("Wed, 21 Oct 2099 07:28:00 GMT") — always
+    /// English day/month abbreviations on a Gregorian calendar. ParseRetryAfter must parse them with
+    /// CultureInfo.InvariantCulture, not the host's CurrentCulture: on a non-English / non-Gregorian host
+    /// (e.g. Thai Buddhist, +543 years) the current-culture parser does not recognize "Oct"/"Wed", silently
+    /// fails, and the Retry-After header is dropped — degrading rate-limit backoff.
+    /// </summary>
+    public sealed class HttpResponseHelpersRetryAfterCultureTests
+    {
+        [Theory]
+        [InlineData("th-TH")] // Thai Buddhist calendar (+543 years)
+        [InlineData("fa-IR")] // Persian calendar
+        [InlineData("ar-SA")] // Umm al-Qura calendar
+        public void ParseRetryAfter_HttpDate_UnderNonGregorianCulture_StillParses(string cultureName)
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+
+                // A fixed far-future IMF-fixdate so the delta is unambiguously large + positive.
+                var headers = new[] { new KeyValuePair<string, string>("Retry-After", "Wed, 21 Oct 2099 07:28:00 GMT") };
+
+                var result = HttpResponseHelpers.ParseRetryAfter(headers);
+
+                Assert.NotNull(result); // current-culture parse drops the header → null (the bug)
+                Assert.True(result!.Value > TimeSpan.FromDays(365 * 50),
+                    $"a 2099 HTTP-date should be decades out, got {result}");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        [Fact]
+        public void ParseRetryAfter_NumericSeconds_Unaffected()
+        {
+            var headers = new[] { new KeyValuePair<string, string>("Retry-After", "120") };
+            Assert.Equal(TimeSpan.FromSeconds(120), HttpResponseHelpers.ParseRetryAfter(headers));
+        }
+    }
+}


### PR DESCRIPTION
Wave-P1 correctness sweep. ParseRetryAfter parsed RFC-7231 HTTP-date Retry-After with the host CurrentCulture (null provider); on non-Gregorian hosts (Thai Buddhist/Persian/Umm-al-Qura) it fails to recognize the English month/day names and silently drops the header, degrading rate-limit backoff for every plugin. Fixed to use InvariantCulture.

This is the only missing-InvariantCulture date-parse instance across the 5 plugins + Common (epoch-overflow class already swept). Tests: th-TH/fa-IR/ar-SA HTTP-date parse correctly; numeric Retry-After unchanged. 16/16 with the rate-limit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)