### PR TITLE
fix(security): keep SSRF policy in force across media redirects (R2-01)

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -213,3 +213,6 @@ static Lidarr.Plugin.Common.Services.Download.DirectoryCleanupResult.Noop.get ->
 static Lidarr.Plugin.Common.Services.Download.DirectoryCleanupResult.Refused(string! reason) -> Lidarr.Plugin.Common.Services.Download.DirectoryCleanupResult
 Lidarr.Plugin.Common.Services.Download.SafeDirectoryCleanup
 static Lidarr.Plugin.Common.Services.Download.SafeDirectoryCleanup.DeleteTreeUnderRoot(string? path, string? root) -> Lidarr.Plugin.Common.Services.Download.DirectoryCleanupResult
+Lidarr.Plugin.Common.Services.Download.MediaRedirectSafeSender
+const Lidarr.Plugin.Common.Services.Download.MediaRedirectSafeSender.DefaultMaxRedirects = 10 -> int
+static Lidarr.Plugin.Common.Services.Download.MediaRedirectSafeSender.SendValidatedAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy! policy, System.Net.Http.HttpCompletionOption completionOption = System.Net.Http.HttpCompletionOption.ResponseHeadersRead, int maxRedirects = 10, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!

--- a/src/Services/Download/ChunkedHttpAssembler.cs
+++ b/src/Services/Download/ChunkedHttpAssembler.cs
@@ -282,7 +282,8 @@ namespace Lidarr.Plugin.Common.Services.Download
         private async Task<long> DownloadChunkToStreamAsync(ChunkSpec chunk, Stream output, int bufferSize, CancellationToken cancellationToken)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, chunk.Url);
-            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            // R2-01: validate redirect targets against the SSRF policy (hostile manifest chunk URLs).
+            using var response = await MediaRedirectSafeSender.SendValidatedAsync(_httpClient, request, _mediaUriPolicy, HttpCompletionOption.ResponseHeadersRead, cancellationToken: cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             await using var content = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
@@ -303,7 +304,8 @@ namespace Lidarr.Plugin.Common.Services.Download
             try
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, chunk.Url);
-                using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                // R2-01: validate redirect targets against the SSRF policy (hostile manifest chunk URLs).
+                using var response = await MediaRedirectSafeSender.SendValidatedAsync(_httpClient, request, _mediaUriPolicy, HttpCompletionOption.ResponseHeadersRead, cancellationToken: cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 await using var content = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 await using var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize, useAsync: true);

--- a/src/Services/Download/HttpFileDownloadService.cs
+++ b/src/Services/Download/HttpFileDownloadService.cs
@@ -62,7 +62,8 @@ namespace Lidarr.Plugin.Common.Services.Download
                 request.Headers.Range = new RangeHeaderValue(existing, null);
             }
 
-            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            // R2-01: keep the SSRF policy in force across redirects (validate each hop + the final URI).
+            using var response = await MediaRedirectSafeSender.SendValidatedAsync(_httpClient, request, _mediaUriPolicy, HttpCompletionOption.ResponseHeadersRead, cancellationToken: cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var contentType = response.Content.Headers.ContentType?.MediaType ?? "unknown";

--- a/src/Services/Download/MediaRedirectSafeSender.cs
+++ b/src/Services/Download/MediaRedirectSafeSender.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lidarr.Plugin.Common.Services.Download
+{
+    /// <summary>
+    /// Sends a media (download) request while keeping the <see cref="RemoteMediaUriGuard"/> SSRF policy in
+    /// force across redirects — closing the gap where the initial URL is validated but a hostile/compromised
+    /// CDN or manifest redirects to an internal host (R2-01).
+    ///
+    /// <para>Works regardless of the injected <see cref="HttpClient"/>'s <c>AllowAutoRedirect</c> setting:</para>
+    /// <list type="bullet">
+    /// <item><b>Auto-redirect OFF</b> (preferred): each 3xx <c>Location</c> is validated against the policy
+    /// before the next hop is issued, so an internal-host redirect target is refused <i>before</i> any request
+    /// reaches it.</item>
+    /// <item><b>Auto-redirect ON</b> (defense-in-depth): the client follows internally, but the final
+    /// <see cref="HttpResponseMessage.RequestMessage"/> URI is validated before the body is read, so a response
+    /// from an internal host is refused rather than written to disk.</item>
+    /// </list>
+    /// Only GET/HEAD media flows are intended; redirect methods follow the usual 301/302/303→GET, 307/308→preserve.
+    /// </summary>
+    public static class MediaRedirectSafeSender
+    {
+        /// <summary>Default maximum redirect hops for a media fetch.</summary>
+        public const int DefaultMaxRedirects = 10;
+
+        /// <summary>
+        /// Sends <paramref name="request"/> via <paramref name="client"/>, validating every redirect hop and
+        /// the final resolved URI against <paramref name="policy"/>. Throws <see cref="InvalidOperationException"/>
+        /// if any hop or the final URI is blocked, or if the hop budget is exhausted.
+        /// </summary>
+        public static async Task<HttpResponseMessage> SendValidatedAsync(
+            HttpClient client,
+            HttpRequestMessage request,
+            RemoteMediaUriPolicy policy,
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseHeadersRead,
+            int maxRedirects = DefaultMaxRedirects,
+            CancellationToken cancellationToken = default)
+        {
+            if (client is null) throw new ArgumentNullException(nameof(client));
+            if (request is null) throw new ArgumentNullException(nameof(request));
+            policy ??= RemoteMediaUriPolicy.Strict;
+
+            var current = request;
+            for (var hop = 0; ; hop++)
+            {
+                var response = await client.SendAsync(current, completionOption, cancellationToken).ConfigureAwait(false);
+
+                // Defense-in-depth: if the client auto-followed redirects internally, RequestMessage.RequestUri
+                // is the final landing URI. Refuse it before the caller consumes the body.
+                var finalUri = response.RequestMessage?.RequestUri;
+                if (finalUri is not null && !RemoteMediaUriGuard.Validate(finalUri, policy).IsAllowed)
+                {
+                    response.Dispose();
+                    throw new InvalidOperationException(
+                        $"Refusing media response from a redirected unsafe URL: {Redact(finalUri)}.");
+                }
+
+                var status = (int)response.StatusCode;
+                var isRedirect = status is 301 or 302 or 303 or 307 or 308;
+                var location = response.Headers.Location;
+                if (!isRedirect || location is null)
+                {
+                    return response; // final (non-redirect) response — already validated above.
+                }
+
+                // Manual follow (auto-redirect OFF path): validate the target BEFORE issuing the next hop.
+                if (hop >= maxRedirects)
+                {
+                    response.Dispose();
+                    throw new InvalidOperationException($"Too many media redirects (> {maxRedirects}).");
+                }
+
+                var target = location.IsAbsoluteUri ? location : new Uri(current.RequestUri!, location);
+                if (!RemoteMediaUriGuard.Validate(target, policy).IsAllowed)
+                {
+                    response.Dispose();
+                    throw new InvalidOperationException(
+                        $"Refusing redirect to an unsafe media URL: {Redact(target)}.");
+                }
+
+                // 301/302/303 downgrade unsafe methods to GET; 307/308 preserve the method. Media is GET/HEAD,
+                // so a fresh request without a body is correct for every case here.
+                var method = status is 307 or 308 ? current.Method : HttpMethod.Get;
+                var next = new HttpRequestMessage(method, target);
+                CopyForwardableHeaders(current, next);
+
+                response.Dispose();
+                if (current != request) current.Dispose();
+                current = next;
+            }
+        }
+
+        private static void CopyForwardableHeaders(HttpRequestMessage from, HttpRequestMessage to)
+        {
+            foreach (var h in from.Headers)
+            {
+                // Drop Authorization on cross-origin redirects to avoid leaking credentials to the new host.
+                if (string.Equals(h.Key, "Authorization", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(from.RequestUri?.Host, to.RequestUri?.Host, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                to.Headers.TryAddWithoutValidation(h.Key, h.Value);
+            }
+        }
+
+        private static string Redact(Uri uri) => $"{uri.Scheme}://{uri.Host}";
+    }
+}

--- a/tests/MediaRedirectSafeSenderTests.cs
+++ b/tests/MediaRedirectSafeSenderTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Services.Download;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// R2-01: media downloads must keep the SSRF policy in force across redirects. A public CDN that redirects
+    /// to a private/loopback/metadata host must be refused — both when the client surfaces the 3xx (auto-redirect
+    /// off, validated before the next hop) and when the client auto-follows internally (final RequestUri validated
+    /// before the body is consumed).
+    /// </summary>
+    public sealed class MediaRedirectSafeSenderTests
+    {
+        private sealed class ScriptedHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _steps;
+            public readonly List<Uri> Sent = new();
+            public ScriptedHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] steps) => _steps = new(steps);
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                Sent.Add(request.RequestUri!);
+                var resp = _steps.Dequeue()(request);
+                resp.RequestMessage ??= request;
+                return Task.FromResult(resp);
+            }
+        }
+
+        private static HttpResponseMessage Redirect(string location)
+        {
+            var r = new HttpResponseMessage(HttpStatusCode.Found); // 302
+            r.Headers.Location = new Uri(location);
+            return r;
+        }
+
+        private static HttpResponseMessage Ok(string? finalUri = null)
+        {
+            var r = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(new byte[] { 1, 2, 3 }) };
+            if (finalUri != null) r.RequestMessage = new HttpRequestMessage(HttpMethod.Get, finalUri);
+            return r;
+        }
+
+        private static Task<HttpResponseMessage> Send(ScriptedHandler h, string url)
+        {
+            using var client = new HttpClient(h);
+            var req = new HttpRequestMessage(HttpMethod.Get, url);
+            return MediaRedirectSafeSender.SendValidatedAsync(client, req, RemoteMediaUriPolicy.Strict);
+        }
+
+        [Fact]
+        public async Task Redirect_ToPrivateHost_IsRefused_WithoutFetchingIt()
+        {
+            var handler = new ScriptedHandler(_ => Redirect("https://10.0.0.1/internal"));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Send(handler, "https://8.8.8.8/seg.m4s"));
+
+            Assert.Single(handler.Sent); // only the original public host was contacted; the private target was NOT
+            Assert.Equal("8.8.8.8", handler.Sent[0].Host);
+        }
+
+        [Fact]
+        public async Task Redirect_ToMetadataHost_IsRefused()
+        {
+            var handler = new ScriptedHandler(_ => Redirect("https://169.254.169.254/latest/meta-data/"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Send(handler, "https://8.8.8.8/seg.m4s"));
+        }
+
+        [Fact]
+        public async Task AutoRedirectLandedOnPrivate_FinalUriRefused()
+        {
+            // Simulate a client that auto-followed to a private host: 200 with RequestMessage.RequestUri private.
+            var handler = new ScriptedHandler(_ => Ok(finalUri: "https://10.0.0.1/internal"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Send(handler, "https://8.8.8.8/seg.m4s"));
+        }
+
+        [Fact]
+        public async Task PublicRedirect_IsFollowed_AndReturned()
+        {
+            var handler = new ScriptedHandler(
+                _ => Redirect("https://1.1.1.1/cdn/seg.m4s"),
+                _ => Ok(finalUri: "https://1.1.1.1/cdn/seg.m4s"));
+
+            var resp = await Send(handler, "https://8.8.8.8/seg.m4s");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal(2, handler.Sent.Count);
+            Assert.Equal("1.1.1.1", handler.Sent[1].Host);
+        }
+
+        [Fact]
+        public async Task PublicDirect_Returned()
+        {
+            var handler = new ScriptedHandler(_ => Ok(finalUri: "https://8.8.8.8/seg.m4s"));
+            var resp = await Send(handler, "https://8.8.8.8/seg.m4s");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
Round-2 R2-01 (HIGH): RemoteMediaUriGuard validated only the first URL; a CDN/manifest redirect to an internal host bypassed it. New MediaRedirectSafeSender validates every redirect hop (auto-redirect off) and the final RequestUri (auto-redirect on, before body read), drops Authorization cross-host, caps hops. Wired into HttpFileDownloadService + both ChunkedHttpAssembler sends. 81 tests green incl. public→private/metadata redirect rejection.

Scope: closes the two raw media-download paths; the ExecuteWithResilienceAsync/orchestrator redirect loop is a tracked follow-up (general-purpose helper, 26 callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)