### PR TITLE
fix(security): validate media URL before the first send (R2-01 follow-up)

### DIFF
--- a/src/Services/Download/MediaRedirectSafeSender.cs
+++ b/src/Services/Download/MediaRedirectSafeSender.cs
@@ -46,6 +46,16 @@ namespace Lidarr.Plugin.Common.Services.Download
             var current = request;
             for (var hop = 0; ; hop++)
             {
+                // Validate the target BEFORE issuing the request — refuse a private/internal/non-https host
+                // up-front rather than only catching it on the response. This covers the FIRST hop (the initial
+                // URL) too, so a direct request to an internal host is never sent at all (R2-01 follow-up).
+                if (current.RequestUri is { } targetUri && !RemoteMediaUriGuard.Validate(targetUri, policy).IsAllowed)
+                {
+                    if (current != request) current.Dispose();
+                    throw new InvalidOperationException(
+                        $"Refusing media request to an unsafe URL: {Redact(targetUri)}.");
+                }
+
                 var response = await client.SendAsync(current, completionOption, cancellationToken).ConfigureAwait(false);
 
                 // Defense-in-depth: if the client auto-followed redirects internally, RequestMessage.RequestUri

--- a/tests/MediaRedirectSafeSenderTests.cs
+++ b/tests/MediaRedirectSafeSenderTests.cs
@@ -79,6 +79,16 @@ namespace Lidarr.Plugin.Common.Tests
         }
 
         [Fact]
+        public async Task DirectPrivateHost_IsRefused_BeforeAnyRequestIsSent()
+        {
+            // The initial URL itself targets a private host. It must be refused BEFORE the first send — the
+            // handler must never be invoked, so the internal host is never contacted at all.
+            var handler = new ScriptedHandler(_ => Ok()); // would 200 if ever called
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Send(handler, "https://10.0.0.1/internal"));
+            Assert.Empty(handler.Sent); // never sent
+        }
+
+        [Fact]
         public async Task PublicRedirect_IsFollowed_AndReturned()
         {
             var handler = new ScriptedHandler(


### PR DESCRIPTION
## R2-01 follow-up — surfaced by the qobuz R2-02 work

`MediaRedirectSafeSender` validated `response.RequestMessage.RequestUri` (the auto-redirect-on defense) and each manual redirect target — but it issued the **initial** request *before* any validation. So a direct request to an internal host fired before being refused; only the response body was then rejected. For SSRF, the request itself reaching the internal host is the problem.

### Fix
Validate `current.RequestUri` at the **top** of the send loop, covering the first hop too. A direct private/internal/non-https target is now refused before the request is ever issued. This makes the guard robust even for callers that don't separately pre-validate the initial URL (`HttpFileDownloadService` and the qobuz raw fetches do; the **tidal raw probe** does not, and is retroactively tightened by this change once tidal re-pins).

### Test
New test: a direct request to a private host throws and the handler is **never invoked** (`Assert.Empty(handler.Sent)`). 6/6 `MediaRedirectSafeSender` + 54 Common download tests green.

### Honest scope note
`SimpleDownloadOrchestrator` (no plugin **source** caller today — only present in the merged Common DLL) follows redirects via `HttpClientExtensions.ExecuteWithResilienceAsync`, whose redirect loop still doesn't re-validate targets. It *does* pre-validate the initial URL. Threading a redirect-target validator through that method (two core overloads + host-gate/rate-limit redirect loops) is a separate, focused follow-up — not folded in here to avoid a risky change to a hot shared method for a latent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)