### PR TITLE
fix(download): truncate not append on non-206 (LOOP-003)

### DIFF
--- a/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -222,3 +222,5 @@ Lidarr.Plugin.Common.Utilities.TimeParsing
 static Lidarr.Plugin.Common.Utilities.TimeParsing.TryFromUnixTimeSeconds(long seconds, out System.DateTimeOffset value) -> bool
 static Lidarr.Plugin.Common.Utilities.TimeParsing.TryFromUnixTimeMilliseconds(long milliseconds, out System.DateTimeOffset value) -> bool
 static Lidarr.Plugin.Common.Utilities.TimeParsing.TryParseIsoDateInvariant(string? text, out System.DateTimeOffset value) -> bool
+Lidarr.Plugin.Common.Services.Download.PartialFileReset
+static Lidarr.Plugin.Common.Services.Download.PartialFileReset.ResolveWriteMode(bool serverHonoredRange) -> System.IO.FileMode

--- a/src/Services/Download/HttpFileDownloadService.cs
+++ b/src/Services/Download/HttpFileDownloadService.cs
@@ -106,8 +106,13 @@ namespace Lidarr.Plugin.Common.Services.Download
             long totalWritten = existing;
             int read;
 
+            // LOOP-003: on a 200 (server ignored the resume Range) truncate instead of appending, so a stale
+            // .partial that the best-effort delete above failed to remove can't be appended onto (silent
+            // stale+fresh corruption that the byte-count check below does NOT catch — it counts session bytes).
+            var partialWriteMode = PartialFileReset.ResolveWriteMode(serverHonoredRange: isPartial);
+
             // Explicit scope ensures fileStream is closed before File.Move
-            await using (var fileStream = new FileStream(partialPath, FileMode.Append, FileAccess.Write, FileShare.None, 131072, useAsync: true))
+            await using (var fileStream = new FileStream(partialPath, partialWriteMode, FileAccess.Write, FileShare.None, 131072, useAsync: true))
             {
                 read = await responseStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
                 if (read <= 0)

--- a/src/Services/Download/PartialFileReset.cs
+++ b/src/Services/Download/PartialFileReset.cs
@@ -1,0 +1,25 @@
+using System.IO;
+
+namespace Lidarr.Plugin.Common.Services.Download
+{
+    /// <summary>
+    /// LOOP-003: chooses the <see cref="FileMode"/> for writing a (possibly resumed) download body to its
+    /// <c>.partial</c> file, so a fresh full body can never be appended onto stale bytes.
+    ///
+    /// <para>When the server honored the resume <c>Range</c> (HTTP 206 Partial Content) the existing
+    /// <c>.partial</c> bytes are the verified prefix, so the new bytes are appended. For any other response
+    /// (200 OK — the server ignored the Range and is sending the WHOLE file) the write must <b>truncate</b>:
+    /// <see cref="FileMode.Create"/> resets the file as it opens, so a stale <c>.partial</c> that a best-effort
+    /// delete failed to remove cannot corrupt the download by being appended onto. This is fail-closed — it does
+    /// not rely on the delete succeeding.</para>
+    /// </summary>
+    public static class PartialFileReset
+    {
+        /// <summary>
+        /// <see cref="FileMode.Append"/> when <paramref name="serverHonoredRange"/> (HTTP 206), otherwise
+        /// <see cref="FileMode.Create"/> (truncate the whole file).
+        /// </summary>
+        public static FileMode ResolveWriteMode(bool serverHonoredRange)
+            => serverHonoredRange ? FileMode.Append : FileMode.Create;
+    }
+}

--- a/tests/PartialFileResetTests.cs
+++ b/tests/PartialFileResetTests.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using Lidarr.Plugin.Common.Services.Download;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// LOOP-003: a resumable download must NOT append a fresh full body onto stale <c>.partial</c> bytes when the
+    /// server ignored the resume <c>Range</c> (answered 200, not 206). The previous code deleted the stale partial
+    /// best-effort (swallowing failures) and then opened <c>FileMode.Append</c> unconditionally — so a delete that
+    /// failed left stale+fresh on disk (silent corruption; the byte-count check counts session bytes, not file
+    /// size, so it passes). PartialFileReset chooses <c>Create</c> (truncate) on a non-206 so the write is
+    /// fail-closed regardless of whether the delete succeeded.
+    /// </summary>
+    public sealed class PartialFileResetTests
+    {
+        [Fact]
+        public void ResolveWriteMode_PartialContent_Appends()
+        {
+            // 206: the server honored the Range, so the existing .partial bytes are the prefix — append to them.
+            Assert.Equal(FileMode.Append, PartialFileReset.ResolveWriteMode(serverHonoredRange: true));
+        }
+
+        [Fact]
+        public void ResolveWriteMode_FullResponse_Truncates()
+        {
+            // 200 (or anything not 206): the body is the WHOLE file — truncate so stale partial bytes can't be
+            // appended onto, even if the best-effort delete failed.
+            Assert.Equal(FileMode.Create, PartialFileReset.ResolveWriteMode(serverHonoredRange: false));
+        }
+    }
+}


### PR DESCRIPTION
## LOOP-003 — append-after-failed-delete corruption in Common

`HttpFileDownloadService` deleted a stale `.partial` best-effort (swallowed `catch`) when the server ignored the resume `Range` (answered **200**, not 206), then opened `FileMode.Append` **unconditionally**. If that delete failed, the fresh full body was appended onto the stale bytes — **silent corruption** that the byte-count integrity check does *not* catch (it counts bytes-read-this-session, `== Content-Length`, not the on-disk file size).

### Fix
Adds `PartialFileReset.ResolveWriteMode(serverHonoredRange)`: `Append` on 206, `Create` (truncate) otherwise — **fail-closed**, so a stale partial the delete couldn't remove can't be appended onto. Wired into `HttpFileDownloadService`. Same class as the qobuz **R2-07** fix (`TrackDownloadService` already used `isPartial ? Append : Create`); this is the **Common root** — every consumer is fixed on re-pin, and qobuz `AudioFileDownloader` can adopt the helper.

### Honest test note
The corruption requires the best-effort delete to fail (held handle / attribute / transient error); the fix removes the dependency on the delete entirely. A reliable cross-platform delete-failure unit test isn't practical, so the regression gate is the explicit `ResolveWriteMode` helper test (Append on 206, Create otherwise). **13/13 green** (2 new + 11 existing `HttpFileDownloadService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)