### PR TITLE
feat(common): overflow- and culture-safe TimeParsing helpers (R2-08)

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -218,3 +218,7 @@ static Lidarr.Plugin.Common.Services.Download.SafeDirectoryCleanup.DeleteTreeUnd
 Lidarr.Plugin.Common.Services.Download.MediaRedirectSafeSender
 const Lidarr.Plugin.Common.Services.Download.MediaRedirectSafeSender.DefaultMaxRedirects = 10 -> int
 static Lidarr.Plugin.Common.Services.Download.MediaRedirectSafeSender.SendValidatedAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Lidarr.Plugin.Common.Services.Download.RemoteMediaUriPolicy! policy, System.Net.Http.HttpCompletionOption completionOption = System.Net.Http.HttpCompletionOption.ResponseHeadersRead, int maxRedirects = 10, System.Threading.CancellationToken cancellationToken = default) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
+Lidarr.Plugin.Common.Utilities.TimeParsing
+static Lidarr.Plugin.Common.Utilities.TimeParsing.TryFromUnixTimeSeconds(long seconds, out System.DateTimeOffset value) -> bool
+static Lidarr.Plugin.Common.Utilities.TimeParsing.TryFromUnixTimeMilliseconds(long milliseconds, out System.DateTimeOffset value) -> bool
+static Lidarr.Plugin.Common.Utilities.TimeParsing.TryParseIsoDateInvariant(string? text, out System.DateTimeOffset value) -> bool

--- a/src/Utilities/TimeParsing.cs
+++ b/src/Utilities/TimeParsing.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Globalization;
+
+namespace Lidarr.Plugin.Common.Utilities
+{
+    /// <summary>
+    /// Culture- and overflow-safe parsing of external time values (R2-08). Streaming/credential APIs return epoch
+    /// seconds/milliseconds and ISO-8601 dates from untrusted bodies; a hostile or malformed value (e.g.
+    /// <see cref="long.MaxValue"/>) makes <see cref="DateTimeOffset.FromUnixTimeSeconds"/> /
+    /// <see cref="DateTimeOffset.FromUnixTimeMilliseconds"/> throw <see cref="ArgumentOutOfRangeException"/>, and
+    /// parsing under a non-invariant culture can shift the instant. These <c>Try*</c> helpers fail closed
+    /// (return <c>false</c>) instead of throwing, so callers can skip a bad value rather than crash the pipeline.
+    /// </summary>
+    public static class TimeParsing
+    {
+        // DateTimeOffset's representable Unix range, precomputed so an out-of-range epoch is rejected by a
+        // comparison rather than by catching the exception FromUnixTime* would throw.
+        private static readonly long MinUnixSeconds = DateTimeOffset.MinValue.ToUnixTimeSeconds();
+        private static readonly long MaxUnixSeconds = DateTimeOffset.MaxValue.ToUnixTimeSeconds();
+        private static readonly long MinUnixMilliseconds = DateTimeOffset.MinValue.ToUnixTimeMilliseconds();
+        private static readonly long MaxUnixMilliseconds = DateTimeOffset.MaxValue.ToUnixTimeMilliseconds();
+
+        /// <summary>Converts Unix epoch <paramref name="seconds"/> to a <see cref="DateTimeOffset"/>, returning
+        /// <c>false</c> (instead of throwing) when the value is outside the representable range.</summary>
+        public static bool TryFromUnixTimeSeconds(long seconds, out DateTimeOffset value)
+        {
+            if (seconds < MinUnixSeconds || seconds > MaxUnixSeconds)
+            {
+                value = default;
+                return false;
+            }
+
+            value = DateTimeOffset.FromUnixTimeSeconds(seconds);
+            return true;
+        }
+
+        /// <summary>Converts Unix epoch <paramref name="milliseconds"/> to a <see cref="DateTimeOffset"/>,
+        /// returning <c>false</c> (instead of throwing) when the value is outside the representable range.</summary>
+        public static bool TryFromUnixTimeMilliseconds(long milliseconds, out DateTimeOffset value)
+        {
+            if (milliseconds < MinUnixMilliseconds || milliseconds > MaxUnixMilliseconds)
+            {
+                value = default;
+                return false;
+            }
+
+            value = DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
+            return true;
+        }
+
+        /// <summary>Parses an ISO-8601 / RFC-3339 date-time using <see cref="CultureInfo.InvariantCulture"/> and
+        /// normalizing to UTC (<see cref="DateTimeStyles.AssumeUniversal"/> | <see cref="DateTimeStyles.AdjustToUniversal"/>),
+        /// so a zone-less string is treated as UTC and a non-Gregorian/locale culture can't shift the instant.</summary>
+        public static bool TryParseIsoDateInvariant(string? text, out DateTimeOffset value)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                value = default;
+                return false;
+            }
+
+            return DateTimeOffset.TryParse(
+                text,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out value);
+        }
+    }
+}

--- a/tests/TimeParsingTests.cs
+++ b/tests/TimeParsingTests.cs
@@ -1,0 +1,79 @@
+using System;
+using Lidarr.Plugin.Common.Utilities;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// R2-08: external time values (epoch seconds/ms from untrusted JSON, ISO dates) must parse without throwing
+    /// on hostile/malformed input. DateTimeOffset.FromUnixTime* throws ArgumentOutOfRangeException past its
+    /// representable range, and DateTime(Offset).Parse without InvariantCulture can shift the instant on a
+    /// non-Gregorian/locale culture. These Try* helpers fail closed instead.
+    /// </summary>
+    public sealed class TimeParsingTests
+    {
+        [Fact]
+        public void TryFromUnixTimeSeconds_Valid_ReturnsTrue()
+        {
+            Assert.True(TimeParsing.TryFromUnixTimeSeconds(0, out var epoch));
+            Assert.Equal(DateTimeOffset.UnixEpoch, epoch);
+
+            Assert.True(TimeParsing.TryFromUnixTimeSeconds(1_700_000_000, out var recent));
+            Assert.Equal(2023, recent.UtcDateTime.Year);
+        }
+
+        [Theory]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public void TryFromUnixTimeSeconds_OutOfRange_ReturnsFalse_DoesNotThrow(long seconds)
+        {
+            Assert.False(TimeParsing.TryFromUnixTimeSeconds(seconds, out var value));
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void TryFromUnixTimeMilliseconds_Valid_ReturnsTrue()
+        {
+            Assert.True(TimeParsing.TryFromUnixTimeMilliseconds(1_700_000_000_000, out var recent));
+            Assert.Equal(2023, recent.UtcDateTime.Year);
+        }
+
+        [Theory]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public void TryFromUnixTimeMilliseconds_OutOfRange_ReturnsFalse_DoesNotThrow(long ms)
+        {
+            Assert.False(TimeParsing.TryFromUnixTimeMilliseconds(ms, out var value));
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void TryParseIsoDateInvariant_Valid_ParsesAsUtc()
+        {
+            Assert.True(TimeParsing.TryParseIsoDateInvariant("2024-03-15T08:30:00Z", out var value));
+            Assert.Equal(TimeSpan.Zero, value.Offset); // adjusted to UTC
+            Assert.Equal(new DateTime(2024, 3, 15, 8, 30, 0, DateTimeKind.Utc), value.UtcDateTime);
+        }
+
+        [Fact]
+        public void TryParseIsoDateInvariant_NoZone_AssumedUtc()
+        {
+            // No offset in the string → AssumeUniversal treats it as UTC rather than local.
+            Assert.True(TimeParsing.TryParseIsoDateInvariant("2024-03-15T08:30:00", out var value));
+            Assert.Equal(TimeSpan.Zero, value.Offset);
+            Assert.Equal(8, value.UtcDateTime.Hour);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not a date")]
+        [InlineData("13/45/2024")]
+        public void TryParseIsoDateInvariant_Invalid_ReturnsFalse(string? text)
+        {
+            Assert.False(TimeParsing.TryParseIsoDateInvariant(text, out var value));
+            Assert.Equal(default, value);
+        }
+    }
+}


### PR DESCRIPTION
## Round-2 review R2-08 — Common foundation

Streaming/credential APIs return epoch seconds/ms and ISO dates from untrusted bodies. `DateTimeOffset.FromUnixTime*` throws `ArgumentOutOfRangeException` on values past its representable range (e.g. `long.MaxValue` from malformed JSON → unhandled exception / pipeline crash), and `DateTime(Offset).Parse` without `InvariantCulture` can shift the parsed instant on a non-Gregorian/locale culture.

Adds `Lidarr.Plugin.Common.Utilities.TimeParsing`:
- `TryFromUnixTimeSeconds` / `TryFromUnixTimeMilliseconds` — range-checked against `DateTimeOffset`'s representable Unix range, **fail closed** (return `false`) instead of throwing.
- `TryParseIsoDateInvariant` — `InvariantCulture` + `AssumeUniversal | AdjustToUniversal` (zone-less → UTC).

### Sweep (follow-up, gated on this merge + re-pin)
Plugins replace unguarded `FromUnixTime*`/`Parse`: brainarr `SubscriptionCredentialLoader`/`CredentialRefreshService` (untrusted credential JSON — highest risk), amazon/qobuz catalog timestamps.

### Tests
13/13: valid ranges, `long.Max`/`long.Min` → `false` (no throw), ISO + zone-less → UTC, junk/empty/null → `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)