### PR TITLE
fix(security): re-validate redirect targets in resilience send loop (LOOP-004)

### DIFF
--- a/src/Services/Download/SimpleDownloadOrchestrator.cs
+++ b/src/Services/Download/SimpleDownloadOrchestrator.cs
@@ -414,7 +414,13 @@ namespace Lidarr.Plugin.Common.Services.Download
                     else if (lastModified.HasValue) req.Headers.TryAddWithoutValidation("If-Range", lastModified.Value.ToString("R"));
                 }
 
-                using var resp = await _httpClient.ExecuteWithResilienceAsync(req, ResiliencePolicy.Streaming, cancellationToken).ConfigureAwait(false);
+                // LOOP-004: keep the SSRF policy in force across the resilience layer's redirect-following — the
+                // initial URL is validated above, but a 3xx could otherwise bounce to an internal host.
+                using var resp = await _httpClient.ExecuteWithResilienceAsync(
+                    req,
+                    ResiliencePolicy.Streaming,
+                    cancellationToken,
+                    validateRedirectTarget: u => RemoteMediaUriGuard.Validate(u, _mediaUriPolicy).IsAllowed).ConfigureAwait(false);
                 resp.EnsureSuccessStatusCode();
 
                 var totalHeader = resp.Content.Headers.ContentLength;

--- a/src/Services/Network/NetworkResilienceService.cs
+++ b/src/Services/Network/NetworkResilienceService.cs
@@ -13,7 +13,7 @@ namespace Lidarr.Plugin.Common.Services.Network
     /// <summary>
     /// Network resilience service for coordinating batch operations and non-HTTP workflows.
     /// For outbound HTTP, this service delegates to the unified HTTP executor to prevent drift
-    /// and avoid double-retry. Use <see cref="HttpClientExtensions.ExecuteWithResilienceAsync(HttpClient, HttpRequestMessage, ResiliencePolicy, CancellationToken)"/>
+    /// and avoid double-retry. Use <see cref="HttpClientExtensions.ExecuteWithResilienceAsync(HttpClient, HttpRequestMessage, ResiliencePolicy, CancellationToken, System.Func{System.Uri, bool})"/>
     /// for all HTTP calls; this service remains as a thin adapter for batches and cross-cutting policies.
     /// </summary>
     /// <remarks>
@@ -64,7 +64,7 @@ namespace Lidarr.Plugin.Common.Services.Network
 
         /// <summary>
         /// Thin adapter that executes a batch of HTTP requests via the shared HTTP resilience executor.
-        /// Avoids double-retry by delegating all retry behavior to <see cref="HttpClientExtensions.ExecuteWithResilienceAsync(HttpClient, HttpRequestMessage, ResiliencePolicy, CancellationToken)"/>.
+        /// Avoids double-retry by delegating all retry behavior to <see cref="HttpClientExtensions.ExecuteWithResilienceAsync(HttpClient, HttpRequestMessage, ResiliencePolicy, CancellationToken, System.Func{System.Uri, bool})"/>.
         /// Batch-level checkpoints/circuit-breaker are still honored.
         /// </summary>
         public async Task<ResilientBatchResult<HttpResponseMessage>> ExecuteHttpBatchAsync(

--- a/src/Utilities/HttpClientExtensions.cs
+++ b/src/Utilities/HttpClientExtensions.cs
@@ -165,7 +165,8 @@ namespace Lidarr.Plugin.Common.Utilities
             this HttpClient httpClient,
             HttpRequestMessage request,
             ResiliencePolicy policy,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            Func<Uri, bool>? validateRedirectTarget = null)
         {
             if (policy == null) throw new ArgumentNullException(nameof(policy));
             return ExecuteWithResilienceAsyncCore(
@@ -176,7 +177,8 @@ namespace Lidarr.Plugin.Common.Utilities
                 policy.MaxConcurrencyPerHost,
                 policy.MaxTotalConcurrencyPerHost,
                 policy.PerRequestTimeout,
-                cancellationToken);
+                cancellationToken,
+                validateRedirectTarget);
         }
 
 
@@ -343,7 +345,8 @@ namespace Lidarr.Plugin.Common.Utilities
             int maxConcurrencyPerHost,
             int maxTotalConcurrencyPerHost,
             TimeSpan? perRequestTimeout,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            Func<Uri, bool>? validateRedirectTarget = null)
         {
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (request == null) throw new ArgumentNullException(nameof(request));
@@ -477,6 +480,16 @@ namespace Lidarr.Plugin.Common.Utilities
                                 var loc = response.Headers.Location;
                                 var targetUri = loc.IsAbsoluteUri ? loc : new Uri(attemptRequest.RequestUri!, loc);
 
+                                // LOOP-004: re-validate the redirect target when a validator is supplied (media
+                                // callers pass the SSRF guard) — a hostile/compromised host must not be able to
+                                // bounce the request to an internal address via a 3xx. Refuse before the next hop.
+                                if (validateRedirectTarget != null && !validateRedirectTarget(targetUri))
+                                {
+                                    response.Dispose();
+                                    throw new InvalidOperationException(
+                                        $"Refusing redirect to an unsafe URL: {targetUri.Scheme}://{targetUri.Host}.");
+                                }
+
                                 // Bound redirect-following: cap the hop count and honor the retry-budget deadline
                                 // so a redirect cycle (A->B->A, or a self-redirect) cannot loop forever. The
                                 // deadline check below the retryable path is skipped by the redirect `continue`,
@@ -536,6 +549,7 @@ namespace Lidarr.Plugin.Common.Utilities
                                 // Continue immediately without backoff; do not count against retry budget
                                 continue;
                             }
+                            catch (InvalidOperationException) { throw; } // LOOP-004: an SSRF redirect refusal must propagate, not be swallowed
                             catch (Exception swallowEx) { SwallowToTrace(swallowEx); /* fall through to return */ }
                         }
                         // Handle 301/302 redirects only when safe (GET/HEAD). Do not auto-follow for unsafe methods (e.g., POST)
@@ -546,6 +560,15 @@ namespace Lidarr.Plugin.Common.Utilities
                             {
                                 var loc = response.Headers.Location;
                                 var targetUri = loc.IsAbsoluteUri ? loc : new Uri(attemptRequest.RequestUri!, loc);
+
+                                // LOOP-004: re-validate the redirect target when a validator is supplied (see the
+                                // 307/308 branch above) — refuse a 3xx that points at an internal/unsafe host.
+                                if (validateRedirectTarget != null && !validateRedirectTarget(targetUri))
+                                {
+                                    response.Dispose();
+                                    throw new InvalidOperationException(
+                                        $"Refusing redirect to an unsafe URL: {targetUri.Scheme}://{targetUri.Host}.");
+                                }
 
                                 // Bound redirect-following: cap the hop count and honor the retry-budget deadline
                                 // so a redirect cycle (A->B->A, or a self-redirect) cannot loop forever. The
@@ -601,6 +624,7 @@ namespace Lidarr.Plugin.Common.Utilities
                                 // Continue without backoff; redirect handling should not consume retry budget
                                 continue;
                             }
+                            catch (InvalidOperationException) { throw; } // LOOP-004: an SSRF redirect refusal must propagate, not be swallowed
                             catch (Exception swallowEx) { SwallowToTrace(swallowEx); /* fall through to return */ }
                         }
                         return response;

--- a/tests/ResilienceRedirectSsrfTests.cs
+++ b/tests/ResilienceRedirectSsrfTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Services.Download;
+using Lidarr.Plugin.Common.Utilities;
+using Xunit;
+
+namespace Lidarr.Plugin.Common.Tests
+{
+    /// <summary>
+    /// LOOP-004: ExecuteWithResilienceAsync follows 301/302/307/308 redirects itself. When a caller supplies a
+    /// redirect-target validator (media callers pass the SSRF guard), a 3xx that points at an internal/unsafe
+    /// host must be refused before the next hop — a hostile CDN can't bounce the resilience layer to localhost.
+    /// </summary>
+    public sealed class ResilienceRedirectSsrfTests
+    {
+        private sealed class RedirectHandler : DelegatingHandler
+        {
+            private readonly string _location;
+            public int Calls;
+            public RedirectHandler(string location) => _location = location;
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                Interlocked.Increment(ref Calls);
+                if (Calls == 1)
+                {
+                    var r = new HttpResponseMessage(HttpStatusCode.Redirect); // 302
+                    r.Headers.Location = new Uri(_location);
+                    return Task.FromResult(r);
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(new byte[] { 1 }) });
+            }
+        }
+
+        private static bool GuardAllows(Uri u) => RemoteMediaUriGuard.Validate(u, RemoteMediaUriPolicy.Strict).IsAllowed;
+
+        [Fact]
+        public async Task RedirectToPrivateHost_IsRefused_BeforeFetchingIt()
+        {
+            var handler = new RedirectHandler("https://10.0.0.1/internal"); // 302 → private
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("https://8.8.8.8/") };
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/seg");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.ExecuteWithResilienceAsync(
+                    request, ResiliencePolicy.Streaming, CancellationToken.None,
+                    validateRedirectTarget: GuardAllows));
+
+            Assert.Equal(1, handler.Calls); // only the original public host was contacted; the private target was NOT
+        }
+
+        [Fact]
+        public async Task RedirectToPublicHost_IsFollowed_WithValidator()
+        {
+            var handler = new RedirectHandler("https://1.1.1.1/cdn/seg"); // 302 → public
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("https://8.8.8.8/") };
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/seg");
+
+            using var resp = await client.ExecuteWithResilienceAsync(
+                request, ResiliencePolicy.Streaming, CancellationToken.None,
+                validateRedirectTarget: GuardAllows);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal(2, handler.Calls); // followed the public redirect
+        }
+
+        [Fact]
+        public async Task RedirectToPrivateHost_NoValidator_FollowsAsBefore()
+        {
+            // Without a validator the behavior is unchanged (the ~26 non-media callers): the redirect is followed.
+            var handler = new RedirectHandler("https://10.0.0.1/internal");
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("https://8.8.8.8/") };
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/seg");
+
+            using var resp = await client.ExecuteWithResilienceAsync(request, ResiliencePolicy.Streaming, CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Equal(2, handler.Calls);
+        }
+    }
+}


### PR DESCRIPTION
## LOOP-004 — finish SSRF coverage for the resilience redirect loop

`ExecuteWithResilienceAsync` follows 301/302/307/308 redirects itself (host-gate aware) but did **not** re-validate the target — so a hostile/compromised CDN could 3xx-bounce a media fetch to an internal host even though the initial URL was guarded. Latent today (the only media consumer, `SimpleDownloadOrchestrator`, has no plugin **source** caller) but it's the real, deferred R2-01 follow-up.

### Fix
- Optional `Func<Uri,bool>? validateRedirectTarget` on the policy-based overload + the core (**default null = unchanged** for the ~26 non-media callers). Each computed redirect `targetUri` is validated in **both** the 307/308 and 301/302 branches; a blocked target throws `InvalidOperationException`.
- The throw sits inside each branch's swallow-all `try`, so both branches now `catch (InvalidOperationException) { throw; }` first — an SSRF refusal must propagate, not be swallowed as a redirect-follow error.
- `SimpleDownloadOrchestrator` passes `u => RemoteMediaUriGuard.Validate(u, _mediaUriPolicy).IsAllowed`.

### Tests
3 new (302→private refused with `Calls==1`; 302→public followed; no-validator unchanged) + **353** redirect/resilience/HttpClientExtensions tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)