### PR TITLE
fix(security): DNS-resolver seam on policy + label-boundary suffix match (R2-02, R2-09)

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -189,6 +189,8 @@ Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.AllowedHostSuffixes.
 Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.AllowedHostSuffixes.init -> void
 Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.ResolveDns.get -> bool
 Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.ResolveDns.init -> void
+Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.DnsResolver.get -> System.Func<string!, System.Net.IPAddress![]!>?
+Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.DnsResolver.init -> void
 static Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy.Strict.get -> Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy!
 Lidarr.Plugin.Common.Services.Download.UriGuardResult
 Lidarr.Plugin.Common.Services.Download.UriGuardResult.UriGuardResult(bool IsAllowed, string? Reason) -> void

--- a/src/Services/Download/RemoteMediaUriGuard.cs
+++ b/src/Services/Download/RemoteMediaUriGuard.cs
@@ -27,6 +27,12 @@ namespace Lidarr.Plugin.Common.Services.Download
         /// Mitigates (does not fully prevent — see remarks) DNS-rebinding to internal hosts.</summary>
         public bool ResolveDns { get; init; } = true;
 
+        /// <summary>Optional DNS resolver used when <see cref="ResolveDns"/> is on and no explicit resolver is
+        /// passed to <c>Validate</c>. Lets production wire the guard with a policy alone while keeping
+        /// <see cref="ResolveDns"/> = true, and lets tests inject a deterministic resolver instead of weakening
+        /// the policy to <c>ResolveDns = false</c> (R2-02). Null ⇒ real <see cref="System.Net.Dns"/>.</summary>
+        public Func<string, IPAddress[]>? DnsResolver { get; init; }
+
         /// <summary>Strict default: https only, public destinations only.</summary>
         public static RemoteMediaUriPolicy Strict { get; } = new();
     }
@@ -102,13 +108,20 @@ namespace Lidarr.Plugin.Common.Services.Download
                 return UriGuardResult.Blocked("URL has no host.");
             }
 
+            // R2-09: a trailing-dot FQDN ("host." == "host"). Normalize before any host comparison so a trailing
+            // dot can't bypass the metadata blocklist or the allowed-suffix check.
+            if (host.Length > 1 && host[^1] == '.')
+            {
+                host = host[..^1];
+            }
+
             if (MetadataHosts.Any(m => string.Equals(host, m, StringComparison.OrdinalIgnoreCase)))
             {
                 return UriGuardResult.Blocked("URL targets a cloud metadata host.");
             }
 
             if (policy.AllowedHostSuffixes is { Count: > 0 } &&
-                !policy.AllowedHostSuffixes.Any(s => host.EndsWith(s, StringComparison.OrdinalIgnoreCase)))
+                !policy.AllowedHostSuffixes.Any(s => HostMatchesSuffix(host, s)))
             {
                 return UriGuardResult.Blocked("URL host is not in the allowed host-suffix list.");
             }
@@ -130,7 +143,8 @@ namespace Lidarr.Plugin.Common.Services.Download
                 IPAddress[] resolved;
                 try
                 {
-                    resolved = (dnsResolver ?? Dns.GetHostAddresses)(host);
+                    // Precedence: explicit arg > policy-carried resolver (R2-02) > real DNS.
+                    resolved = (dnsResolver ?? policy.DnsResolver ?? Dns.GetHostAddresses)(host);
                 }
                 catch (Exception ex) when (ex is SocketException or ArgumentException)
                 {
@@ -152,6 +166,28 @@ namespace Lidarr.Plugin.Common.Services.Download
             }
 
             return UriGuardResult.Allowed;
+        }
+
+        /// <summary>R2-09: host matches an allowed suffix only on a label (dot) boundary — exact host, or a
+        /// real subdomain ending in ".&lt;suffix&gt;". A bare suffix "cdn.com" must not admit "evilcdn.com".
+        /// Accepts the suffix written with or without a leading dot.</summary>
+        private static bool HostMatchesSuffix(string host, string suffix)
+        {
+            if (string.IsNullOrEmpty(suffix))
+            {
+                return false;
+            }
+
+            var bare = suffix[0] == '.' ? suffix[1..] : suffix;
+            if (bare.Length == 0)
+            {
+                return false;
+            }
+
+            return string.Equals(host, bare, StringComparison.OrdinalIgnoreCase) ||
+                   (host.Length > bare.Length &&
+                    host[host.Length - bare.Length - 1] == '.' &&
+                    host.EndsWith(bare, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>True if the address is loopback, link-local, private, ULA, multicast, unspecified, or

--- a/tests/RemoteMediaUriGuardTests.cs
+++ b/tests/RemoteMediaUriGuardTests.cs
@@ -106,5 +106,52 @@ namespace Lidarr.Plugin.Common.Tests
             Assert.True(RemoteMediaUriGuard.Validate("https://a.trusted-cdn.com/x", policy, ResolvePublic).IsAllowed);
             Assert.False(RemoteMediaUriGuard.Validate("https://evil.example.com/x", policy, ResolvePublic).IsAllowed);
         }
+
+        // R2-09: suffix matching must be on a label (dot) boundary, not a raw substring tail. A bare suffix
+        // "trusted-cdn.com" must NOT let "eviltrusted-cdn.com" through; only the exact host or a real
+        // ".trusted-cdn.com" subdomain qualifies. Tested with both the bare and leading-dot suffix forms.
+        [Theory]
+        [InlineData("trusted-cdn.com", "https://eviltrusted-cdn.com/x", false)]   // glued prefix — NOT a subdomain
+        [InlineData("trusted-cdn.com", "https://trusted-cdn.com/x", true)]        // exact host
+        [InlineData("trusted-cdn.com", "https://a.trusted-cdn.com/x", true)]      // real subdomain
+        [InlineData(".trusted-cdn.com", "https://eviltrusted-cdn.com/x", false)]  // leading-dot form, same boundary rule
+        [InlineData(".trusted-cdn.com", "https://trusted-cdn.com/x", true)]       // leading-dot form still allows exact
+        public void Validate_AllowedHostSuffixes_MatchesOnLabelBoundary(string suffix, string url, bool allowed)
+        {
+            var policy = new RemoteMediaUriPolicy { AllowedHostSuffixes = new List<string> { suffix } };
+            Assert.Equal(allowed, RemoteMediaUriGuard.Validate(url, policy, ResolvePublic).IsAllowed);
+        }
+
+        // R2-09: a trailing-dot FQDN ("host.") is the same host — it must not bypass the metadata-host blocklist
+        // nor the allowed-suffix check.
+        [Fact]
+        public void Validate_TrailingDotFqdn_IsNormalized()
+        {
+            // metadata host with a trailing dot is still the metadata host -> blocked
+            Assert.False(RemoteMediaUriGuard.Validate("https://metadata.google.internal./x", RemoteMediaUriPolicy.Strict).IsAllowed);
+            // trailing-dot subdomain still satisfies the suffix allow-list
+            var policy = new RemoteMediaUriPolicy { AllowedHostSuffixes = new List<string> { "trusted-cdn.com" } };
+            Assert.True(RemoteMediaUriGuard.Validate("https://a.trusted-cdn.com./x", policy, ResolvePublic).IsAllowed);
+        }
+
+        // R2-02: production code wires the guard with only a policy (no dnsResolver arg). The policy must be able
+        // to carry a DnsResolver so a host's resolution can be classified — letting production keep ResolveDns=true
+        // while tests inject a deterministic resolver instead of relaxing the policy to ResolveDns=false.
+        [Fact]
+        public void Validate_PolicyDnsResolver_IsUsed_WhenNoExplicitResolverPassed()
+        {
+            var resolvesPrivate = new RemoteMediaUriPolicy
+            {
+                DnsResolver = _ => new[] { System.Net.IPAddress.Parse("10.0.0.1") }
+            };
+            // No explicit dnsResolver arg — the policy's resolver classifies the host as private and blocks it.
+            Assert.False(RemoteMediaUriGuard.Validate("https://cdn.example.com/seg.m4s", resolvesPrivate).IsAllowed);
+
+            var resolvesPublic = new RemoteMediaUriPolicy
+            {
+                DnsResolver = _ => new[] { System.Net.IPAddress.Parse("8.8.8.8") }
+            };
+            Assert.True(RemoteMediaUriGuard.Validate("https://cdn.example.com/seg.m4s", resolvesPublic).IsAllowed);
+        }
     }
 }


### PR DESCRIPTION
## Round-2 review findings R2-02 + R2-09 (both in RemoteMediaUriGuard)

### R2-02 (HIGH) — DNS-resolver seam carried on the policy
Wave-P0 relaxed `RemoteMediaUriPolicy.ResolveDns` to `false` in two production downloaders (amazon `AmazonmusicarrManifestService`, tidal `TidalChunkDownloader`) purely so unit tests with non-resolving CDN hosts would pass. The reviewer correctly flagged that as weakening SSRF in production.

Fix: `RemoteMediaUriPolicy` gains an optional `DnsResolver`. Production wires the guard with a policy alone, so it can keep `ResolveDns = true` (real DNS) while tests inject a deterministic resolver **through the policy**. `Validate` precedence: explicit `dnsResolver` arg > `policy.DnsResolver` > real `Dns.GetHostAddresses`.

Follow-up (separate plugin PRs, gated on this merge + re-pin): flip amazon/tidal production policies back to `ResolveDns = true` and inject the fake resolver via the policy in their tests.

### R2-09 (LOW/latent) — host-suffix substring bypass + trailing-dot
- `AllowedHostSuffixes` used a raw `host.EndsWith(suffix)` → a bare suffix `cdn.com` admitted `evilcdn.com`. Now matches on a **label (dot) boundary**: exact host or a real `.<suffix>` subdomain. Accepts the suffix written with or without a leading dot.
- A trailing-dot FQDN (`host.` ≡ `host`) is normalized before any host comparison, so it can't bypass the metadata-host blocklist or the suffix allow-list.

## Tests
`RemoteMediaUriGuardTests` 38/38 green, incl. 5 new cases: policy-carried resolver (private→blocked, public→allowed), label-boundary matching (glued-prefix blocked, exact/subdomain allowed, both suffix forms), trailing-dot normalization (metadata host blocked, subdomain allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)