### PR TITLE
fix(security): refuse recursive delete through a reparse-point target (R2-05)

### DIFF
--- a/src/Services/Download/SafeDirectoryCleanup.cs
+++ b/src/Services/Download/SafeDirectoryCleanup.cs
@@ -74,6 +74,24 @@ namespace Lidarr.Plugin.Common.Services.Download
                 return DirectoryCleanupResult.Noop;
             }
 
+            // R2-05: the lexical containment check above resolves "." and ".." but NOT symlink/junction targets,
+            // so a reparse point can be in-bounds by path yet point at an unrelated tree. Refuse to recursively
+            // delete through a reparse-point target. (Nested reparse points are not traversed by .NET's recursive
+            // delete, so this closes the top-level case; a legitimate download tree is never a symlink.) The
+            // residual TOCTOU race — a path component swapped to a reparse point between this check and the
+            // delete — requires concurrent write access to the trusted download root and is out of scope.
+            try
+            {
+                if (new DirectoryInfo(canonicalPath).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                {
+                    return DirectoryCleanupResult.Refused("path is a reparse point (symlink/junction); refusing to delete through it.");
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return DirectoryCleanupResult.Refused("path attributes could not be read.");
+            }
+
             Directory.Delete(canonicalPath, recursive: true);
             return DirectoryCleanupResult.Removed;
         }

--- a/tests/SafeDirectoryCleanupTests.cs
+++ b/tests/SafeDirectoryCleanupTests.cs
@@ -112,5 +112,44 @@ namespace Lidarr.Plugin.Common.Tests
             }
             finally { try { Directory.Delete(root, true); } catch { } }
         }
+
+        // R2-05: a directory symlink/junction can be lexically in-bounds (Path.GetFullPath resolves "." and ".."
+        // but NOT the link target) while pointing OUTSIDE the root. Recursively deleting through it must be
+        // refused so cleanup can't be steered into deleting an unrelated tree. (Nested reparse points are already
+        // not traversed by .NET's recursive delete; this closes the top-level case.)
+        [Fact]
+        public void DeleteTreeUnderRoot_ReparsePointTarget_Refuses_AndLinkTargetSurvives()
+        {
+            var root = NewTempRoot();
+            var outside = NewTempRoot();
+            try
+            {
+                var outsideFile = Path.Combine(outside, "precious.flac");
+                File.WriteAllText(outsideFile, "do not delete");
+
+                var link = Path.Combine(root, "link");
+                try
+                {
+                    Directory.CreateSymbolicLink(link, outside);
+                }
+                catch (System.Exception ex) when (ex is System.IO.IOException or System.UnauthorizedAccessException or System.PlatformNotSupportedException)
+                {
+                    // Creating a directory symlink needs privilege on some platforms (e.g. Windows without
+                    // Developer Mode). Where we can't create one, there's nothing to assert here.
+                    return;
+                }
+
+                var result = SafeDirectoryCleanup.DeleteTreeUnderRoot(link, root);
+
+                Assert.False(result.Deleted, "a reparse-point target must not be recursively deleted");
+                Assert.False(string.IsNullOrEmpty(result.Reason));
+                Assert.True(File.Exists(outsideFile), "the link's real target must be untouched");
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+                try { Directory.Delete(outside, true); } catch { }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Round-2 review R2-05

`SafeDirectoryCleanup.DeleteTreeUnderRoot`'s containment check uses `Path.GetFullPath`, which resolves `.`/`..` but **not** symlink/junction targets — so a directory reparse point can be lexically in-bounds while pointing at an unrelated tree. A recursive delete through it could be steered into destroying data outside the root.

### Fix
Refuse when the target directory is itself a reparse point. .NET's recursive delete already does **not** traverse *nested* reparse points, so this closes the top-level case; a legitimate download tree is never a symlink. The residual TOCTOU race (a component swapped to a reparse point between the check and the delete) requires concurrent write access to the trusted download root and is documented as out of scope.

### Test
Creates an in-bounds directory symlink to an outside tree, asserts the delete is **refused** and the link's real target survives (skips gracefully where creating a directory symlink needs privilege, e.g. Windows without Developer Mode — runs fully on Linux CI). 9/9 `SafeDirectoryCleanup` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)